### PR TITLE
61 archiving last behavior in a project should be handled better

### DIFF
--- a/src/jabs/ui/archive_behavior_dialog.py
+++ b/src/jabs/ui/archive_behavior_dialog.py
@@ -46,10 +46,15 @@ class ArchiveBehaviorDialog(QDialog):
 
     def __archive(self):
         behavior = self._behavior_selection.currentText()
-        self.behavior_archived.emit(behavior)
 
         # remove from combo box
         self.__remove_behavior(behavior)
+
+        # if there are no other behaviors that can be archived hide the dialog
+        if self._behavior_selection.count() == 0:
+            self.hide()
+
+        self.behavior_archived.emit(behavior)
 
     def __remove_behavior(self, behavior: str):
         idx = self._behavior_selection.findText(behavior, QtCore.Qt.MatchExactly)

--- a/src/jabs/ui/archive_behavior_dialog.py
+++ b/src/jabs/ui/archive_behavior_dialog.py
@@ -56,6 +56,9 @@ class ArchiveBehaviorDialog(QDialog):
 
         self.behavior_archived.emit(behavior)
 
+        if self._behavior_selection.count() == 0:
+            self.done(1)
+
     def __remove_behavior(self, behavior: str):
         idx = self._behavior_selection.findText(behavior, QtCore.Qt.MatchExactly)
         if idx != -1:

--- a/src/jabs/ui/archive_behavior_dialog.py
+++ b/src/jabs/ui/archive_behavior_dialog.py
@@ -45,17 +45,18 @@ class ArchiveBehaviorDialog(QDialog):
         self._confirm.setChecked(False)
 
     def __archive(self):
+        # remove selected behavior from combo box
         behavior = self._behavior_selection.currentText()
-
-        # remove from combo box
         self.__remove_behavior(behavior)
 
-        # if there are no other behaviors that can be archived hide the dialog
+        # if there are no other behaviors that can be archived then hide the dialog
         if self._behavior_selection.count() == 0:
             self.hide()
 
+        # emit the signal to handle archiving the behavior
         self.behavior_archived.emit(behavior)
 
+        # after emitting the signal, we can close the dialog if there are no more behaviors in the drop-down
         if self._behavior_selection.count() == 0:
             self.done(1)
 

--- a/src/jabs/ui/main_control_widget.py
+++ b/src/jabs/ui/main_control_widget.py
@@ -385,7 +385,7 @@ class MainControlWidget(QtWidgets.QWidget):
             self._behaviors = sorted(list(project_settings['behavior'].keys()))
         self.behavior_selection.clear()
         self.behavior_selection.addItems(self._behaviors)
-        if 'selected_behavior' in project_settings:
+        if 'selected_behavior' in project_settings and project_settings['selected_behavior']:
             # make sure this behavior is in the behavior selection drop down
             if project_settings['selected_behavior'] not in self._behaviors:
                 self.behavior_selection.clear()

--- a/src/jabs/ui/main_control_widget.py
+++ b/src/jabs/ui/main_control_widget.py
@@ -406,7 +406,6 @@ class MainControlWidget(QtWidgets.QWidget):
         # run all the updates for when a behavior changes
         self._behavior_changed()
 
-
     def set_identities(self, identities):
         """ populate the identity_selection combobox """
         self.identity_selection.currentIndexChanged.disconnect()
@@ -427,6 +426,9 @@ class MainControlWidget(QtWidgets.QWidget):
             self.behavior_selection.removeItem(idx)
             self._behaviors.remove(behavior)
         self.behavior_list_changed.emit(self._behaviors)
+
+        if len(self._behaviors) == 0:
+            self._get_first_label()
 
     def _set_window_sizes(self, sizes: List[int]):
         """ set the list of available window sizes """
@@ -451,24 +453,26 @@ class MainControlWidget(QtWidgets.QWidget):
 
     def _get_first_label(self):
         """
-        show the new label dialog until the user enters one. Used when
-        opening a new project for the fist time.
-        TODO: make custom dialog so the user can't close the dialog until
-          they've entered a behavior label
+        show the new label dialog.
+        Used when opening a new project for the fist time or if a user archives all behaviors in a project.
         """
-        ok = False
-        text = ""
+        dialog = QtWidgets.QInputDialog()
+        dialog.setWindowTitle("New Behavior")
+        dialog.setLabelText("Please enter a behavior name to continue:")
+        dialog.setOkButtonText("OK")
+        dialog.setCancelButtonText("Quit JABS")
+        dialog.setWindowFlags(dialog.windowFlags() & ~QtCore.Qt.WindowCloseButtonHint | QtCore.Qt.CustomizeWindowHint)
 
-        while not ok:
-            text, ok = QtWidgets.QInputDialog.getText(
-                self, 'New Behavior',
-                'New project - please enter a behavior name to continue:',
-                QtWidgets.QLineEdit.Normal)
-        self._behaviors = [text]
-        self.behavior_selection.addItem(text)
-        self.behavior_selection.setCurrentText(text)
-        self.behavior_list_changed.emit(self._behaviors)
-        self._behavior_changed()
+        if dialog.exec():
+            text, ok = dialog.textValue(), dialog.result()
+            if ok:
+                self._behaviors = [text]
+                self.behavior_selection.addItem(text)
+                self.behavior_selection.setCurrentText(text)
+                self.new_behavior_label.emit(self._behaviors)
+                self._behavior_changed()
+        else:
+            sys.exit(0)
 
     def _new_window_size(self):
         """

--- a/src/jabs/ui/main_control_widget.py
+++ b/src/jabs/ui/main_control_widget.py
@@ -455,6 +455,9 @@ class MainControlWidget(QtWidgets.QWidget):
         """
         show the new label dialog.
         Used when opening a new project for the fist time or if a user archives all behaviors in a project.
+
+        dialog is customized to hide the window close button. The only way to close the dialog is to create a new
+        label or to quit jabs (the Cancel button of the dialog has been renamed "Quit JABS").
         """
         dialog = QtWidgets.QInputDialog()
         dialog.setWindowTitle("New Behavior")

--- a/src/jabs/ui/main_window.py
+++ b/src/jabs/ui/main_window.py
@@ -83,7 +83,7 @@ class MainWindow(QtWidgets.QMainWindow):
         # archive behavior action
         self._archive_behavior = QtGui.QAction('Archive Behavior', self)
         self._archive_behavior.setStatusTip('Open Archive Behavior Dialog')
-        self._archive_behavior.setEnabled(True)
+        self._archive_behavior.setEnabled(False)
         self._archive_behavior.triggered.connect(self._open_archive_behavior_dialog)
         file_menu.addAction(self._archive_behavior)
 
@@ -213,6 +213,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.video_list.set_project(self._project)
 
         # Update which controls should be available
+        self._archive_behavior.setEnabled(True)
         self.enable_cm_units.setEnabled(self._project.is_cm_unit)
         self.enable_social_features.setEnabled(self._project.can_use_social_features)
         self.enable_segmentation_features.setEnabled(self._project.can_use_segmentation)
@@ -387,8 +388,8 @@ class MainWindow(QtWidgets.QMainWindow):
         dialog.exec_()
 
     def _archive_behavior_callback(self, behavior):
-        self._central_widget.remove_behavior(behavior)
         self._project.archive_behavior(behavior)
+        self._central_widget.remove_behavior(behavior)
 
     def show_license_dialog(self):
         dialog = LicenseAgreementDialog(self)


### PR DESCRIPTION
closes #61

archiving the last behavior in a project behaves consistently with opening a project with no behaviors defined: a dialog is shown for the user to create a new behavior

dialog has been updated to allow user to quit JABS instead of saving a new behavior label (for example, if they open the wrong directory by mistake when selecting a project directory in the file open dialog)