### PR TITLE
OFA features

### DIFF
--- a/docs/features/features.md
+++ b/docs/features/features.md
@@ -157,11 +157,20 @@ Per-frame features fill missing values with zeros before passing into the FFT.
 
 # Extra Features calculated, but not used in a classifier
 
+These features are calculated and stored in cached feature files outside the `features` folder. These features are excluded from being available features during classifier training. Features present here are either allocentric or otherwise represent information that may be useful when postprocessing behavior calls. For example, if you train a chase classifier, one may be interested in inspecting which other mouse the individual is chasing. Inspecting the closest mouse in field of view during each chase bout would provide that information.
+
 ## Closest Objects
 
-For calculating distances and bearings to nearby items, sometimes there are multiple items to choose from. For the following objects, we identify which object is closest by using the current mouses convex hull centroid and the other object. These features are not available in trained classifiers.
+For calculating distances and bearings to nearby items, sometimes there are multiple items to choose from. For the following objects, we identify which object is closest by using the current mouses convex hull centroid and the other object.
 
-* Closest mouse
-* Closest mouse in field of view
-* Closest arena corner
-* Closest water spout (lixit)
+* Closest mouse index
+* Closest mouse index in field of view
+* Closest arena corner index
+* Closest water spout (lixit) index
+
+## Wall Distances
+
+When calculating the nearest arena wall distance, we also calculate the perpendicular distance from the animal centroid to every wall.
+
+* Perpendicular distance to all 4 walls
+* Average wall length

--- a/src/feature_extraction/features.py
+++ b/src/feature_extraction/features.py
@@ -16,7 +16,7 @@ from .landmark_features import LandmarkFeatureGroup
 from .segmentation_features import SegmentationFeatureGroup
 
 
-FEATURE_VERSION = 10
+FEATURE_VERSION = 11
 
 _FEATURE_MODULES = [
     BaseFeatureGroup,

--- a/src/feature_extraction/features.py
+++ b/src/feature_extraction/features.py
@@ -204,10 +204,13 @@ class IdentityFeatures:
                 self._closest_corner = features_h5['closest_corners'][:]
 
             if 'wall_distances' in features_h5:
-                self._wall_distances = features_h5['wall_distances'][:]
+                wall_distances = {}
+                for key in features_h5['wall_distances'].keys():
+                    wall_distances[key] = features_h5['wall_distances'][key][:]
+                self._wall_distances = wall_distances
 
             if 'avg_wall_length' in features_h5:
-                self._avg_wall_length = features_h5['avg_wall_length'][:]
+                self._avg_wall_length = features_h5['avg_wall_length'][...]
 
             if 'closest_lixit' in features_h5:
                 self._closest_lixit = features_h5['closest_lixit'][:]
@@ -253,8 +256,10 @@ class IdentityFeatures:
                 avg_wall_length = corner_info.get_avg_wall_length(self._identity)
                 if corner_data is not None:
                     features_h5['closest_corners'] = corner_data
-                    features_h5['wall_distances'] = wall_distances
                     features_h5['avg_wall_length'] = avg_wall_length
+                    wall_dist_grp = features_h5.require_group('wall_distances')
+                    for key, value in wall_distances.items():
+                        wall_dist_grp[key] = value
 
                 lixit_info = self._feature_modules[LandmarkFeatureGroup.name()].get_lixit_info(self._identity)
                 lixit_data = lixit_info.get_closest_lixit(self._identity)

--- a/src/feature_extraction/features.py
+++ b/src/feature_extraction/features.py
@@ -203,6 +203,12 @@ class IdentityFeatures:
             if 'closest_corners' in features_h5:
                 self._closest_corner = features_h5['closest_corners'][:]
 
+            if 'wall_distances' in features_h5:
+                self._wall_distances = features_h5['wall_distances'][:]
+
+            if 'avg_wall_length' in features_h5:
+                self._avg_wall_length = features_h5['avg_wall_length'][:]
+
             if 'closest_lixit' in features_h5:
                 self._closest_lixit = features_h5['closest_lixit'][:]
 
@@ -243,8 +249,12 @@ class IdentityFeatures:
             if LandmarkFeatureGroup.name() in self._feature_modules:
                 corner_info = self._feature_modules[LandmarkFeatureGroup.name()].get_corner_info(self._identity)
                 corner_data = corner_info.get_closest_corner(self._identity)
+                wall_distances = corner_info.get_wall_distances(self._identity)
+                avg_wall_length = corner_info.get_avg_wall_length(self._identity)
                 if corner_data is not None:
                     features_h5['closest_corners'] = corner_data
+                    features_h5['wall_distances'] = wall_distances
+                    features_h5['avg_wall_length'] = avg_wall_length
 
                 lixit_info = self._feature_modules[LandmarkFeatureGroup.name()].get_lixit_info(self._identity)
                 lixit_data = lixit_info.get_closest_lixit(self._identity)

--- a/src/feature_extraction/landmark_features/corner.py
+++ b/src/feature_extraction/landmark_features/corner.py
@@ -27,6 +27,7 @@ class CornerDistanceInfo:
         self._closest_corner_idx = {}
         self._cached_distances = {}
         self._cached_bearings = {}
+        self._all_wall_distances = {}
 
     def cache_features(self, identity: int):
         """
@@ -40,6 +41,7 @@ class CornerDistanceInfo:
         corner_distances = np.full(self._poses.num_frames, np.nan, dtype=np.float32)
         center_distances = np.full(self._poses.num_frames, np.nan, dtype=np.float32)
         wall_distances = np.full(self._poses.num_frames, np.nan, dtype=np.float32)
+        all_wall_distances = np.full([self._poses.num_frames, 4], np.nan, dtype=np.float32)
         center_bearings = np.full(self._poses.num_frames, np.nan, dtype=np.float32)
         corner_bearings = np.full(self._poses.num_frames, np.nan, dtype=np.float32)
         closest_corners = None
@@ -48,7 +50,9 @@ class CornerDistanceInfo:
 
         if 'corners' in self._poses.static_objects:
             closest_corners = np.full(self._poses.num_frames, -1, dtype=np.int8)
-            corners = self._poses.static_objects['corners']
+            corners = self.sort_points_clockwise(self._poses.static_objects['corners'])
+            wall_vectors = corners.astype(np.float32) - np.roll(corners.astype(np.float32), 1, axis=0)
+            avg_wall_length = np.mean(np.hypot(wall_vectors[:, 0], wall_vectors[:, 1])) * self._pixel_scale
 
             arena_center_np = np.mean(corners, axis=0)
             arena_center = Point(arena_center_np[0], arena_center_np[1])
@@ -83,12 +87,21 @@ class CornerDistanceInfo:
                 center_bearing = self.compute_angle(self_nose_point, self_base_neck_point, arena_center_np)
 
                 center_dist = self_shape.distance(arena_center)
-                # Note that self_shape.xy stores a [2,1] point data, but cv2 needs shape [2]
-                wall_dist = cv2.pointPolygonTest(corners.astype(np.float32), np.asarray(self_shape.centroid.xy).squeeze() * self._pixel_scale, True)
+                # Calculate distance to all walls using cross product
+                p1 = corners.astype(np.float32)
+                p2 = np.roll(p1, 1, axis=0)
+                centroid_point = np.asarray(self_shape.centroid.xy).squeeze()
+                # Note that we can skip dividing by the norm of p2-p1 because we re-scale it anyway
+                wall_dist = np.abs(np.cross(centroid_point - p1, p2 - p1))  # / np.linalg.norm(p2 - p1)
+                shortest_wall_dist = np.min(wall_dist)
+                wall_dist_cv2 = cv2.pointPolygonTest(corners.astype(np.float32), centroid_point, True)
+                correction_scale = wall_dist_cv2 / shortest_wall_dist
+                wall_dist *= correction_scale
 
                 corner_distances[frame] = distance * self._pixel_scale
                 center_distances[frame] = center_dist * self._pixel_scale
-                wall_distances[frame] = wall_dist * self._pixel_scale
+                wall_distances[frame] = wall_dist_cv2 * self._pixel_scale
+                all_wall_distances[frame] = wall_dist * self._pixel_scale
                 corner_bearings[frame] = corner_bearing
                 center_bearings[frame] = center_bearing
                 closest_corners[frame] = closest_idx
@@ -105,6 +118,8 @@ class CornerDistanceInfo:
         }
 
         self._closest_corner_idx[identity] = closest_corners
+        self._all_wall_distances[identity] = all_wall_distances
+        self._avg_wall_length = avg_wall_length
 
     def get_distances(self, identity: int) -> typing.Dict:
         """
@@ -135,6 +150,41 @@ class CornerDistanceInfo:
         if identity not in self._closest_corner_idx:
             self.cache_features(identity)
         return self._closest_corner_idx[identity]
+
+    def get_wall_distances(self, identity: int) -> np.ndarray:
+        """
+        get the wall distances
+        :param identity: integer identity to get the wall distances
+        :return: np.ndarray of all wall distances
+        """
+        if identity not in self._all_wall_distances:
+            self.cache_features(identity)
+        return self._all_wall_distances[identity]
+
+    def get_avg_wall_length(self, identity: int = 0) -> np.ndarray:
+        """
+        gets the average wall length
+        :param identity: identity to cache if not yet calculated
+        :returns: average wall length
+        """
+        if self._avg_wall_length is None:
+            self.cache_features(identity)
+        return self._avg_wall_length
+
+    @staticmethod
+    def sort_points_clockwise(points):
+        """
+        sorts a list of points to be clockwise relative to the first point
+        :param points: points to sort of shape [n_points, 2]
+        :return: points sorted clockwise
+        """
+        origin_point = np.mean(points, axis=0)
+        vectors = points - origin_point
+        vec_angles = np.arctan2(vectors[:, 0], vectors[:, 1])
+        sorted_points = points[np.argsort(vec_angles), :]
+        # Roll the points to have the first point still be first
+        first_point_idx = np.where(np.all(sorted_points == points[0], axis=1))[0][0]
+        return np.roll(sorted_points, -first_point_idx, axis=0)
 
     @staticmethod
     def compute_angle(a, b, c):

--- a/src/feature_extraction/landmark_features/corner.py
+++ b/src/feature_extraction/landmark_features/corner.py
@@ -118,7 +118,7 @@ class CornerDistanceInfo:
         }
 
         self._closest_corner_idx[identity] = closest_corners
-        self._all_wall_distances[identity] = all_wall_distances
+        self._all_wall_distances[identity] = {f'wall_{i}': all_wall_distances[:, i] for i in np.arange(all_wall_distances.shape[1])}
         self._avg_wall_length = avg_wall_length
 
     def get_distances(self, identity: int) -> typing.Dict:


### PR DESCRIPTION
Adding some features that get calculated and cached but not used in classifiers. These features are designed to enable traditional open field metrics to be calculated, as well as enabling more granular information about spatial location to be available for behavior calls.

Also found bugs with "nearest wall" feature, so still needed to bump the version

Exact Changes
* Added "distance to all walls" to be stored in feature cache file
* Added "average wall distance" to be stored in feature cache file
* Fixed a bug where mouse centroid would get px -> cm conversion twice in wall distance calculation
* Fixed a bug where wall corner points were assumed to be sorted, when they are not guaranteed to be sorted... by sorting them