### PR TITLE
Allow mp4 videos

### DIFF
--- a/src/project/project.py
+++ b/src/project/project.py
@@ -641,7 +641,7 @@ class Project:
     @staticmethod
     def get_videos(dir_path: Path):
         """ Get list of video filenames (without path) in a directory """
-        return [f.name for f in dir_path.glob("*.avi")]
+        return [f.name for f in dir_path.glob("*") if f.suffix in ['.avi', '.mp4']]
 
     def get_labeled_features(self, behavior=None, progress_callable=None):
         """


### PR DESCRIPTION
Due to our recent release of the strain survey dataset, we should also allow the GUI to use mp4 files as videos.