### PR TITLE
Add working `environment.yml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ estimation neural networks. Single mouse pose files are generated from [this rep
 ## Requirements
 Developed and tested on Python 3.10. See the `requirements.txt` 
 for a list of required Python packages. These packages are available from the 
-Python Package Index (PyPI)
+Python Package Index (PyPI).
+
+See below for conda installation instructions.
 
 ### Python Virtual Environment
 
@@ -118,3 +120,30 @@ python app.py
 
 We supply a tested pair of singularity definition files. The [first vm](vm/behavior-classifier-vm.def) is indended for command-line use on compute clusters when scaling inferences. The [second vm](vm/behavior-classifier-gui-vm.def) is designed for interacting with the GUI in a portable environment. Please inspect the definition files for related linux packages to run the software.
 
+### Conda
+
+To install via `conda`, first clone the repository and then run:
+
+```bash
+conda env create -f environment.yml
+```
+
+See [`environment.yml`](environment.yml) for information on the installed environment.
+
+After installation, you can activate the environment with:
+
+```bash
+conda activate jabs
+```
+
+Then run the GUI with:
+
+```bash
+python app.py
+```
+
+To uninstall, simply delete the environment:
+
+```bash
+conda env remove -n jabs
+```

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,33 @@
+name: jabs
+
+channels:
+  - conda-forge
+
+dependencies:
+  - python=3.10
+  - h5py
+  - joblib
+  - markdown2
+  - numpy <2.0.0
+  - opencv
+  - pandas
+  # - pip-licenses
+  - ptable
+  # - pyside6  # see below
+  - pyyaml
+  - scikit-learn
+  - scipy
+  - shapely
+  # - shiboken6
+  - six
+  - tabulate
+  - threadpoolctl
+  - unittest-xml-reporting
+  - xgboost
+  - pip
+  - pip:
+    # QtWebEngine is not available on conda-forge for 6.x.
+    # https://github.com/conda-forge/qt-webengine-feedstock/pull/46
+    - PySide6
+  # Enable the following when package definition exists.
+  #   - "--editable=."


### PR DESCRIPTION
This PR adds an `environment.yml` that produces a working conda environment across platforms and corresponding instructions in the README.

The only non-conda package that is used is for `PySide6` since `QtWebEngine` is not yet available for Qt 6.x on `conda-forge` (https://github.com/conda-forge/qt-webengine-feedstock/pull/46).

I didn't add anything to the docs in case you guys wanted to hold off on that before testing.