### PR TITLE
add support for external ids 

### DIFF
--- a/src/jabs/pose_estimation/pose_est.py
+++ b/src/jabs/pose_estimation/pose_est.py
@@ -50,6 +50,7 @@ class PoseEstimation(ABC):
         super().__init__()
         self._num_frames = 0
         self._identities = []
+        self._external_identities = None
         self._convex_hull_cache = dict()
         self._path = file_path
         self._cache_dir = cache_dir
@@ -230,3 +231,7 @@ class PoseEstimation(ABC):
     @property
     def lixit_keypoints(self) -> int:
         return 0
+
+    @property
+    def external_identities(self) -> list[int] | None:
+        return self._external_identities

--- a/src/jabs/pose_estimation/pose_est_v4.py
+++ b/src/jabs/pose_estimation/pose_est_v4.py
@@ -220,6 +220,7 @@ class PoseEstimationV4(PoseEstimation):
             self._num_frames = int(cache_h5.attrs['num_frames'])
             self._identities = [*range(self._num_identities)]
             if "external_identity_mapping" in pose_grp:
+                # we're going to serialize these in a JSON file so convert from uint32 stored in the hdf5 to Python int
                 self._external_identities = pose_grp["external_identity_mapping"][:].astype(int).tolist()
 
             # get pixel size

--- a/src/jabs/project/prediction_manager.py
+++ b/src/jabs/project/prediction_manager.py
@@ -121,7 +121,6 @@ class PredictionManager:
                 _classes = behavior_group["predicted_class"][:]
 
                 for i in range(nident):
-                    identity = str(i)
                     indexes = np.asarray(
                         range(behavior_group["predicted_class"].shape[1])
                     )
@@ -136,9 +135,9 @@ class PredictionManager:
 
                     # we're left with classes/probabilities for frames that
                     # were inferred and their frame indexes
-                    predictions[identity] = _classes[i]
-                    probabilities[identity] = _probabilities[i]
-                    frame_indexes[identity] = indexes
+                    predictions[i] = _classes[i]
+                    probabilities[i] = _probabilities[i]
+                    frame_indexes[i] = indexes
 
         except (MissingBehaviorError, FileNotFoundError):
             # no saved predictions for this behavior for this video

--- a/src/jabs/project/prediction_manager.py
+++ b/src/jabs/project/prediction_manager.py
@@ -41,6 +41,7 @@ class PredictionManager:
         probabilities,
         poses,
         classifier,
+        external_identities: list[int] | None = None,
     ):
         """
         write predictions out to a file
@@ -50,6 +51,7 @@ class PredictionManager:
         :param probabilities: matrix of probability for the predicted class of shape [n_animals, n_frames]
         :param poses: PoseEstimation object for which predictions were made
         :param classifier: Classifier object for which was used to make predictions
+        :param external_identities: list of external identities that correspond to the jabs identities
         """
         # TODO catch exceptions
         with h5py.File(output_path, "a") as h5:
@@ -57,6 +59,8 @@ class PredictionManager:
             h5.attrs["pose_hash"] = poses.hash
             h5.attrs["version"] = cls._PREDICTION_FILE_VERSION
             prediction_group = h5.require_group("predictions")
+            if external_identities is not None:
+                prediction_group.create_dataset("external_identity_map", data=np.array(external_identities, dtype=np.uint32))
             behavior_group = prediction_group.require_group(to_safe_name(behavior))
             behavior_group.attrs["classifier_file"] = classifier.classifier_file
             behavior_group.attrs["classifier_hash"] = classifier.classifier_hash

--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 
 import jabs.feature_extraction as fe
-from jabs.pose_estimation import get_pose_path, open_pose_file
+from jabs.pose_estimation import get_pose_path, open_pose_file, PoseEstimation
 from jabs.project import TrackLabels
 from jabs.types import ProjectDistanceUnit
 from jabs.video_reader.utilities import get_fps
@@ -126,7 +126,7 @@ class Project:
         """
         return self._paths
 
-    def load_pose_est(self, video_path: Path):
+    def load_pose_est(self, video_path: Path) -> PoseEstimation:
         """
         return a PoseEstimation object for a given video path
         :param video_path: pathlib.Path containing location of video file
@@ -257,11 +257,11 @@ class Project:
 
             # we need some info from the PoseEstimation and VideoLabels objects
             # associated with this video
-            video_tracks = self._video_manager.load_video_labels(video)
             poses = open_pose_file(
                 get_pose_path(self._video_manager.video_path(video)),
                 self._paths.cache_dir,
             )
+            video_tracks = self._video_manager.load_video_labels(video, poses.external_identities)
 
             # allocate numpy arrays to write to h5 file
             prediction_labels = np.full(
@@ -424,7 +424,7 @@ class Project:
                 )
 
                 labels = (
-                    self._video_manager.load_video_labels(video)
+                    self._video_manager.load_video_labels(video, pose_est.external_identities)
                     .get_track_labels(str(identity), behavior)
                     .get_labels()
                 )

--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -271,15 +271,14 @@ class Project:
 
             # populate numpy arrays
             for identity in predictions[video]:
-                identity_index = int(identity)
 
                 inferred_indexes = frame_indexes[video][identity]
-                track = video_tracks.get_track_labels(identity, behavior)
+                track = video_tracks.get_track_labels(str(identity), behavior)
 
-                prediction_labels[identity_index, inferred_indexes] = predictions[
+                prediction_labels[identity, inferred_indexes] = predictions[
                     video
                 ][identity][inferred_indexes]
-                prediction_prob[identity_index, inferred_indexes] = probabilities[
+                prediction_prob[identity, inferred_indexes] = probabilities[
                     video
                 ][identity][inferred_indexes]
 

--- a/src/jabs/project/video_manager.py
+++ b/src/jabs/project/video_manager.py
@@ -51,11 +51,12 @@ class VideoManager:
     def total_project_identities(self) -> int:
         return self._total_project_identities
 
-    def load_video_labels(self, video_name):
+    def load_video_labels(self, video_name, external_identities: list[int] | None = None):
         """
         load labels for a video from the project directory or from a cached of
         annotations that have previously been opened and not yet saved
         :param video_name: filename of the video: string or pathlib.Path
+        :param external_identities: list of external identities that correspond to the jabs identities
         :return: initialized VideoLabels object
         """
 
@@ -72,7 +73,7 @@ class VideoManager:
         else:
             video_path = self._paths.project_dir / video_filename
             nframes = get_frame_count(str(video_path))
-            return VideoLabels(video_filename, nframes)
+            return VideoLabels(video_filename, nframes, external_identities)
 
     def check_video_name(self, video_filename):
         """

--- a/src/jabs/scripts/convert_parquet.py
+++ b/src/jabs/scripts/convert_parquet.py
@@ -179,14 +179,14 @@ def convert_data_frame(
 
     with h5py.File(output_path, "w") as pose_out:
         pose_group = pose_out.create_group("poseest")
-        pose_group["points"] = jabs_points
-        pose_group["confidence"] = jabs_confidences
-        pose_group["id_mask"] = jabs_id_mask
-        pose_group["instance_embed_id"] = jabs_embed_id
+        pose_group.create_dataset("points", data=jabs_points, dtype=np.uint16)
+        pose_group.create_dataset("confidence", data=jabs_confidences, dtype=np.float32)
+        pose_group.create_dataset("id_mask", data=jabs_id_mask, dtype=np.bool_)
+        pose_group.create_dataset("instance_embed_id", data=jabs_embed_id, dtype=np.uint32)
 
         # the parquet file uses global identities for the animal ids, while JABS always uses 0..(num_identities-1)
         # save the original animal ids in the pose file so we can map back to the original ids downstream
-        pose_group["external_identity_mapping"] = identities
+        pose_group.create_dataset("external_identity_mapping", data=identities, dtype=np.uint32)
 
         static_objects_group = pose_out.create_group("static_objects")
         if lixit_predictions is not None:

--- a/src/jabs/ui/central_widget.py
+++ b/src/jabs/ui/central_widget.py
@@ -399,10 +399,10 @@ class CentralWidget(QtWidgets.QWidget):
         behavior or identity is changed
         """
         behavior = self._controls.current_behavior
-        identity = self._controls.current_identity
+        identity = self._controls.current_identity_index
 
-        if identity != '' and behavior != '' and self._labels is not None:
-            labels = self._labels.get_track_labels(identity, behavior)
+        if identity != -1 and behavior != '' and self._labels is not None:
+            labels = self._labels.get_track_labels(str(identity), behavior)
             self.manual_labels.set_labels(
                 labels, mask=self._player_widget.get_identity_mask())
             self.timeline_widget.set_labels(labels)
@@ -415,7 +415,7 @@ class CentralWidget(QtWidgets.QWidget):
         behavior
         """
         return self._labels.get_track_labels(
-            self._controls.current_identity,
+            str(self._controls.current_identity_index),
             self._controls.current_behavior
         )
 
@@ -534,7 +534,7 @@ class CentralWidget(QtWidgets.QWidget):
         if self._loaded_video is None:
             return
 
-        identity = self._controls.current_identity
+        identity = self._controls.current_identity_index
 
         try:
             indexes = self._frame_indexes[identity]
@@ -590,7 +590,7 @@ class CentralWidget(QtWidgets.QWidget):
         # by only updating the current identity in the current video
         self._counts[self._loaded_video.name] = self._labels.counts(self.behavior)
 
-        identity = self._controls.current_identity
+        identity = self._controls.current_identity_index
 
         label_behavior_current = 0
         label_not_behavior_current = 0

--- a/src/jabs/ui/central_widget.py
+++ b/src/jabs/ui/central_widget.py
@@ -18,6 +18,7 @@ from .timeline_label_widget import TimelineLabelWidget
 from .training_thread import TrainingThread
 from .main_control_widget import MainControlWidget
 
+_CLICK_THRESHOLD = 20
 
 class CentralWidget(QtWidgets.QWidget):
     """
@@ -31,7 +32,6 @@ class CentralWidget(QtWidgets.QWidget):
 
         # video player
         self._player_widget = PlayerWidget()
-        self._player_widget.updateIdentities.connect(self._set_identities)
         self._player_widget.updateFrameNumber.connect(self._frame_change)
         self._player_widget.pixmap_clicked.connect(self._pixmap_clicked)
         self._curr_frame_index = 0
@@ -176,19 +176,26 @@ class CentralWidget(QtWidgets.QWidget):
             self._controls.select_button_set_checked(False)
 
         try:
+            self._loaded_video = path
+
+            # open poses and any labels that might exist for this video
+            self._pose_est = self._project.load_pose_est(path)
+            self._labels = self._project.video_manager.load_video_labels(path, self._pose_est.external_identities)
+
             # load saved predictions for this video
             self._predictions, self._probabilities, self._frame_indexes = \
                 self._project.prediction_manager.load_predictions(path.name, self.behavior)
 
-            # load labels for new video and set track for current identity
-            self._labels = self._project.video_manager.load_video_labels(path)
 
-            # open the video
-            self._loaded_video = path
-            self._pose_est = self._project.load_pose_est(path)
+            # load video into player
             self._player_widget.load_video(path, self._pose_est)
 
             # update ui components with properties of new video
+            if self._pose_est.external_identities:
+                self._set_identities(self._pose_est.external_identities)
+            else:
+                self._set_identities(self._pose_est.identities)
+
             self.manual_labels.set_num_frames(self._player_widget.num_frames())
             self.manual_labels.set_framerate(self._player_widget.stream_fps())
             self.prediction_vis.set_num_frames(self._player_widget.num_frames())
@@ -627,14 +634,36 @@ class CentralWidget(QtWidgets.QWidget):
         handle event where user clicked on the video -- if they click
         on one of the mice, make that one active
         """
+        clicked_identity = None
         if self._pose_est is not None:
             pt = Point(event['x'], event['y'])
             for i, ident in enumerate(self._pose_est.identities):
                 c_hulls = self._pose_est.get_identity_convex_hulls(ident)
                 curr_c_hull = c_hulls[self._curr_frame_index]
-                if curr_c_hull is not None and (curr_c_hull.contains(pt) or curr_c_hull.distance(pt) < 5):
-                    self._controls.set_identity_index(i)
+
+                # if the click is in a convex hull, set that identity as active
+                if curr_c_hull is not None and curr_c_hull.contains(pt):
+                    clicked_identity = i
                     break
+
+            # if the click was not on a convex hull, check to see if it was close to one
+            # with few keypoints, sometimes the convex hull is thin and easy to miss when clicking on the mouse
+            min_distance = float('inf')
+            closest_identity = None
+            for i, ident in enumerate(self._pose_est.identities):
+                c_hulls = self._pose_est.get_identity_convex_hulls(ident)
+                curr_c_hull = c_hulls[self._curr_frame_index]
+
+                # if the click is in a convex hull, set that identity as active
+                if curr_c_hull is not None and curr_c_hull.distance(pt) < min_distance:
+                    closest_identity = i
+                    min_distance = curr_c_hull.distance(pt)
+
+            if clicked_identity is None and min_distance < _CLICK_THRESHOLD:
+                clicked_identity = closest_identity
+
+        if clicked_identity is not None:
+            self._controls.set_identity_index(clicked_identity)
 
     def _window_feature_size_changed(self, new_size):
         """ handle window feature size change """

--- a/src/jabs/ui/classification_thread.py
+++ b/src/jabs/ui/classification_thread.py
@@ -51,16 +51,15 @@ class ClassifyThread(QtCore.QThread):
             probabilities[video] = {}
             frame_indexes[video] = {}
 
-            for ident in pose_est.identities:
+            for identity in pose_est.identities:
                 self.current_status.emit(
-                    f"Classifying {video},  Identity {ident}")
+                    f"Classifying {video},  Identity {identity}")
 
                 # get the features for this identity
                 features = IdentityFeatures(
-                    video, ident, self._project.feature_dir,
+                    video, identity, self._project.feature_dir,
                     pose_est, fps=fps, op_settings=project_settings,
                 )
-                identity = str(ident)
                 feature_values = features.get_features(project_settings.get('window_size', DEFAULT_WINDOW_SIZE))
 
                 # reformat the data in a single 2D numpy array to pass

--- a/src/jabs/ui/main_control_widget.py
+++ b/src/jabs/ui/main_control_widget.py
@@ -241,7 +241,7 @@ class MainControlWidget(QtWidgets.QWidget):
 
     @property
     def current_identity(self):
-        return self.identity_selection.currentText()
+        return str(self.identity_selection.currentIndex())
 
     @property
     def current_identity_index(self):

--- a/src/jabs/ui/main_control_widget.py
+++ b/src/jabs/ui/main_control_widget.py
@@ -240,11 +240,16 @@ class MainControlWidget(QtWidgets.QWidget):
         return list(self._behaviors)
 
     @property
-    def current_identity(self):
-        return str(self.identity_selection.currentIndex())
+    def current_identity(self) -> str:
+        """
+        this will be the external identity
+        if the pose file doesn't have external identities this will be the string representation of the jabs identity
+        """
+        return self.identity_selection.currentText()
 
     @property
-    def current_identity_index(self):
+    def current_identity_index(self) -> int:
+        """ identity index is the same as the JABS identity """
         return self.identity_selection.currentIndex()
 
     @property

--- a/src/jabs/ui/player_widget/player_widget.py
+++ b/src/jabs/ui/player_widget/player_widget.py
@@ -395,10 +395,6 @@ class PlayerWidget(QtWidgets.QWidget):
         self._video_stream = VideoReader(path)
 
         self._pose_est = pose_est
-
-        # tell main window to populate the identity selection drop down
-        # this will cause set_active_identity() to be called
-        self.updateIdentities.emit(self._pose_est.identities)
         self.set_identities(self._pose_est.identities)
 
         # set up the position slider

--- a/src/jabs/video_reader/frame_annotation.py
+++ b/src/jabs/video_reader/frame_annotation.py
@@ -83,7 +83,7 @@ def label_identity(
 
         # draw a marker at this location.
         cv2.circle(
-            img, (int(center.x), int(center.y)), 4, color, -1, lineType=cv2.LINE_AA
+            img, (int(center.x), int(center.y)), __scale_annotation_size(img, 4), color, -1, lineType=cv2.LINE_AA
         )
 
 
@@ -113,10 +113,13 @@ def label_all_identities(
                 color = _ACTIVE_COLOR
             else:
                 color = _ID_COLOR
+
+            label = str(identity) if not pose_est.external_identities else str(pose_est.external_identities[identity])
+
             # write the identity at that location
             cv2.putText(
                 img,
-                str(identity),
+                label,
                 (int(center.x), int(center.y)),
                 cv2.FONT_HERSHEY_PLAIN,
                 __scale_annotation_size(img, 1.25),


### PR DESCRIPTION
uses optional dataset in pose file "posest/external_identity_mapping", which is a 1D uint32 array

Note: I added code to check for this dataset in all pose file versions >= 4.  Since this is completely optional, I didn't want to create yet another pose file version. 

This ID is displayed in the JABS GUI for both mouse labels in the video and the identity drop down selector:
![image](https://github.com/user-attachments/assets/a544f36e-3a2a-4248-a0dd-ada8984d398a)

Additionally, this is saved in the prediction hdf5 files as "predictions/external_identity_mapping" as well as in the json files JABS uses to store labels internally.  I did not bump the prediction version, but am willing to do so. 

