### PR TITLE
Issue6

### DIFF
--- a/src/feature_extraction/feature_group_base_class.py
+++ b/src/feature_extraction/feature_group_base_class.py
@@ -53,7 +53,7 @@ class FeatureGroup(abc.ABC):
         feature_modules = self._init_feature_mods(identity)
         return {
             name: mod.window(identity, window_size, per_frame_values[name]) for name, mod in
-            feature_modules.items()
+            feature_modules.items() if name in per_frame_values.keys()
         }
 
     def feature_names(self, features: typing.Optional[str] = None):

--- a/src/feature_extraction/feature_group_base_class.py
+++ b/src/feature_extraction/feature_group_base_class.py
@@ -53,7 +53,7 @@ class FeatureGroup(abc.ABC):
         feature_modules = self._init_feature_mods(identity)
         return {
             name: mod.window(identity, window_size, per_frame_values[name]) for name, mod in
-            feature_modules.items() if name in per_frame_values.keys()
+            feature_modules.items()
         }
 
     def feature_names(self, features: typing.Optional[str] = None):

--- a/src/feature_extraction/features.py
+++ b/src/feature_extraction/features.py
@@ -170,9 +170,11 @@ class IdentityFeatures:
 
             self._frame_valid = features_h5['frame_valid'][:]
 
-            # load per frame features
-            for feature in self.get_feature_names(self._compute_social_features,
-                                                  self._extended_features):
+            # load per frame features. Always load all the features from the
+            # file if some are disabled by the project (for example, not
+            # supported by all pose files in the project), then those
+            # features will be excluded from training & classification
+            for feature in feature_grp.keys():
                 if feature in ['point_mask']:
                     continue
                 self._per_frame[feature] = feature_grp[feature][:]
@@ -206,8 +208,7 @@ class IdentityFeatures:
             features_h5.create_dataset('frame_valid', data=self._frame_valid)
 
             grp = features_h5.create_group('features')
-            for feature in self.get_feature_names(self._compute_social_features,
-                                                  self._extended_features):
+            for feature in self._per_frame.keys():
                 # point mask is obtained from the pose file, don't save it
                 if feature in ['point_mask']:
                     continue

--- a/src/feature_extraction/features.py
+++ b/src/feature_extraction/features.py
@@ -289,6 +289,10 @@ class IdentityFeatures:
 
             feature_grp = features_h5['features']
 
+            # load window features. Always load all the features from the
+            # file even if some are disabled by the project (for example,
+            # not supported by all pose files in the project), then those
+            # features will be excluded from training & classification
             for feature_name in feature_grp.keys():
                 # point_mask is loaded from the post estimation, not the
                 # feature file

--- a/src/feature_extraction/features.py
+++ b/src/feature_extraction/features.py
@@ -518,8 +518,8 @@ class IdentityFeatures:
         return column_names
 
     @classmethod
-    def merge_per_frame_features(cls, features: dict, include_social: bool,
-                                 extended_features=None):
+    def merge_per_frame_features(cls, features: list, include_social: bool,
+                                 extended_features=None) -> dict:
         """
         merge a list of per-frame features where each element in the list is
         a set of per-frame features computed for an individual animal
@@ -554,10 +554,10 @@ class IdentityFeatures:
     @classmethod
     def merge_window_features(
             cls,
-            features: dict,
+            features: list,
             include_social: bool,
             extended_features: typing.Optional[typing.Dict] = None
-    ):
+    ) -> dict:
         """
         merge a list of window features where each element in the list is the
         set of window features computed for an individual animal

--- a/src/feature_extraction/features.py
+++ b/src/feature_extraction/features.py
@@ -289,8 +289,7 @@ class IdentityFeatures:
 
             feature_grp = features_h5['features']
 
-            for feature_name in self.get_feature_names(
-                    self._compute_social_features, self._extended_features):
+            for feature_name in feature_grp.keys():
                 # point_mask is loaded from the post estimation, not the
                 # feature file
                 if feature_name == 'point_mask':

--- a/src/feature_extraction/landmark_features/corner.py
+++ b/src/feature_extraction/landmark_features/corner.py
@@ -117,7 +117,7 @@ class DistanceToCorner(Feature):
 
     def per_frame(self, identity: int) -> np.ndarray:
         """
-        get the per frame distance to nearest corner values
+        get the per frame distance to the nearest corner values
         :param identity: identity to get feature values for
         :return: numpy ndarray of values with shape (nframes,)
         """
@@ -146,7 +146,7 @@ class BearingToCorner(Feature):
 
     def per_frame(self, identity: int) -> np.ndarray:
         """
-        get the per frame bearing to nearest corner values
+        get the per frame bearing to the nearest corner values
         :param identity: identity to get feature values for
         :return: numpy ndarray of values with shape (nframes,)
         """

--- a/src/project/project.py
+++ b/src/project/project.py
@@ -151,14 +151,14 @@ class Project:
         # also build a set of static objects common to all pose files in the
         # project
         pose_versions = []
+        static_object_sets = []
         for vid in self._videos:
             vid_path = self.video_path(vid)
             pose_path = get_pose_path(vid_path)
             pose_versions.append(get_pose_file_major_version(pose_path))
-            self._supported_static_objects.update(
-                get_static_objects_in_file(pose_path))
+            static_object_sets.append(set(get_static_objects_in_file(pose_path)))
         self._min_pose_version = min(pose_versions) if len(pose_versions) else 0
-
+        self._supported_static_objects = set.intersection(*static_object_sets)
 
         # determine if this project can use social features or not
         # if all pose files are V3 or greater, enable social features for this
@@ -595,7 +595,7 @@ class Project:
                              use_social_features,
                              progress_callable=None):
         """
-        the the features for all labeled frames
+        the features for all labeled frames
         NOTE: this will currently take a very long time to run if the features
         have not already been computed
 

--- a/src/version/__init__.py
+++ b/src/version/__init__.py
@@ -1,6 +1,6 @@
 __MAJOR = 0
 __MINOR = 16
-__PATCH = 1
+__PATCH = 2
 
 
 def version_str():


### PR DESCRIPTION
more correct fix for issue #6 

this ensures all features are loaded from previously computed hdf5 file. This way, when recomputing window features, we have all necessary features to compute all of the window features supported by a given pose file (even if the current project doesn't use all of those features)