### PR TITLE
fix issue #90

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jabs-behavior-classifier"
-version = "0.21.0"
+version = "0.21.1"
 license = "Proprietary"
 repository = "https://github.com/KumarLabJax/JABS-behavior-classifier"
 description = ""

--- a/src/jabs/ui/central_widget.py
+++ b/src/jabs/ui/central_widget.py
@@ -590,7 +590,8 @@ class CentralWidget(QtWidgets.QWidget):
         # by only updating the current identity in the current video
         self._counts[self._loaded_video.name] = self._labels.counts(self.behavior)
 
-        identity = self._controls.current_identity_index
+        #TODO fix so we're not using the identity index as a string for keys in the label counts
+        identity = str(self._controls.current_identity_index)
 
         label_behavior_current = 0
         label_not_behavior_current = 0


### PR DESCRIPTION
fixes #90 

This bug is related to places where JABS was conflating the internal integer based identity with the string representation of the identity in the identity selection drop down

because we now support "external ids", there is a bit more work to do to clean up some places where it was using the string representation and not the internal integer id

This merge request fixes the immediate issue, but more work is needed to clean up, which will be in a followup pull request 