### PR TITLE
a few small improvements to the label and prediction visualization implementation

### DIFF
--- a/src/jabs/ui/global_inference_widget.py
+++ b/src/jabs/ui/global_inference_widget.py
@@ -47,9 +47,7 @@ class GlobalInferenceWidget(TimelineLabelWidget):
                 continue
 
             # draw a vertical bar of pixels
-            for y in range(self._bar_padding,
-                           self._bar_padding + self._bar_height):
-                qp.drawPoint(x, y)
+            qp.drawLine(x, self._bar_padding, x, self._bar_padding + self._bar_height - 1)
         qp.end()
 
     def set_num_frames(self, num_frames):

--- a/src/jabs/ui/manual_label_widget.py
+++ b/src/jabs/ui/manual_label_widget.py
@@ -218,7 +218,7 @@ class ManualLabelWidget(QWidget):
         """ called to reposition the view around new current frame """
         self._current_frame = current_frame
         # force redraw
-        self.update()
+        self.repaint()
 
     def set_num_frames(self, num_frames):
         """ set number of frames in current video, needed to properly render """

--- a/src/jabs/ui/prediction_vis_widget.py
+++ b/src/jabs/ui/prediction_vis_widget.py
@@ -151,7 +151,7 @@ class PredictionVisWidget(QWidget):
         """ called to reposition the view around new current frame """
         self._current_frame = current_frame
         # force redraw
-        self.update()
+        self.repaint()
 
     def set_num_frames(self, num_frames):
         """ set number of frames in current video, needed to properly render """

--- a/src/jabs/ui/timeline_label_widget.py
+++ b/src/jabs/ui/timeline_label_widget.py
@@ -81,7 +81,7 @@ class TimelineLabelWidget(QWidget):
         """ override QWidget paintEvent """
 
         # make sure we have something to draw
-        if self._pixmap is None:
+        if self._pixmap is None or self._bin_size == 0:
             return
 
         # get the current position
@@ -170,10 +170,7 @@ class TimelineLabelWidget(QWidget):
             else:
                 continue
 
-            # draw a vertical bar of pixels
-            for y in range(self._bar_padding,
-                           self._bar_padding + self._bar_height):
-                qp.drawPoint(x, y)
+            qp.drawLine(x, self._bar_padding, x, self._bar_padding + self._bar_height - 1)
         qp.end()
 
     def _update_scale(self):


### PR DESCRIPTION
replaces a loop that calls drawPixel with a single drawLine call

fix potential error if paintEvent is called before self._bin_size is calculated and is still zero

uses repaint() to force an immediate redraw when updating the current frame vs queue a repaint event by calling update()