### PR TITLE
move project loading into a separate QThread to keep main UI thread responsive

### DIFF
--- a/src/jabs/ui/central_widget.py
+++ b/src/jabs/ui/central_widget.py
@@ -281,6 +281,10 @@ class CentralWidget(QtWidgets.QWidget):
     def remove_behavior(self, behavior: str):
         self._controls.remove_behavior(behavior)
 
+    @property
+    def controls(self):
+        return self._controls
+
     def _change_behavior(self, new_behavior):
         """
         make UI changes to reflect the currently selected behavior

--- a/src/jabs/ui/project_loader_thread.py
+++ b/src/jabs/ui/project_loader_thread.py
@@ -1,0 +1,40 @@
+from PySide6.QtCore import QThread, Signal, SignalInstance
+
+from jabs.project import Project
+
+
+class ProjectLoaderThread (QThread):
+    """
+    JABS Project Loader Thread
+
+    This thread is used to load a JABS project in the background so that the main
+    GUI thread remains responsive. It emits signals when the project is loaded.
+    """
+
+    project_loaded: SignalInstance = Signal()
+    load_error: SignalInstance = Signal(Exception)
+
+    def __init__(self, project_path: str, parent=None):
+        super().__init__(parent)
+        self._project_path = project_path
+        self._project = None
+
+    def run(self):
+        """
+        Run the thread.
+        """
+        # Open the project, this can take a while
+        try:
+            self._project = Project(self._project_path)
+            self.project_loaded.emit()
+        except Exception as e:
+            # if there was an exception, we'll emit the Exception as a signal so that
+            # the main GUI thread can handle it
+            self.load_error.emit(e)
+
+    @property
+    def project(self):
+        """
+        Return the loaded project.
+        """
+        return self._project

--- a/src/jabs/utils/__init__.py
+++ b/src/jabs/utils/__init__.py
@@ -9,4 +9,5 @@ __all__ = [
     "get_bool_env_var",
     "hash_file",
     "hide_stderr",
+    "FINAL_TRAIN_SEED",
 ]


### PR DESCRIPTION
This change moves the loading of a project into a separate QThread

this prevents the "spinning beach ball" on macOS or the "this program is unresponsive" error on Windows

While the project is being loaded in its own thread, the main window will display an indeterminate progress bar animation 

If an exception is raised while loading a project, that Exception is passed back to the main UI thread and the string representation is displayed in an alert dialog 

also adds type hints in main_window.py 