### PR TITLE
fix bug when adding new behaviors

### DIFF
--- a/src/jabs/ui/main_control_widget.py
+++ b/src/jabs/ui/main_control_widget.py
@@ -31,7 +31,7 @@ class MainControlWidget(QtWidgets.QWidget):
     classifier_changed = QtCore.Signal()
     behavior_changed = QtCore.Signal(str)
     kfold_changed = QtCore.Signal()
-    new_behavior_label = QtCore.Signal(dict)
+    new_behavior_label = QtCore.Signal(list)
     window_size_changed = QtCore.Signal(int)
     new_window_sizes = QtCore.Signal(list)
     use_balace_labels_changed = QtCore.Signal(int)


### PR DESCRIPTION
fixes bug preventing new behaviors from getting saved to the project settings json file


The type was not correct in the signal that MainControlWidget sends to the MainWindow when a new behavior label is created. This was preventing the project.json file from getting updated, so next time the user loads the project the behaviors are not in the drop down selector

this the same behavior as a previous bug, but different root cause.  I think for some versions of python/PySide6 the signal type is ignored and bug was not observed. 