### PR TITLE
use docconvert to change re-Structured Text docstring format to google

### DIFF
--- a/src/jabs/classifier/classifier.py
+++ b/src/jabs/classifier/classifier.py
@@ -56,10 +56,9 @@ class Classifier:
 
     def __init__(self, classifier=ClassifierType.RANDOM_FOREST, n_jobs=1):
         """
-        :param classifier: type of classifier to use. Must be ClassifierType
-        :param n_jobs: number of jobs to use for classifiers that support
-        this parameter for parallelism
-        enum value. Defaults to ClassifierType.RANDOM_FOREST
+        Args:
+            classifier: type of classifier to use. Must be ClassifierType enum value. Defaults to ClassifierType.RANDOM_FOREST
+            n_jobs: number of jobs to use for classifiers that support this parameter for parallelism
         """
 
         self._classifier_type = classifier
@@ -81,8 +80,11 @@ class Classifier:
     @classmethod
     def from_training_file(cls, path: Path):
         """
-        :param path: exported training data file
-        :return: trained classifier object
+        Args:
+            path: exported training data file
+
+        Returns:
+            trained classifier object
         """
         loaded_training_data, _ = load_training_data(path)
         behavior = loaded_training_data['behavior']
@@ -112,12 +114,12 @@ class Classifier:
 
     @property
     def classifier_name(self) -> str:
-        """ return the name of the classifier used as a string """
+        """return the name of the classifier used as a string"""
         return self._classifier_names[self._classifier_type]
 
     @property
     def classifier_type(self) -> ClassifierType:
-        """ return classifier type """
+        """return classifier type"""
         return self._classifier_type
 
     @property
@@ -134,7 +136,7 @@ class Classifier:
 
     @property
     def project_settings(self) -> dict:
-        """ return a copy of dictionary of project settings for this classifier """
+        """return a copy of dictionary of project settings for this classifier"""
         if self._project_settings is not None:
             return dict(self._project_settings)
         return {}
@@ -153,22 +155,20 @@ class Classifier:
 
     @property
     def feature_names(self) -> list:
-        """
-        returns the list of feature names used when training this classifier
-        """
+        """returns the list of feature names used when training this classifier"""
         return self._feature_names
 
     @staticmethod
     def train_test_split(per_frame_features, window_features, label_data):
-        """
-        split features and labels into training and test datasets
+        """split features and labels into training and test datasets
 
-        :param per_frame_features: per frame features as returned from
-        IdentityFeatures object, filtered to only include labeled frames
-        :param window_features: window features as returned from
-        IdentityFeatures object, filtered to only include labeled frames
-        :param label_data: labels that correspond to the features
-        :return: dictionary of training and test data and labels:
+        Args:
+            per_frame_features: per frame features as returned from IdentityFeatures object, filtered to only include labeled frames
+            window_features: window features as returned from IdentityFeatures object, filtered to only include labeled frames
+            label_data: labels that correspond to the features
+
+        Returns:
+            dictionary of training and test data and labels:
 
         {
             'training_data': list of numpy arrays,
@@ -193,11 +193,14 @@ class Classifier:
 
     @staticmethod
     def get_leave_one_group_out_max(labels, groups):
-        """
-        counts the number of possible leave one out groups for k-fold cross validation
-        :param labels: labels to check if they were above the threshold
-        :param groups: group id corrosponding to the labels
-        :return: int of the maximum number of cross validation to use
+        """counts the number of possible leave one out groups for k-fold cross validation
+
+        Args:
+            labels: labels to check if they were above the threshold
+            groups: group id corresponding to the labels
+
+        Returns:
+            int of the maximum number of cross validation to use
         """
         unique_groups = np.unique(groups)
         count_behavior = [np.sum(np.asarray(labels)[np.asarray(groups)==x] == TrackLabels.Label.BEHAVIOR) for x in unique_groups]
@@ -208,13 +211,16 @@ class Classifier:
     @staticmethod
     def leave_one_group_out(per_frame_features, window_features, labels,
                             groups):
-        """
-        implements "leave one group out" data splitting strategy
-        :param per_frame_features: per frame features for all labeled data
-        :param window_features: window features for all labeled data
-        :param labels: labels corresponding to each feature row
-        :param groups: group id corresponding to each feature row
-        :return: dictionary of training and test data and labels:
+        """implements "leave one group out" data splitting strategy
+
+        Args:
+            per_frame_features: per frame features for all labeled data
+            window_features: window features for all labeled data
+            labels: labels corresponding to each feature row
+            groups: group id corresponding to each feature row
+
+        Returns:
+            dictionary of training and test data and labels:
         {
             'training_data': list of numpy arrays,
             'test_data': list of numpy arrays,
@@ -259,11 +265,15 @@ class Classifier:
 
     @staticmethod
     def downsample_balance(features, labels, random_seed=None):
-        """
-        downsamples features and labels such that labels are equally distributed
-        :param features: features to downsample
-        :param labels: labels to downsample
-        :return: tuple of downsampled features, labels
+        """downsamples features and labels such that labels are equally distributed
+
+        Args:
+            features: features to downsample
+            labels: labels to downsample
+            random_seed: optional random seed
+
+        Returns:
+            tuple of downsampled features, labels
         """
         label_states, label_counts = np.unique(labels, return_counts=True)
         max_examples_per_class = np.min(label_counts)
@@ -281,15 +291,18 @@ class Classifier:
 
     @staticmethod
     def augment_symmetric(features, labels, random_str='ASygRQDZJD'):
-        """
-        augments the features to include L-R and R-L duplicates
+        """augments the features to include L-R and R-L duplicates
         This requires 'left' or 'right' to be in the feature name to be swapped
         Features that don't include these terms will not be swapped
-        :param features: features to augment
-        :param labels: labels to augment
-        :param feature_names: feature names to detect LR exchanges
-        :param random_str: a random string to use as a temporary replacement when swapping left/right
-        :return: tuple of augmented features, labels
+
+        Args:
+            features: features to augment
+            labels: labels to augment
+            random_str: a random string to use as a temporary
+                replacement when swapping left/right
+
+        Returns:
+            tuple of augmented features, labels
         """
 
         # Figure out the L-R swapping of features
@@ -312,14 +325,13 @@ class Classifier:
         return features, labels
 
     def set_classifier(self, classifier):
-        """ change the type of the classifier being used """
+        """change the type of the classifier being used"""
         if classifier not in _classifier_choices:
             raise ValueError("Invalid Classifier Type")
         self._classifier_type = classifier
 
     def set_project_settings(self, project: Project):
-        """
-        assign project settings to the classifier
+        """assign project settings to the classifier
         :project: project to copy classifier-relevant settings from for the current behavior
 
         if no behavior is currently set, will simply use project defaults
@@ -330,8 +342,7 @@ class Classifier:
             self._project_settings = project.settings_manager.get_behavior(self._behavior)
 
     def set_dict_settings(self, settings: dict):
-        """
-        assign project settings via a dict to the classifier
+        """assign project settings via a dict to the classifier
         :settings: dict of project settings. Must be same structure as project.settings_manager.get_behavior
 
         TODO: Add checks to enforce conformity to project settings
@@ -339,9 +350,10 @@ class Classifier:
         self._project_settings = dict(settings)
 
     def classifier_choices(self):
-        """
-        get the available classifier types
-        :return: dict where keys are ClassifierType enum values, and the
+        """get the available classifier types
+
+        Returns:
+            dict where keys are ClassifierType enum values, and the
         values are string names for the classifiers. example:
 
         {
@@ -355,12 +367,15 @@ class Classifier:
         }
 
     def train(self, data, random_seed: typing.Optional[int] = None):
-        """
-        train the classifier
-        :param data: dict returned from train_test_split()
-        :param random_seed: optional random seed (used when we want reproducible
-        results between trainings)
-        :return: None
+        """train the classifier
+
+        Args:
+            data: dict returned from train_test_split()
+            random_seed: optional random seed (used when we want
+                reproducible results between trainings)
+
+        Returns:
+            None
 
         raises ValueError for having either unset project settings or an unset classifier
         """
@@ -402,9 +417,7 @@ class Classifier:
         self._classifier_source = None
 
     def sort_features_to_classify(self, features):
-        """
-        sorts features to match the current classifier
-        """
+        """sorts features to match the current classifier"""
         if self._classifier_type == ClassifierType.XGBOOST:
             classifier_columns = self._classifier.get_booster().feature_names
         # sklearn places feature names in the same spot
@@ -414,9 +427,7 @@ class Classifier:
         return features_sorted
 
     def predict(self, features):
-        """
-        predict classes for a given set of features
-        """
+        """predict classes for a given set of features"""
         if self._classifier_type == ClassifierType.XGBOOST:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", category=FutureWarning)
@@ -430,9 +441,7 @@ class Classifier:
         )
 
     def predict_proba(self, features):
-        """
-        predict probabilities for a given set of features
-        """
+        """predict probabilities for a given set of features"""
         if self._classifier_type == ClassifierType.XGBOOST:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", category=FutureWarning)
@@ -516,11 +525,14 @@ class Classifier:
 
     @staticmethod
     def combine_data(per_frame, window):
-        """
-        combine feature sets together
-        :param per_frame: per frame features dataframe
-        :param window: window feature dataframe
-        :return: merged dataframe
+        """combine feature sets together
+
+        Args:
+            per_frame: per frame features dataframe
+            window: window feature dataframe
+
+        Returns:
+            merged dataframe
         """
         return pd.concat([per_frame, window], axis=1)
 
@@ -550,11 +562,11 @@ class Classifier:
         return classifier
 
     def print_feature_importance(self, feature_list, limit=20):
-        """
-        print the most important features and their importance
-        :param feature_list:
-        :param limit:
-        :return:
+        """print the most important features and their importance
+
+        Args:
+            feature_list
+            limit
         """
         # Get numerical feature importance
         importances = list(self._classifier.feature_importances_)
@@ -573,10 +585,17 @@ class Classifier:
 
     @staticmethod
     def count_label_threshold(all_counts: dict):
-        """
-        counts the number of groups that meet label threshold criteria
-        :param all_counts: labeled frame and bout counts for the entire project
-        parameter is a dict with the following form
+        """counts the number of groups that meet label threshold criteria
+
+        Args:
+            all_counts: labeled frame and bout counts for the entire
+                project
+
+        Returns:
+            number of groups that meet label criteria
+
+
+        all_counts is a dict with the following form
         {
             '<video name>': [
                 (
@@ -586,7 +605,6 @@ class Classifier:
                 ),
             ]
         }
-        :return: number of groups that meet label criteria
         """
         group_count = 0
         for video, counts in all_counts.items():
@@ -598,13 +616,17 @@ class Classifier:
 
     @staticmethod
     def label_threshold_met(all_counts: dict, min_groups: int):
-        """
-        determine if the labeling threshold is met
-        :param all_counts: labeled frame and bout counts for the entire project
-        :param min_groups: minimum number of groups required (more than one
-        group is always required for the "leave one group out" train/test split,
-        but may be more than 2 for k-fold cross validation if k > 2)
-        :return: bool if requested valid groups is > valid group
+        """determine if the labeling threshold is met
+
+        Args:
+            all_counts: labeled frame and bout counts for the entire
+                project
+            min_groups: minimum number of groups required (more than one
+                group is always required for the "leave one group out" train/test split,
+                but may be more than 2 for k-fold cross validation if k > 2)
+
+        Returns:
+            bool if requested valid groups is > valid group
         """
         group_count = Classifier.count_label_threshold(all_counts)
         return True if 1 < group_count >= min_groups else False

--- a/src/jabs/classifier/classifier.py
+++ b/src/jabs/classifier/classifier.py
@@ -591,20 +591,20 @@ class Classifier:
             all_counts: labeled frame and bout counts for the entire
                 project
 
+
+            all_counts is a dict with the following form
+            {
+                '<video name>': [
+                    (
+                        <identity>,
+                        (behavior frame count, not behavior frame count),
+                        (behavior bout count, not behavior bout count)
+                    ),
+                ]
+            }
+
         Returns:
             number of groups that meet label criteria
-
-
-        all_counts is a dict with the following form
-        {
-            '<video name>': [
-                (
-                    <identity>,
-                    (behavior frame count, not behavior frame count),
-                    (behavior bout count, not behavior bout count)
-                ),
-            ]
-        }
         """
         group_count = 0
         for video, counts in all_counts.items():

--- a/src/jabs/cli/progress_bar.py
+++ b/src/jabs/cli/progress_bar.py
@@ -3,20 +3,19 @@
 def cli_progress_bar(completed: int, total_iterations: int, length=40,
                      fill_char='█', padding_char='░', prefix='', suffix='',
                      precision=1, complete_as_percent=True):
-    """
-    Call in a loop to create terminal progress bar. The loop can't print
+    """Call in a loop to create terminal progress bar. The loop can't print
     any other output to stdout.
 
-    :param completed: number of completed iterations
-    :param total_iterations: total number of iterations in calling loop
-    :param length: length of bar in characters
-    :param fill_char: filled bar character
-    :param padding_char: unfilled bar character
-    :param prefix: prefix string, printed before progress bar
-    :param suffix: suffix string, printed after progress bar
-    :param precision: number of decimals in percent complete
-    :param complete_as_percent: if True, print percent complete, if False
-    print "num_complete of total_num"
+    Args:
+        completed: number of completed iterations
+        total_iterations: total number of iterations in calling loop
+        length: length of bar in characters
+        fill_char: filled bar character
+        padding_char: unfilled bar character
+        prefix: prefix string, printed before progress bar
+        suffix: suffix string, printed after progress bar
+        precision: number of decimals in percent complete
+        complete_as_percent: if True, print percent complete, if False print "num_complete of total_num"
     """
 
     if len(fill_char) != 1:

--- a/src/jabs/feature_extraction/angle_index.py
+++ b/src/jabs/feature_extraction/angle_index.py
@@ -3,7 +3,7 @@ from jabs.pose_estimation import PoseEstimation
 
 
 class AngleIndex(enum.IntEnum):
-    """ enum defining the indexes of the angle features """
+    """enum defining the indexes of the angle features"""
     NOSE_BASE_NECK_RIGHT_FRONT_PAW = 0
     NOSE_BASE_NECK_LEFT_FRONT_PAW = 1
     RIGHT_FRONT_PAW_BASE_NECK_CENTER_SPINE = 2

--- a/src/jabs/feature_extraction/base_features/angles.py
+++ b/src/jabs/feature_extraction/base_features/angles.py
@@ -8,8 +8,7 @@ from jabs.feature_extraction.feature_base_class import Feature
 
 class Angles(Feature):
 
-    """
-    this module computes joint angles
+    """this module computes joint angles
     the result is a dict of features of length #frames rows
     """
 
@@ -50,13 +49,15 @@ class Angles(Feature):
     def _compute_angles(
             a: np.ndarray, b: np.ndarray, c: np.ndarray
     ) -> np.ndarray:
-        """
-        compute angles for a set of points
-        :param a: array of point coordinates
-        :param b: array of vertex point coordinates
-        :param c: array of point coordinates
-        :return: array containing angles, in degrees, formed from the lines
-        ab and ba for each row in a, b, and c with range [0, 360)
+        """compute angles for a set of points
+
+        Args:
+            a: array of point coordinates
+            b: array of vertex point coordinates
+            c: array of point coordinates
+
+        Returns:
+            array containing angles, in degrees, formed from the lines ab and ba for each row in a, b, and c with range [0, 360)
         """
         angles = np.degrees(
             np.arctan2(c[:, 1] - b[:, 1], c[:, 0] - b[:, 0]) -

--- a/src/jabs/feature_extraction/base_features/angular_velocity.py
+++ b/src/jabs/feature_extraction/base_features/angular_velocity.py
@@ -6,18 +6,21 @@ from jabs.feature_extraction.feature_base_class import Feature
 
 class AngularVelocity(Feature):
 
-    """ compute angular velocity of animal bearing """
+    """compute angular velocity of animal bearing"""
 
     _name = 'angular_velocity'
 
     def __init__(self, poses: PoseEstimation, pixel_scale: float):
         super().__init__(poses, pixel_scale)
 
-    def per_frame(self, identity: int) -> np.ndarray:
-        """
-        compute the value of the per frame features for a specific identity
-        :param identity: identity to compute features for
-        :return: dict with feature values
+    def per_frame(self, identity: int) -> dict[str, np.ndarray]:
+        """compute the value of the per frame features for a specific identity
+
+        Args:
+            identity: identity to compute features for
+
+        Returns:
+            dict with feature values
         """
         fps = self._poses.fps
 

--- a/src/jabs/feature_extraction/base_features/base_group.py
+++ b/src/jabs/feature_extraction/base_features/base_group.py
@@ -23,10 +23,13 @@ class BaseFeatureGroup(FeatureGroup):
     }
 
     def _init_feature_mods(self, identity: int):
-        """
-        initialize all of the feature modules specified in the current config
-        :param identity: unused, specified by abstract base class
-        :return: dictionary of initialized feature modules for this group
+        """initialize all of the feature modules specified in the current config
+
+        Args:
+            identity: unused, specified by abstract base class
+
+        Returns:
+            dictionary of initialized feature modules for this group
         """
         return {
             feature: self._features[feature](self._poses, self._pixel_scale)

--- a/src/jabs/feature_extraction/base_features/centroid_velocity.py
+++ b/src/jabs/feature_extraction/base_features/centroid_velocity.py
@@ -12,7 +12,7 @@ from jabs.feature_extraction.feature_base_class import Feature
 # work computing each feature. Fix at next update to feature h5 file format.
 
 class CentroidVelocityDir(Feature):
-    """ feature for the direction of the center of mass velocity """
+    """feature for the direction of the center of mass velocity"""
 
     _name = 'centroid_velocity_dir'
 
@@ -60,7 +60,7 @@ class CentroidVelocityDir(Feature):
 
 
 class CentroidVelocityMag(Feature):
-    """ feature for the magnitude of the center of mass velocity """
+    """feature for the magnitude of the center of mass velocity"""
 
     _name = 'centroid_velocity_mag'
 
@@ -68,10 +68,13 @@ class CentroidVelocityMag(Feature):
         super().__init__(poses, pixel_scale)
 
     def per_frame(self, identity: int) -> dict[str, np.ndarray]:
-        """
-        compute the value of the per frame features for a specific identity
-        :param identity: identity to compute features for
-        :return: np.ndarray with feature values
+        """compute the value of the per frame features for a specific identity
+
+        Args:
+            identity: identity to compute features for
+
+        Returns:
+            np.ndarray with feature values
         """
         values = np.full(self._poses.num_frames, np.nan, dtype=np.float32)
         fps = self._poses.fps

--- a/src/jabs/feature_extraction/base_features/pairwise_distances.py
+++ b/src/jabs/feature_extraction/base_features/pairwise_distances.py
@@ -13,11 +13,14 @@ class PairwisePointDistances(Feature):
         super().__init__(poses, pixel_scale)
 
     def per_frame(self, identity: int) -> dict[str, np.ndarray]:
+        """compute the value of the per frame features for a specific identity
+
+        Args:
+            identity: identity to compute features for
+
+        Returns:
+            dict with feature values
         """
-                compute the value of the per frame features for a specific identity
-                :param identity: identity to compute features for
-                :return: dict with feature values
-                """
 
         points, _ = self._poses.get_identity_poses(identity, self._pixel_scale)
 

--- a/src/jabs/feature_extraction/base_features/point_speeds.py
+++ b/src/jabs/feature_extraction/base_features/point_speeds.py
@@ -12,10 +12,13 @@ class PointSpeeds(Feature):
         super().__init__(poses, pixel_scale)
 
     def per_frame(self, identity: int) -> dict[str, np.ndarray]:
-        """
-        compute the value of the per frame features for a specific identity
-        :param identity: identity to compute features for
-        :return: dict with feature values
+        """compute the value of the per frame features for a specific identity
+
+        Args:
+            identity: identity to compute features for
+
+        Returns:
+            dict with feature values
         """
         fps = self._poses.fps
         poses, point_masks = self._poses.get_identity_poses(identity, self._pixel_scale)

--- a/src/jabs/feature_extraction/base_features/point_velocities.py
+++ b/src/jabs/feature_extraction/base_features/point_velocities.py
@@ -11,7 +11,7 @@ from jabs.feature_extraction.feature_base_class import Feature
 # since they both use keypoint gradients
 
 class PointVelocityDirs(Feature, abc.ABC):
-    """ feature for the direction of the point velocity """
+    """feature for the direction of the point velocity"""
 
     # subclass must override this
     _name = 'point_velocity_dirs'

--- a/src/jabs/feature_extraction/feature_base_class.py
+++ b/src/jabs/feature_extraction/feature_base_class.py
@@ -9,8 +9,7 @@ from jabs.pose_estimation import PoseEstimation
 
 
 class Feature(abc.ABC):
-    """
-    Abstract Base Class to define a common interface for classes that implement
+    """Abstract Base Class to define a common interface for classes that implement
     one or more related features
     """
 
@@ -72,13 +71,12 @@ class Feature(abc.ABC):
 
     @classmethod
     def name(cls) -> str:
-        """ return a string name of the feature """
+        """return a string name of the feature"""
         return cls._name
 
     @classmethod
     def feature_names(cls) -> list[str]:
-        """
-        return a list of strings containing the names of the features for the
+        """return a list of strings containing the names of the features for the
         feature set
         """
         return cls._feature_names
@@ -86,13 +84,18 @@ class Feature(abc.ABC):
     @classmethod
     def is_supported(
             cls, pose_version: int, static_objects: set[str], **kwargs) -> bool:
-        """
-        check that a feature is supported by a pose file
-        :param pose_version: pose file version
-        :param static_objects: list of static object available in pose file
-        :param kwargs: additional attributes that can be used to determine if a feature
-          is supported by the project, not used by the default method but might be used by subclasses
-        :return: True if the pose file supports the feature, false otherwise
+        """check that a feature is supported by a pose file
+
+        Args:
+            pose_version: pose file version
+            static_objects: list of static object available in pose file
+            **kwargs: additional attributes that can be used to
+                determine if a feature is supported by the project, not
+                used by the default method but might be used by
+                subclasses
+
+        Returns:
+            True if the pose file supports the feature, false otherwise
         """
 
         # check that the minimum pose version is met
@@ -109,8 +112,7 @@ class Feature(abc.ABC):
 
     @abc.abstractmethod
     def per_frame(self, identity: int) -> dict[str, np.ndarray]:
-        """
-        each FeatureSet subclass will implement this to compute the
+        """each FeatureSet subclass will implement this to compute the
         features in the set
 
         returns an ndarray containing the feature values.
@@ -124,8 +126,7 @@ class Feature(abc.ABC):
 
     def window(self, identity: int, window_size: int,
                per_frame_values: dict) -> dict:
-        """
-        standard method for computing window feature values
+        """standard method for computing window feature values
 
         NOTE: some features may need to override this (for example, those with
         circular values such as angles)
@@ -147,13 +148,15 @@ class Feature(abc.ABC):
         window_size: int,
         per_frame_values: dict
     ) -> dict:
-        """
-        The standard method for computing signal processing window features.
+        """The standard method for computing signal processing window features.
 
-        :param identity: The identity of the mouse.
-        :param window_size: The window size used for signal formation.
-        :param per_frame_values: The values for a particular feature.
-        :return: a dictionary of the signal processing features.
+        Args:
+            identity: The identity of the mouse.
+            window_size: The window size used for signal formation.
+            per_frame_values: The values for a particular feature.
+
+        Returns:
+            a dictionary of the signal processing features.
         """
         values = {}
 
@@ -189,13 +192,15 @@ class Feature(abc.ABC):
 
     def _window_circular(self, identity: int, window_size: int,
                          per_frame_values: dict) -> dict:
-        """
-        helper function for overriding window features to be circular
+        """helper function for overriding window features to be circular
 
-        :param identity: The identity of the mouse.
-        :param window_size: The window size used for signal formation.
-        :param per_frame_values: The values for a particular feature.
-        :return: a dictionary of the circular window features.
+        Args:
+            identity: The identity of the mouse.
+            window_size: The window size used for signal formation.
+            per_frame_values: The values for a particular feature.
+
+        Returns:
+            a dictionary of the circular window features.
         """
         values = {}
         for op_name, op in self._window_operations.items():
@@ -207,16 +212,16 @@ class Feature(abc.ABC):
     def _compute_window_feature(self, feature_values: dict,
                                 frame_mask: np.ndarray, window_size: int,
                                 op: typing.Callable) -> dict:
-        """
-        helper function to compute window feature values
+        """helper function to compute window feature values
 
-        :param feature_values: dict of per frame feature values
-        :param frame_mask: array indicating which frames are valid for the
-        current identity
-        :param window_size: number of frames (in each direction) to include
-        in the window. The actual number of frames is 2 * window_size + 1
-        :param op: function to perform the actual computation
-        :return: dict containing feature values
+        Args:
+            feature_values: dict of per frame feature values
+            frame_mask: array indicating which frames are valid for the current identity
+            window_size: number of frames (in each direction) to include in the window. The actual number of frames is 2 * window_size + 1
+            op: function to perform the actual computation
+
+        Returns:
+            dict containing feature values
         """
         values = {}
         for key, val in feature_values.items():
@@ -227,17 +232,19 @@ class Feature(abc.ABC):
     def _compute_signal_features(
             self, freqs: np.ndarray, psd: dict,
             frame_mask: np.ndarray, op: typing.Callable, **kwargs) -> dict:
-        """
-        helper function to compute signal window feature values.
+        """helper function to compute signal window feature values.
 
-        :param freqs: frequency values for psd matrices
-        :param psd: dict of power spectral density
-        :param frame_mask: array indicating which frames are valid for the
-        current identity
-        :param op: function to perform the actual computation. Operation must
-        accept frequencies and psd as input
-        :param kwargs: additional keyword args used by op
-        :return: numpy nd array containing feature values
+        Args:
+            freqs: frequency values for psd matrices
+            psd: dict of power spectral density
+            frame_mask: array indicating which frames are valid for the current identity
+            op: function to perform the actual computation. Operation must accept frequencies and psd as input
+            **kwargs: additional keyword args used by op
+
+
+
+        Returns:
+            numpy nd array containing feature values
         """
         values = {}
         for key, value in psd.items():
@@ -249,15 +256,16 @@ class Feature(abc.ABC):
             self, feature_values: dict, frame_mask: np.ndarray,
             window_size: int, op: typing.Callable
     ) -> dict:
-        """
-        special case compute_window_features for circular measurements
+        """special case compute_window_features for circular measurements
 
-        :param feature_values: dict of per-frame feature values
-        :param frame_mask: numpy array that indicates if the frame is valid or
-        not for the specific identity we are computing features for
-        :param window_size:
-        :param op:
-        :return: dict with circular feature values
+        Args:
+            feature_values: dict of per-frame feature values
+            frame_mask: numpy array that indicates if the frame is valid for the specific identity we are computing features for
+            window_size:
+            op:
+
+        Returns:
+            dict with circular feature values
         """
         nframes = self._poses.num_frames
         values = {}

--- a/src/jabs/feature_extraction/feature_group_base_class.py
+++ b/src/jabs/feature_extraction/feature_group_base_class.py
@@ -25,11 +25,13 @@ class FeatureGroup(abc.ABC):
         self._enabled_features = list(self._features.keys())
 
     def per_frame(self, identity: int) -> dict:
-        """
-        compute the value of the per frame features for a specific identity
-        :param identity: identity to compute features for
-        :return: dict where each key is the name of a feature module included
-        in this FeatureGroup
+        """compute the value of the per frame features for a specific identity
+
+        Args:
+            identity: identity to compute features for
+
+        Returns:
+            dict where each key is the name of a feature module included in this FeatureGroup
         """
         feature_modules = self._init_feature_mods(identity)
         return {
@@ -39,15 +41,18 @@ class FeatureGroup(abc.ABC):
 
     def window(self, identity: int, window_size: int,
                per_frame_values: dict) -> dict:
-        """
-        compute window feature values for a given identities per frame values
-        :param identity: subject identity
-        :param window_size: window size
-          NOTE: (actual window size is 2 * window_size + 1)
-        :param per_frame_values: per frame feature values
-        :return: dictionary where keys are feature module names that are part
-        of this FeatureGroup. The value for each element is the window feature
-        dict returned by that module.
+        """compute window feature values for a given identities per frame values
+
+        Args:
+            identity: subject identity
+            window_size: window size NOTE: (actual window size is 2 *
+                window_size + 1)
+            per_frame_values: per frame feature values
+
+        Returns:
+            dictionary where keys are feature module names that are part
+            of this FeatureGroup. The value for each element is the window feature
+            dict returned by that module.
         """
         feature_modules = self._init_feature_mods(identity)
         return {
@@ -78,13 +83,13 @@ class FeatureGroup(abc.ABC):
             static_objects: set[str],
             **kwargs,
     ) -> list[str]:
-        """
-        Get the features supported by this group based on the pose version,
+        """Get the features supported by this group based on the pose version,
           static objects, and optional additional attributes
-        :param pose_version:
-        :param static_objects:
-        :param kwargs:
-        :return:
+
+        Args:
+            pose_version
+            static_objects
+            **kwargs
         """
         features = []
         for feature_name, feature_class in cls._features.items():

--- a/src/jabs/feature_extraction/features.py
+++ b/src/jabs/feature_extraction/features.py
@@ -50,9 +50,7 @@ class DistanceScaleException(Exception):
 
 
 class IdentityFeatures:
-    """
-    per frame and window features for a single identity
-    """
+    """per frame and window features for a single identity"""
 
     _version = FEATURE_VERSION
 
@@ -61,23 +59,28 @@ class IdentityFeatures:
                  op_settings: dict | None = None, cache_window: bool = True, 
                  compression_opts: int = COMPRESSION_OPTS_DEFAULT):
         """
-        :param source_file: name of the source video or pose file, used for
+        Args:
+            source_file: name of the source video or pose file, used for
+            identity: identity to extract features for
+            directory: path of the project directory. A value of None
+                can
+            pose_est: PoseEstimation object corresponding to this video
+            force: force regeneration of per frame features even if the
+            fps: frames per second. Used for converting angular velocity
+                from
+            op_settings: dict of optional settings to enable/disable
+            cache_window: bool to indicate saving the window features in
+                the cache directory
+            compression_opts: int to indicate the compression level for
+                saving features
         generating filenames for saving extracted features into the project
         directory. You can use None for this argument if directory is also set
         to None
-        :param identity: identity to extract features for
-        :param directory: path of the project directory. A value of None can
         be given to prevent saving to and loading from a project dir.
-        :param pose_est: PoseEstimation object corresponding to this video
-        :param force: force regeneration of per frame features even if the
         per frame feature .h5 file exists for this video/identity
-        :param fps: frames per second. Used for converting angular velocity from
         degrees per frame to degrees per second
-        :param op_settings: dict of optional settings to enable/disable
         when returning features. This will modify the contents returned by
         get_window_features, get_per_frame, and get_features
-        :param cache_window: bool to indicate saving the window features in the cache directory
-        :param compression_opts: int to indicate the compression level for saving features
         """
 
         self._pose_version = pose_est.format_major_version
@@ -143,11 +146,13 @@ class IdentityFeatures:
                 self.__initialize_from_pose_estimation(pose_est)
 
     def __initialize_from_pose_estimation(self, pose_est):
-        """
-        Initialize from a PoseEstimation object and save them in an h5 file
+        """Initialize from a PoseEstimation object and save them in an h5 file
 
-        :param pose_est: PoseEstimation object used to initialize self
-        :return: None
+        Args:
+            pose_est: PoseEstimation object used to initialize self
+
+        Returns:
+            None
         """
 
         # indicate this identity exists in this frame
@@ -162,17 +167,23 @@ class IdentityFeatures:
             self.__save_per_frame()
 
     def __load_from_file(self):
-        """
-        initialize from state previously saved in a h5 file on disk
+        """initialize from state previously saved in a h5 file on disk
         This method will throw an exception if this object
         was constructed with a value of None for directory
-        :raises OSError: if unable to open h5 file
-        :raises TypeError: if this object was constructed with a value of None
+
+        Raises:
+            OSError: if unable to open h5 file
+            TypeError: if this object was constructed with a value of
+                None
+            FeatureVersionException: if file version differs from
+                current
+            AssertionError: if metadata shape doesn't match feature
+                shape
         for directory
-        :raises FeatureVersionException: if file version differs from current
         feature version
-        :raises AssertionError: if metadata shape doesn't match feature shape
-        :return: None
+
+        Returns:
+            None
         """
 
         path = self._identity_feature_dir / 'features.h5'
@@ -228,8 +239,7 @@ class IdentityFeatures:
                 self._per_frame[module_name] = cur_module
 
     def __save_per_frame(self):
-        """
-        save per frame features to a h5 file
+        """save per frame features to a h5 file
         This method will throw an exception if this object
         was constructed with a value of None for directory
         """
@@ -315,14 +325,17 @@ class IdentityFeatures:
                 )
 
     def __save_window_features(self, features, window_size):
-        """
-        save window features to an h5 file
+        """save window features to an h5 file
         This method will throw an exception if this object
         was constructed with a value of None for directory
-        :param features: window features returned from
-        `get_window_features()` to save
-        :param window_size: window size used
-        :return: None
+
+        Args:
+            features: window features returned from `get_window_features()` to save
+            window_size: window size used
+
+
+        Returns:
+            None
         """
         path = self._identity_feature_dir / 'features.h5'
 
@@ -347,20 +360,21 @@ class IdentityFeatures:
                 )
 
     def __load_window_features(self, window_size):
-        """
-        load window features from an h5 file
-        :param window_size: window size specified as the number of frames on
-        each side of current frame, in addition to the current frame, to
-        include in the window
-        (so if size=5, the total number of frames in the window is actually 11)
-        :raises OSError: if unable to open h5 file
-        :raises AttributeError: if h5 file exists but doesn't contain cached window features
-        :raises TypeError: if this object was constructed with a value of None
-        for directory
-        :raises FeatureVersionException: if file version differs from current
-        feature version
+        """load window features from an h5 file
 
-        :return: window feature dict
+        Args:
+            window_size: window size specified as the number of frames
+                on each side of current frame, in addition to the current frame, to
+                include in the window (so if size=5, the total number of frames in the window is actually 11)
+
+        Raises:
+            OSError: if unable to open h5 file
+            AttributeError: if h5 file exists but doesn't contain cached window features
+            TypeError: if this object was constructed with a value of Nonefor directory
+            FeatureVersionException: if file version differs from current feature version
+
+        Returns:
+            window feature dict
         """
         path = self._identity_feature_dir / 'features.h5'
 
@@ -404,21 +418,26 @@ class IdentityFeatures:
 
     def get_window_features(self, window_size: int,
                             labels=None, force: bool = False):
-        """
-        get window features for a given window size, computing if not previously
+        """get window features for a given window size, computing if not previously
         computed and saved as h5 file
-        :param window_size: number of frames on each side of the current frame to
-        include in the window
-        :param labels: optional frame labels, if present then only features for
-        labeled frames will be returned
-        NOTE: if labels is None, this will also include values for frames where
-        the identity does not exist. These get filtered out when filtering out
-        unlabeled frames, since those frames are always unlabeled.
-        :param force: force regeneration of the window features even if the
-        h5 file already exists
-        :return: window features for given window size. the format is documented
-        in the docstring for _compute_window_features
-        features are filtered by self.op_settings
+
+        Args:
+            window_size: number of frames on each side of the current
+                frame to include in the window
+            labels: optional frame labels, if present then only features
+                for labeled frames will be returned
+            force: force regeneration of the window features even if the
+               features are filtered by self.op_settings
+
+        NOTE:
+            if labels is None, this will also include values for frames where
+            the identity does not exist. These get filtered out when filtering out
+            unlabeled frames, since those frames are always unlabeled.
+            h5 file already exists
+
+        Returns:
+            window features for given window size. the format is
+            documented in the docstring for _compute_window_features
         """
 
         if force or self._identity_feature_dir is None:
@@ -465,25 +484,30 @@ class IdentityFeatures:
         return final_features
 
     def get_per_frame(self, labels=None):
-        """
-        get per frame features
-        :param labels: if present, only return features for labeled frames
-        NOTE: if labels is None, this will include also values for frames where
-        the identity does not exist. These get filtered out when filtering out
-        unlabeled frames, since those frames are always unlabeled.
-        :return: returns per frame features in dictionary with this form
+        """get per frame features
 
-        {
-            'pairwise_distances': {
-                'distance1': 1d numpy array,
-                'distance2': 1d numpy array,
+        Args:
+            labels: if present, only return features for labeled frames
+
+        NOTE: if labels is None, this will include also values for frames where
+            the identity does not exist. These get filtered out when filtering out
+            unlabeled frames, since those frames are always unlabeled.
+
+        Returns:
+            returns per frame features in dictionary with this form
+
+            {
+                'pairwise_distances': {
+                    'distance1': 1d numpy array,
+                    'distance2': 1d numpy array,
+                    ...
+                },
+                'angles': {...},
+                'point_speeds': {...},
                 ...
-            },
-            'angles': {...},
-            'point_speeds': {...},
-            ...
-        }
-        features are filtered by self.op_settings
+            }
+
+            features are filtered by self.op_settings
         """
 
         if labels is None:
@@ -505,18 +529,22 @@ class IdentityFeatures:
         return features
 
     def get_features(self, window_size: int):
-        """
-        get features and corresponding frame indexes for classification
+        """get features and corresponding frame indexes for classification
         omits frames where the identity is not valid, so 'frame_indexes' array
         may not be consecutive
-        :param window_size: window size to use
-        :return: dictionary with the following keys:
 
-          'per_frame': dict with feature name as keys, numpy array as values
-          'window': dict, see _compute_window_features
-          'frame_indexes': 1D np array, maps elements of per frame and window
-             feature arrays back to global frame indexes
-        features are filtered by self.op_settings
+        Args:
+            window_size: window size to use
+
+        Returns:
+            dictionary with the following keys:
+
+            'per_frame': dict with feature name as keys, numpy array as values
+            'window': dict, see _compute_window_features
+            'frame_indexes': 1D np array, maps elements of per frame and window
+               feature arrays back to global frame indexes
+
+            features are filtered by self.op_settings
         """
         per_frame_features = self.get_per_frame()
         window_features = self.get_window_features(window_size)
@@ -530,10 +558,13 @@ class IdentityFeatures:
         }
 
     def _filter_base_features_by_op(self, features):
-        """
-        filter either per_frame or window features by the self._op_settings
-        :param features: dict of feature data
-        :return: filtered features
+        """filter either per_frame or window features by the self._op_settings
+
+        Args:
+            features: dict of feature data
+
+        Returns:
+            filtered features
         """
         names_to_remove = []
         for setting_name, setting_val in self._op_settings.items():
@@ -550,10 +581,13 @@ class IdentityFeatures:
         return {k: v for k, v in features.items() if k not in names_to_remove}
 
     def _filter_window_features_by_op(self, features):
-        """
-        filter window features by the self._op_settings
-        :param features: dict of window feature data (must be dict of dict of dict)
-        :return: filtered features
+        """filter window features by the self._op_settings
+
+        Args:
+            features: dict of window feature data (must be dict of dict of dict)
+
+        Returns:
+            filtered features
         """
         names_to_remove = []
         for setting_name, setting_val in self._op_settings.items():
@@ -577,13 +611,15 @@ class IdentityFeatures:
 
 
     def __compute_window_features(self, window_size: int):
-        """
-        compute all window features using a given window size
-        :param window_size: number of frames on each side of the current frame
-        to include in the window
-        (so, for example, if window_size = 5, then the total number of frames
-        in the window is 11)
-        :return: dictionary of the form:
+        """compute all window features using a given window size
+
+        Args:
+            window_size: number of frames on each side of the current frame to include in the window
+                (so, for example, if window_size = 5, then the total number of frames
+                in the window is 11)
+
+        Returns:
+            dictionary of the form:
         {
             'angles' {
                 'mean': {
@@ -620,12 +656,14 @@ class IdentityFeatures:
 
     @classmethod
     def merge_per_frame_features(cls, features: dict) -> dict:
-        """
-        merge a dict of per-frame features where each element in the dict is
+        """merge a dict of per-frame features where each element in the dict is
         a set of per-frame features computed for an individual animal
-        :param features: list of per-frame feature instances
 
-        :return: dict of the form
+        Args:
+            features: list of per-frame feature instances
+
+        Returns:
+            dict of the form
         {
             'feature_1_name': feature_1_vector,
             'feature_2_name': feature_2_vector,
@@ -645,11 +683,14 @@ class IdentityFeatures:
 
     @classmethod
     def merge_window_features(cls, features: dict) -> dict:
-        """
-        merge a dict of window features where each element in the dict is the
+        """merge a dict of window features where each element in the dict is the
         set of window features computed for an individual animal
-        :param features: dict of window feature dicts
-        :return: dictionary of the form:
+
+        Args:
+            features: dict of window feature dicts
+
+        Returns:
+            dictionary of the form:
         {
             'mod1 feature_1_name': mod1_feature_1_vector,
             'mod2 feature_2_name': mod2_feature_2_vector,
@@ -674,19 +715,24 @@ class IdentityFeatures:
             static_objects: set[str],
             **kwargs,
     ) -> dict[str, list[str]]:
-        """
-        get all the extended features that can be used given a minimum pose
+        """get all the extended features that can be used given a minimum pose
         version and list of available static objects
-        :param pose_version: integer pose version
-        :param static_objects: list of static object names
-        :param kwargs: additional keyword arguments that might be used to determine
-          if a feature is supported for a given pose file
-        :return: dictionary of supported extended features, where the keys
-        are "feature group" name(s) and values are feature names that can
-        be used from that group
 
-        TODO social features probably should get moved into the 'extended'
-          features, but they are still handled as a special case
+        Args:
+            pose_version: integer pose version
+            static_objects: list of static object names
+            **kwargs: additional keyword arguments that might be used to
+                determine if a feature is supported for a given pose
+                file
+
+        Returns:
+            dictionary of supported extended features, where the keys
+            are "feature group" name(s) and values are feature names that can
+            be used from that group
+
+        TODO:
+            social features probably should get moved into the 'extended'
+            features, but they are still handled as a special case
         """
 
         return {

--- a/src/jabs/feature_extraction/features.py
+++ b/src/jabs/feature_extraction/features.py
@@ -60,27 +60,34 @@ class IdentityFeatures:
                  compression_opts: int = COMPRESSION_OPTS_DEFAULT):
         """
         Args:
-            source_file: name of the source video or pose file, used for
-            identity: identity to extract features for
-            directory: path of the project directory. A value of None
-                can
-            pose_est: PoseEstimation object corresponding to this video
-            force: force regeneration of per frame features even if the
-            fps: frames per second. Used for converting angular velocity
-                from
-            op_settings: dict of optional settings to enable/disable
-            cache_window: bool to indicate saving the window features in
-                the cache directory
+            source_file:
+              name of the source video or pose file, used for generating
+              filenames for saving extracted features into the project
+              directory. You can use None for this argument if directory
+              is also set to None
+            identity:
+              identity to extract features for
+            directory:
+              path of the project directory. A value of None can be given
+              to prevent saving to and loading from a project dir.
+            pose_est:
+              PoseEstimation object corresponding to this video
+            force:
+              force regeneration of per frame features even if the
+              per frame feature .h5 file exists for this video/identity
+            fps:
+              frames per second. Used for converting angular velocity
+              from degrees per frame to degrees per second
+            op_settings:
+              dict of optional settings to enable/disable when returning
+              features. This will modify the contents returned by
+              get_window_features, get_per_frame, and get_features
+            cache_window:
+              bool to indicate saving the window features in the cache
+              directory
             compression_opts: int to indicate the compression level for
-                saving features
-        generating filenames for saving extracted features into the project
-        directory. You can use None for this argument if directory is also set
-        to None
-        be given to prevent saving to and loading from a project dir.
-        per frame feature .h5 file exists for this video/identity
-        degrees per frame to degrees per second
-        when returning features. This will modify the contents returned by
-        get_window_features, get_per_frame, and get_features
+              saving features
+
         """
 
         self._pose_version = pose_est.format_major_version

--- a/src/jabs/feature_extraction/landmark_features/corner.py
+++ b/src/jabs/feature_extraction/landmark_features/corner.py
@@ -11,8 +11,7 @@ from jabs.feature_extraction.feature_base_class import Feature
 
 
 class CornerDistanceInfo:
-    """
-    because we have two features that both need to know which corner is the
+    """because we have two features that both need to know which corner is the
     closest, we compute that information once in this helper class and then
     pass it to both of the features
     The features are not merged into a single feature because one (bearing to
@@ -30,9 +29,10 @@ class CornerDistanceInfo:
         self._all_wall_distances = {}
 
     def cache_features(self, identity: int):
-        """
-        cache corner distances and bearings for a given identity
-        :param identity: integer identity to get distances for
+        """cache corner distances and bearings for a given identity
+
+        Args:
+            identity: integer identity to get distances for
         """
 
         if identity in self._cached_distances and identity in self._cached_bearings:
@@ -133,50 +133,65 @@ class CornerDistanceInfo:
         self._avg_wall_length = avg_wall_length
 
     def get_distances(self, identity: int) -> typing.Dict:
-        """
-        get corner distance features for a given identity
-        :param identity: integer identity to get distances for
-        :return: dict containing keyed distances
+        """get corner distance features for a given identity
+
+        Args:
+            identity: integer identity to get distances for
+
+        Returns:
+            dict containing keyed distances
         """
         if identity not in self._cached_distances:
             self.cache_features(identity)
         return self._cached_distances[identity]
 
     def get_bearings(self, identity: int) -> typing.Dict:
-        """
-        get corner bearing features for a given identity
-        :param identity: integer identity to get bearings for
-        :return: dict containing keyed bearings
+        """get corner bearing features for a given identity
+
+        Args:
+            identity: integer identity to get bearings for
+
+        Returns:
+            dict containing keyed bearings
         """
         if identity not in self._cached_bearings:
             self.cache_features(identity)
         return self._cached_bearings[identity]
 
     def get_closest_corner(self, identity: int) -> np.ndarray:
-        """
-        get the closest corner index
-        :param identity: integer identity to get the closest corner
-        :return: np.ndarray of the corner index
+        """get the closest corner index
+
+        Args:
+            identity: integer identity to get the closest corner
+
+        Returns:
+            np.ndarray of the corner index
         """
         if identity not in self._closest_corner_idx:
             self.cache_features(identity)
         return self._closest_corner_idx[identity]
 
     def get_wall_distances(self, identity: int) -> np.ndarray:
-        """
-        get the wall distances
-        :param identity: integer identity to get the wall distances
-        :return: np.ndarray of all wall distances
+        """get the wall distances
+
+        Args:
+            identity: integer identity to get the wall distances
+
+        Returns:
+            np.ndarray of all wall distances
         """
         if identity not in self._all_wall_distances:
             self.cache_features(identity)
         return self._all_wall_distances[identity]
 
     def get_avg_wall_length(self, identity: int = 0) -> np.ndarray:
-        """
-        gets the average wall length
-        :param identity: identity to cache if not yet calculated
-        :returns: average wall length
+        """gets the average wall length
+
+        Args:
+            identity: identity to cache if not yet calculated
+
+        Returns:
+            average wall length
         """
         if self._avg_wall_length is None:
             self.cache_features(identity)
@@ -184,10 +199,13 @@ class CornerDistanceInfo:
 
     @staticmethod
     def sort_points_clockwise(points):
-        """
-        sorts a list of points to be clockwise relative to the first point
-        :param points: points to sort of shape [n_points, 2]
-        :return: points sorted clockwise
+        """sorts a list of points to be clockwise relative to the first point
+
+        Args:
+            points: points to sort of shape [n_points, 2]
+
+        Returns:
+            points sorted clockwise
         """
         origin_point = np.mean(points, axis=0)
         vectors = points - origin_point
@@ -199,12 +217,15 @@ class CornerDistanceInfo:
 
     @staticmethod
     def compute_angle(a, b, c):
-        """
-        compute angle created by three connected points
-        :param a: point
-        :param b: vertex point
-        :param c: point
-        :return: angle between AB and BC with range [-180, 180)
+        """compute angle created by three connected points
+
+        Args:
+            a: point
+            b: vertex point
+            c: point
+
+        Returns:
+            angle between AB and BC with range [-180, 180)
         """
 
         # most of the point types are unsigned short integers
@@ -228,10 +249,13 @@ class DistanceToCorner(Feature):
         self._cached_distances = distances
 
     def per_frame(self, identity: int) -> typing.Dict:
-        """
-        get the per frame distance to the nearest corner values
-        :param identity: identity to get feature values for
-        :return: dict of numpy ndarray of values with shape (nframes,)
+        """get the per frame distance to the nearest corner values
+
+        Args:
+            identity: identity to get feature values for
+
+        Returns:
+            dict of numpy ndarray of values with shape (nframes,)
         """
 
         distances = self._cached_distances.get_distances(identity)
@@ -256,10 +280,13 @@ class BearingToCorner(Feature):
         self._cached_distances = distances
 
     def per_frame(self, identity: int) -> typing.Dict:
-        """
-        get the per frame bearing to the nearest corner values
-        :param identity: identity to get feature values for
-        :return: dict of numpy ndarray values with shape (nframes,)
+        """get the per frame bearing to the nearest corner values
+
+        Args:
+            identity: identity to get feature values for
+
+        Returns:
+            dict of numpy ndarray values with shape (nframes,)
         """
 
         bearings = self._cached_distances.get_bearings(identity)

--- a/src/jabs/feature_extraction/landmark_features/food_hopper.py
+++ b/src/jabs/feature_extraction/landmark_features/food_hopper.py
@@ -15,11 +15,15 @@ class FoodHopper(Feature):
     _static_objects = ['food_hopper']
 
     def per_frame(self, identity: int) -> dict:
-        """
-        get the per frame feature values for the food hopper landmark
-        :param identity: identity to get feature values for
-        :return: numpy ndarray of values with shape (nframes, 10)
-        for each frame, the 10 values are the signed distance from the key point
+        """get the per frame feature values for the food hopper landmark
+
+        Args:
+            identity: identity to get feature values for
+
+        Returns:
+            numpy ndarray of values with shape (nframes, 10)
+
+        for each frame, the 10 feature values are the signed distance from the key point
         to the polygon defined by the food hopper key points (10 points
         because the mid tail and tail tip are excluded)
         """

--- a/src/jabs/feature_extraction/landmark_features/landmark_group.py
+++ b/src/jabs/feature_extraction/landmark_features/landmark_group.py
@@ -49,10 +49,13 @@ class LandmarkFeatureGroup(FeatureGroup):
         self._lixit_info = {}
 
     def _init_feature_mods(self, identity: int):
-        """
-        initialize all the feature modules specified in the current config
-        :param identity: identity to initialize the features for
-        :return: dictionary of initialized feature modules for this group
+        """initialize all the feature modules specified in the current config
+
+        Args:
+            identity: identity to initialize the features for
+
+        Returns:
+            dictionary of initialized feature modules for this group
         """
         modules = {}
 
@@ -90,10 +93,13 @@ class LandmarkFeatureGroup(FeatureGroup):
         return modules
 
     def get_corner_info(self, identity: int):
-        """
-        gets the corner info for a specific identity
-        :param identity: identity to get info object for
-        :return: CornerDistanceInfo object for the requested identity
+        """gets the corner info for a specific identity
+
+        Args:
+            identity: identity to get info object for
+
+        Returns:
+            CornerDistanceInfo object for the requested identity
         """
         if identity not in self._corner_info:
             self._corner_info[identity] = CornerDistanceInfo(
@@ -102,10 +108,13 @@ class LandmarkFeatureGroup(FeatureGroup):
         return self._corner_info[identity]
 
     def get_lixit_info(self, identity: int):
-        """
-        gets the lixit info for a specific identity
-        :param identity: identity to get the info object for
-        :return: LixitDistanceInfo object for the requested identity
+        """gets the lixit info for a specific identity
+
+        Args:
+            identity: identity to get the info object for
+
+        Returns:
+            LixitDistanceInfo object for the requested identity
         """
         if identity not in self._lixit_info:
             self._lixit_info[identity] = LixitDistanceInfo(
@@ -115,11 +124,13 @@ class LandmarkFeatureGroup(FeatureGroup):
 
     @classmethod
     def static_object_features(cls, static_object: str):
-        """
-        get a list of the features derived from a given static object (landmark)
-        :param static_object: name of object (e.g. 'corners')
-        :return: list of strings containing feature names derived from that
-        object
+        """get a list of the features derived from a given static object (landmark)
+
+        Args:
+            static_object: name of object (e.g. 'corners')
+
+        Returns:
+            list of strings containing feature names derived from that object
         """
         try:
             return cls.feature_map[static_object]
@@ -128,10 +139,14 @@ class LandmarkFeatureGroup(FeatureGroup):
 
     @classmethod
     def static_object_per_frame_features(cls, feature_name: str):
-        """
-        get a list of per frame features derived from a static object feature
-        :param feature_name: name of feature to retrieve the per frame feature names
-        :return: list of strings containing per frame features derived from that object
+        """get a list of per frame features derived from a static object feature
+
+        Args:
+            feature_name: name of feature to retrieve the per frame
+                feature names
+
+        Returns:
+            list of strings containing per frame features derived from that object
         """
         try:
             return cls._features[feature_name].feature_names()
@@ -140,10 +155,13 @@ class LandmarkFeatureGroup(FeatureGroup):
 
     @classmethod
     def static_object_window_features(cls, feature_name: str):
-        """
-        get a list of window features derived from a static object feature
-        :param feature_name: name of feature to retrieve the window feature names
-        :return: list of strings containing window features derived from that object
+        """get a list of window features derived from a static object feature
+
+        Args:
+            feature_name: name of feature to retrieve the window feature names
+
+        Returns:
+            list of strings containing window features derived from that object
         """
         try:
             return list(cls._features[feature_name]._window_operations.keys())
@@ -152,19 +170,24 @@ class LandmarkFeatureGroup(FeatureGroup):
 
     @classmethod
     def get_supported_objects(cls):
-        """
-        get a list of all objects supported
-        :return: list of the object names
+        """get a list of all objects supported
+
+        Returns:
+            list of the object names
         """
         return cls.feature_map.keys()
 
     @classmethod
     def get_objects_from_features(cls, features: list):
-        """
-        gets a list of objects required to generate features
+        """gets a list of objects required to generate features
+
         this is the reverse of static_object_features
-        :param features: list of features which may include static object features
-        :return: list of objects needed to generate the features
+
+        Args:
+            features: list of features which may include static object features
+
+        Returns:
+            list of objects needed to generate the features
         """
         found_objects = []
         for cur_feature in features:
@@ -175,10 +198,10 @@ class LandmarkFeatureGroup(FeatureGroup):
 
     @classmethod
     def get_feature_names(cls, static_objects: list = None):
-        """
-        get the features supported
-        :param static_objects: list of static objects. if None, get features for all supported static objects
-        :return:
+        """get the features supported
+
+        Args:
+            static_objects: list of static objects. if None, get features for all supported static objects
         """
         if static_objects is None:
             valid_objects = cls.get_supported_objects()

--- a/src/jabs/feature_extraction/landmark_features/lixit.py
+++ b/src/jabs/feature_extraction/landmark_features/lixit.py
@@ -6,8 +6,7 @@ from jabs.feature_extraction.feature_base_class import Feature
 
 
 class LixitDistanceInfo:
-    """
-    because we have two feature groups that both need to know which lixit is the
+    """because we have two feature groups that both need to know which lixit is the
     closest, we compute that information once in this helper class and then
     pass it to both of the features
     The features cannot be merged into a single feature because one requires a
@@ -102,30 +101,39 @@ class LixitDistanceInfo:
             )
 
     def get_distances(self, identity: int) -> dict:
-        """
-        get lixit distance feature for a given identity
-        :param identity: integer identity to get distances foor
-        :return: dict containing keyed distances
+        """get lixit distance feature for a given identity
+
+        Args:
+            identity: integer identity to get distances for
+
+        Returns:
+            dict containing keyed distances
         """
         if identity not in self._cached_distances:
             self.cache_features(identity)
         return self._cached_distances[identity]
 
     def get_bearings(self, identity: int) -> dict:
-        """
-        get lixit bearing features for a given identity
-        :param identity: integer identity to get bearings for
-        :return: dict containing keyed bearings
+        """get lixit bearing features for a given identity
+
+        Args:
+            identity: integer identity to get bearings for
+
+        Returns:
+            dict containing keyed bearings
         """
         if identity not in self._cached_bearings:
             self.cache_features(identity)
         return self._cached_bearings[identity]
 
     def get_closest_lixit(self, identity: int) -> np.ndarray:
-        """
-        get the closest lixit index
-        :param identity: integer identity to get the closest lixit
-        :return: np.ndarray of the lixit index
+        """get the closest lixit index
+
+        Args:
+            identity: integer identity to get the closest lixit
+
+        Returns:
+            np.ndarray of the lixit index
         """
         if identity not in self._closest_lixit_idx:
             self.cache_features(identity)
@@ -133,13 +141,15 @@ class LixitDistanceInfo:
 
     @staticmethod
     def compute_angles(a: np.ndarray, b: np.ndarray, c: np.ndarray) -> np.ndarray:
-        """
-        compute angles for a set of points
-        :param a: array of point coordinates
-        :param b: array of vertex point coordinates
-        :param c: array of point coordinates
-        :return: array containing angles, in degrees, formed from the lines
-        ab and ba for each row in a, b, and c with range [-180, 180)
+        """compute angles for a set of points
+
+        Args:
+            a: array of point coordinates
+            b: array of vertex point coordinates
+            c: array of point coordinates
+
+        Returns:
+            array containing angles, in degrees, formed from the lines ab and ba for each row in a, b, and c with range [-180, 180)
         """
         angles = np.degrees(
             np.arctan2(c[:, 1] - b[:, 1], c[:, 0] - b[:, 0])
@@ -161,10 +171,13 @@ class DistanceToLixit(Feature):
         self._cached_distances = distances
 
     def per_frame(self, identity: int) -> dict:
-        """
-        get the per frame distance to nearest lixit
-        :param identity: identity to get feature values for
-        :return: dict of numpy ndarray of values with shape (nframes,)
+        """get the per frame distance to nearest lixit
+
+        Args:
+            identity: identity to get feature values for
+
+        Returns:
+            dict of numpy ndarray of values with shape (nframes,)
         """
         distances = self._cached_distances.get_distances(identity)
         return distances
@@ -193,10 +206,13 @@ class BearingToLixit(Feature):
         self._cached_distances = distances
 
     def per_frame(self, identity: int) -> dict[str, np.ndarray]:
-        """
-        get the per frame bearing to the nearest lixit values
-        :param identity: identity to get the feature values for
-        :return: dict of numpy ndarray values with shape (nframes,)
+        """get the per frame bearing to the nearest lixit values
+
+        Args:
+            identity: identity to get the feature values for
+
+        Returns:
+            dict of numpy ndarray values with shape (nframes,)
         """
         bearings = self._cached_distances.get_bearings(identity)
 
@@ -210,8 +226,7 @@ class BearingToLixit(Feature):
 
 
 class MouseLixitAngle(Feature):
-    """
-    This class computes two features.
+    """This class computes two features.
 
     1. the angle between the vector going from the tip of the lixit to the middle of the two sides
     and the vector going from the centroid to the nose
@@ -247,8 +262,7 @@ class MouseLixitAngle(Feature):
         return False
 
     def per_frame(self, identity: int) -> dict[str, np.ndarray]:
-        """
-        Calculate per frame features.
+        """Calculate per frame features.
 
         Args:
             identity (int): The identity of the mouse for which the feature is being calculated.

--- a/src/jabs/feature_extraction/segmentation_features/hu_moments.py
+++ b/src/jabs/feature_extraction/segmentation_features/hu_moments.py
@@ -11,9 +11,7 @@ if typing.TYPE_CHECKING:
 
 
 class HuMoments(Feature):
-    """
-    Feature for the hu image moments of the segmentation contours.
-    """
+    """Feature for the hu image moments of the segmentation contours."""
 
     _name = 'hu_moments'
     _feature_names = [f"hu{i}" for i in range(1, 8)]

--- a/src/jabs/feature_extraction/segmentation_features/moment_cache.py
+++ b/src/jabs/feature_extraction/segmentation_features/moment_cache.py
@@ -5,8 +5,7 @@ from jabs.pose_estimation import PoseEstimation
 
 
 class MomentInfo:
-    """
-    this info is needed to compute a number of different image moment features.
+    """this info is needed to compute a number of different image moment features.
     It can be done once for a given identity, and then an instance of this
     object can be passed into all the features that need it
 
@@ -44,54 +43,74 @@ class MomentInfo:
                 self._moments[frame, j] = moments[self._moment_keys[j]]*np.power(self._pixel_scale, self._moment_conversion_powers[j])
     
     def get_pixel_power(self, key):
-        """
-        get the degree that pixels influence this image moment
-        :param key: key of the image moment
-        :return: power that should be used for converting from pixels to cm space
+        """get the degree that pixels influence this image moment
+
+        Args:
+            key: key of the image moment
+
+        Returns:
+            power that should be used for converting from pixels to cm
+            space
         """
         # Only works for image moments 0-9 on either dimension
         # opencv only does the first 3 moments (0-2)
         return int(key[-1]) + int(key[-2]) + 2
 
     def get_moment(self, frame, key):
-        """
-        retrieve a single moment value
-        :param frame: frame to retrieve moment data
-        :param key: key of moment data to retrieve
-        :return: moment value
+        """retrieve a single moment value
+
+        Args:
+            frame: frame to retrieve moment data
+            key: key of moment data to retrieve
+
+        Returns:
+            moment value
         """
         key_idx = self._moment_keys.index(key)
         return self._moments[frame, key_idx]
 
     def get_all_moments(self, frame):
-        """
-        retrieve moments for a frame
-        :param frame: frame to retrieve moment data
-        :return: dict of moment data
+        """retrieve moments for a frame
+
+        Args:
+            frame: frame to retrieve moment data
+
+        Returns:
+            dict of moment data
         """
         return {key:value for key,value in zip(self._moment_keys,self._moments[frame])}
 
     def get_trimmed_contours(self, frame):
-        """
-        retrieves a contour for a specific frame
-        :param frame: frame to retrieve contour data
-        :return: an opencv-complaint list of contours
+        """retrieves a contour for a specific frame
+
+        Args:
+            frame: frame to retrieve contour data
+
+        Returns:
+            an opencv-complaint list of contours
         """
         return self._seg_data[frame]
 
     def get_flags(self, frame):
-        """
-        retrieves the internal/external flags for a specific frame
-        :param frame: frame to retrieve flags
-        :return: a binary vector of whether the segmentation contours are external (1) or internal (0)
+        """retrieves the internal/external flags for a specific frame
+
+        Args:
+            frame: frame to retrieve flags
+
+        Returns:
+            a binary vector of whether the segmentation contours are
+            external (1) or internal (0)
         """
         return self._seg_flags[frame]
 
     def trim_contour(self, arr):
-        """
-        removes -1s from contour data
-        :param arr: contour, padded with -1s
-        :return: opencv-complaint contour
+        """removes -1s from contour data
+
+        Args:
+            arr: contour, padded with -1s
+
+        Returns:
+            opencv-complaint contour
         """
         assert arr.ndim == 2
         return_arr = arr[np.all(arr!=-1, axis=1),:]
@@ -99,20 +118,27 @@ class MomentInfo:
             return return_arr.astype(np.int32)
 
     def trim_contour_list(self, arr):
-        """
-        trims a fully padded 3D matrix into opencv-compliant contour list
-        :param arr: a full matrix of contours, padded with -1s
-        :return: opencv-complaint contour list
+        """trims a fully padded 3D matrix into opencv-compliant contour list
+
+        Args:
+            arr: a full matrix of contours, padded with -1s
+
+        Returns:
+            opencv-complaint contour list
         """
         assert arr.ndim == 3
         return [self.trim_contour(x) for x in arr if np.any(x!=-1)]
 
     @staticmethod
     def calculate_moments(contour_list):
-        """
-        Renders the contour data onto a frame to calculate the moments
-        :param contour_list: list of polygons, the format opencv returns from cv2.findContours
-        :return: dict of cv2.moments image moments
+        """Renders the contour data onto a frame to calculate the moments
+
+        Args:
+            contour_list: list of polygons, the format opencv returns
+                from cv2.findContours
+
+        Returns:
+            dict of cv2.moments image moments
         """
         frame_size = np.max(np.concatenate(contour_list)) + 1
         # Render the contours on a frame

--- a/src/jabs/feature_extraction/segmentation_features/moments.py
+++ b/src/jabs/feature_extraction/segmentation_features/moments.py
@@ -10,8 +10,7 @@ if typing.TYPE_CHECKING:
 
 
 class Moments(Feature):
-    """feature for the image moments of the contours.
-    """
+    """feature for the image moments of the contours."""
 
     _name = 'moments'
     # These are all the opencv moments

--- a/src/jabs/feature_extraction/segmentation_features/segment_group.py
+++ b/src/jabs/feature_extraction/segmentation_features/segment_group.py
@@ -20,10 +20,13 @@ class SegmentationFeatureGroup(FeatureGroup):
         self._moments_cache = None
 
     def _init_feature_mods(self, identity: int):
-        """
-        initialize all of the feature modules specified in the current config
-        :param identity: subject identity to use when computing segmentation features
-        :return: dictionary of initialized feature modules for this group
+        """initialize all of the feature modules specified in the current config
+
+        Args:
+            identity: subject identity to use when computing segmentation features
+
+        Returns:
+            dictionary of initialized feature modules for this group
         """
         self._moments_cache = MomentInfo(
             self._poses, identity, self._pixel_scale)

--- a/src/jabs/feature_extraction/segmentation_features/shape_descriptors.py
+++ b/src/jabs/feature_extraction/segmentation_features/shape_descriptors.py
@@ -11,8 +11,7 @@ if typing.TYPE_CHECKING:
 
 
 class ShapeDescriptors(Feature):
-    """
-    Feature related to shape descriptors of the segmentation data.
+    """Feature related to shape descriptors of the segmentation data.
     Ellipse-fit was adopted from https://doi.org/10.1038/nmeth.2281
     Additional shape features are taken from definitions in http://dx.doi.org/10.5772/6237
     """

--- a/src/jabs/feature_extraction/social_features/closest_distances.py
+++ b/src/jabs/feature_extraction/social_features/closest_distances.py
@@ -19,10 +19,13 @@ class ClosestDistances(Feature):
         super().__init__(poses, pixel_scale)
         self._social_distance_info = social_distance_info
 
-    def per_frame(self, identity: int) -> np.ndarray:
-        """
-        compute the value of the per frame features for a specific identity
-        :param identity: identity to compute features for
-        :return: dict with feature values
+    def per_frame(self, identity: int) -> dict[str, np.ndarray]:
+        """compute the value of the per frame features for a specific identity
+
+        Args:
+            identity: identity to compute features for
+
+        Returns:
+            dict with feature values
         """
         return {'closest social distance': self._social_distance_info.compute_distances(self._social_distance_info.closest_identities)}

--- a/src/jabs/feature_extraction/social_features/closest_fov_angles.py
+++ b/src/jabs/feature_extraction/social_features/closest_fov_angles.py
@@ -26,17 +26,20 @@ class ClosestFovAngles(Feature):
         super().__init__(poses, pixel_scale)
         self._social_distance_info = social_distance_info
 
-    def per_frame(self, identity: int) -> np.ndarray:
-        """
-        compute the value of the per frame features for a specific identity
-        :param identity: identity to compute features for
-        :return: dict with feature values
+    def per_frame(self, identity: int) -> dict[str, np.ndarray]:
+        """compute the value of the per frame features for a specific identity
+
+        Args:
+            identity: identity to compute features for
+
+        Returns:
+            dict with feature values
         """
         # this is already computed
         return {'angle of closest social distance in FoV': self._social_distance_info.closest_fov_angles}
 
     def window(self, identity: int, window_size: int,
-               per_frame_values: np.ndarray) -> typing.Dict:
+               per_frame_values: dict[str, np.ndarray]) -> typing.Dict:
         # need to override to use special method for computing window features
         # with circular values
         return self._window_circular(identity, window_size, per_frame_values)

--- a/src/jabs/feature_extraction/social_features/closest_fov_distances.py
+++ b/src/jabs/feature_extraction/social_features/closest_fov_distances.py
@@ -19,10 +19,13 @@ class ClosestFovDistances(Feature):
         super().__init__(poses, pixel_scale)
         self._social_distance_info = social_distance_info
 
-    def per_frame(self, identity: int) -> np.ndarray:
-        """
-        compute the value of the per frame features for a specific identity
-        :param identity: identity to compute features for
-        :return: dict with feature values
+    def per_frame(self, identity: int) -> dict[str, np.ndarray]:
+        """compute the value of the per frame features for a specific identity
+
+        Args:
+            identity: identity to compute features for
+
+        Returns:
+            dict with feature values
         """
         return {'closest social distance in FoV': self._social_distance_info.compute_distances(self._social_distance_info.closest_fov_identities)}

--- a/src/jabs/feature_extraction/social_features/pairwise_social_distances.py
+++ b/src/jabs/feature_extraction/social_features/pairwise_social_distances.py
@@ -35,10 +35,13 @@ class PairwiseSocialDistances(Feature):
         self._poses = poses
 
     def per_frame(self, identity: int) -> dict:
-        """
-        compute the value of the per frame features for a specific identity
-        :param identity: identity to compute features for
-        :return: dict with feature values
+        """compute the value of the per frame features for a specific identity
+
+        Args:
+            identity: identity to compute features for
+
+        Returns:
+            dict with feature values
         """
 
         return self._social_distance_info.compute_pairwise_social_distances(
@@ -49,8 +52,7 @@ class PairwiseSocialDistances(Feature):
 
 class PairwiseSocialFovDistances(PairwiseSocialDistances):
 
-    """
-    PairwiseSocialFovDistances, nearly the same as the PairwiseSocialDistances,
+    """PairwiseSocialFovDistances, nearly the same as the PairwiseSocialDistances,
     except closest_fov_identities is passed to compute_pairwise_social_distances
     rather than closest_identities
     """
@@ -58,11 +60,14 @@ class PairwiseSocialFovDistances(PairwiseSocialDistances):
     _name = 'social_pairwise_fov_distances'
 
     def per_frame(self, identity: int) -> np.ndarray:
+        """compute the value of the per frame features for a specific identity
+
+        Args:
+            identity: identity to compute features for
+
+        Returns:
+            np.ndarray with feature values
         """
-                compute the value of the per frame features for a specific identity
-                :param identity: identity to compute features for
-                :return: np.ndarray with feature values
-                """
         return self._social_distance_info.compute_pairwise_social_distances(
             _social_point_subset,
             self._social_distance_info.closest_fov_identities

--- a/src/jabs/feature_extraction/social_features/social_distance.py
+++ b/src/jabs/feature_extraction/social_features/social_distance.py
@@ -6,8 +6,7 @@ from jabs.pose_estimation import PoseEstimation
 
 
 class ClosestIdentityInfo:
-    """
-    this info is needed to compute a number of different social features.
+    """this info is needed to compute a number of different social features.
     It can be done once for a given identity, and then an instance of this
     object can be passed into all the features that need it
     """
@@ -87,12 +86,15 @@ class ClosestIdentityInfo:
 
     @staticmethod
     def compute_angle(a, b, c):
-        """
-        compute angle created by three connected points
-        :param a: point
-        :param b: vertex point
-        :param c: point
-        :return: angle between AB and BC with range [-180, 180)
+        """compute angle created by three connected points
+
+        Args:
+            a: point
+            b: vertex point
+            c: point
+
+        Returns:
+            angle between AB and BC with range [-180, 180)
         """
 
         angle = np.degrees(
@@ -155,12 +157,15 @@ class ClosestIdentityInfo:
 
     @staticmethod
     def _compute_social_pairwise_distance(points1, points2):
-        """
-        compute distances between all pairs of points
-        :param points1: 1st collection of points
-        :param points2: 2st collection of points
-        :return: list of distances between all pairwise combinations of points
-            from points1 and points2
+        """compute distances between all pairs of points
+
+        Args:
+            points1: 1st collection of points
+            points2: 2nd collection of points
+
+        Returns:
+            list of distances between all pairwise combinations of
+            points from points1 and points2
         """
         distances = []
 

--- a/src/jabs/feature_extraction/social_features/social_group.py
+++ b/src/jabs/feature_extraction/social_features/social_group.py
@@ -24,10 +24,14 @@ class SocialFeatureGroup(FeatureGroup):
         self._closest_identities_cache = None
 
     def _init_feature_mods(self, identity: int):
-        """
-        initialize all of the feature modules specified in the current config
-        :param identity: subject identity to use when computing social features
-        :return: dictionary of initialized feature modules for this group
+        """initialize all of the feature modules specified in the current config
+
+        Args:
+            identity: subject identity to use when computing social
+                features
+
+        Returns:
+            dictionary of initialized feature modules for this group
         """
 
         # cache the most recent ClosestIdentityInfo, it's needed by
@@ -45,8 +49,7 @@ class SocialFeatureGroup(FeatureGroup):
 
     @property
     def closest_identities(self):
-        """
-        return the closest identities computed during the last call to
+        """return the closest identities computed during the last call to
         per_frame() (per_frame inherited from super class)
         """
         return self._closest_identities_cache

--- a/src/jabs/feature_extraction/window_operations/signal_stats.py
+++ b/src/jabs/feature_extraction/window_operations/signal_stats.py
@@ -4,52 +4,62 @@ import warnings
 
 
 def psd_sum(freqs: np.ndarray, psd: np.ndarray) -> np.ndarray:
-    """
-    Calculates the sum power spectral density
+    """Calculates the sum power spectral density
 
-    :param freqs: frequencies in the psd, ignored
-    :param psd: power spectral density matrix
-    :return: sum of power
+    Args:
+        freqs: frequencies in the psd, ignored
+        psd: power spectral density matrix
+
+    Returns:
+        sum of power
     """
     return np.sum(psd, axis=0)
 
 def psd_max(freqs: np.ndarray, psd: np.ndarray) -> np.ndarray:
-    """
-    Calculates the max power
+    """Calculates the max power
 
-    :param freqs: frequencies in the psd, ignored
-    :param psd: power spectral density matrix
-    :return: max of power
+    Args:
+        freqs: frequencies in the psd, ignored
+        psd: power spectral density matrix
+
+    Returns:
+        max of power
     """
     return np.nanmax(psd, axis=0)
 
 def psd_min(freqs: np.ndarray, psd: np.ndarray) -> np.ndarray:
-    """
-    Calculates the min power
+    """Calculates the min power
 
-    :param freqs: frequencies in the psd, ignored
-    :param psd: power spectral density matrix
-    :return: min of power
+    Args:
+        freqs: frequencies in the psd, ignored
+        psd: power spectral density matrix
+
+    Returns:
+        min of power
     """
     return np.min(psd, axis=0)
 
 def psd_mean(freqs: np.ndarray, psd: np.ndarray) -> np.ndarray:
-    """
-    Calculates the mean power spectral density
+    """Calculates the mean power spectral density
 
-    :param freqs: frequencies in the psd, ignored
-    :param psd: power spectral density matrix
-    :return: mean of power
+    Args:
+        freqs: frequencies in the psd, ignored
+        psd: power spectral density matrix
+
+    Returns:
+        mean of power
     """
     return np.mean(psd, axis=0)
 
 def psd_mean_band(freqs: np.ndarray, psd: np.ndarray, band_low: int = 0, band_high: float = np.finfo(np.float64).max) -> np.ndarray:
-    """
-    Calculates the mean power spectral density in a band
+    """Calculates the mean power spectral density in a band
 
-    :param freqs: frequencies in the psd, ignored
-    :param psd: power spectral density matrix
-    :return: mean of power
+    Args:
+        freqs: frequencies in the psd, ignored
+        psd: power spectral density matrix
+
+    Returns:
+        mean of power
     """
     idx = np.logical_and(freqs >= band_low, freqs < band_high)
 
@@ -58,32 +68,38 @@ def psd_mean_band(freqs: np.ndarray, psd: np.ndarray, band_low: int = 0, band_hi
     return np.mean(np.asarray(psd)[idx], axis=0)
 
 def psd_median(freqs: np.ndarray, psd: np.ndarray) -> np.ndarray:
-    """
-    Calculates the median power spectral density
+    """Calculates the median power spectral density
 
-    :param freqs: frequencies in the psd, ignored
-    :param psd: power spectral density matrix
-    :return: median of power
+    Args:
+        freqs: frequencies in the psd, ignored
+        psd: power spectral density matrix
+
+    Returns:
+        median of power
     """
     return np.median(psd, axis=0)
 
 def psd_std_dev(freqs: np.ndarray, psd: np.ndarray) -> np.ndarray:
-    """
-    Calculates the standard deviation power spectral density
+    """Calculates the standard deviation power spectral density
 
-    :param freqs: frequencies in the psd, ignored
-    :param psd: power spectral density matrix
-    :return: standard deviation of power
+    Args:
+        freqs: frequencies in the psd, ignored
+        psd: power spectral density matrix
+
+    Returns:
+        standard deviation of power
     """
     return np.std(psd, axis=0)
 
 def psd_kurtosis(freqs: np.ndarray, psd: np.ndarray) -> np.ndarray:
-    """
-    Calculates the kurtosis power spectral density
+    """Calculates the kurtosis power spectral density
 
-    :param freqs: frequencies in the psd, ignored
-    :param psd: power spectral density matrix
-    :return: kurtosis of power
+    Args:
+        freqs: frequencies in the psd, ignored
+        psd: power spectral density matrix
+
+    Returns:
+        kurtosis of power
     """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=RuntimeWarning)
@@ -93,12 +109,14 @@ def psd_kurtosis(freqs: np.ndarray, psd: np.ndarray) -> np.ndarray:
     return return_values
 
 def psd_skew(freqs: np.ndarray, psd: np.ndarray) -> np.ndarray:
-    """
-    Calculates the skew power spectral density
+    """Calculates the skew power spectral density
 
-    :param freqs: frequencies in the psd, ignored
-    :param psd: power spectral density matrix
-    :return: skew of power
+    Args:
+        freqs: frequencies in the psd, ignored
+        psd: power spectral density matrix
+
+    Returns:
+        skew of power
     """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=RuntimeWarning)
@@ -108,11 +126,13 @@ def psd_skew(freqs: np.ndarray, psd: np.ndarray) -> np.ndarray:
     return return_values
 
 def psd_peak_freq(freqs: np.ndarray, psd: np.ndarray) -> np.ndarray:
-    """
-    Calculates the frequency with the most power
+    """Calculates the frequency with the most power
 
-    :param freqs: frequencies in the psd
-    :param psd: power spectral density matrix
-    :return: frequency with highest power
+    Args:
+        freqs: frequencies in the psd
+        psd: power spectral density matrix
+
+    Returns:
+        frequency with highest power
     """
     return freqs[np.argmax(psd, axis=0)]

--- a/src/jabs/feature_extraction/window_operations/window_stats.py
+++ b/src/jabs/feature_extraction/window_operations/window_stats.py
@@ -3,16 +3,15 @@ import warnings
 
 
 def pad_sliding_window(arr: np.ndarray, window: int, pad_const: float = None) -> np.ndarray:
-    """
-    Generates a sliding window view of an input array with nan-padding.
+    """Generates a sliding window view of an input array with nan-padding.
 
-    :param arr: 1d array to generate a sliding window
-    :param window: half size of sliding window
-    :param pad_const: Constant to pad the array with. None will
-    pad with value at the edge.
-    :return: an unmodifiable 2d view of the input array where
-    the first axis is time and the second axis is the window.
-    Note that typical usage will use summary stats with axis=1.
+    Args:
+        arr: 1d array to generate a sliding window
+        window: half size of sliding window
+        pad_const: Constant to pad the array with. None will pad with value at the edge.
+
+    Returns:
+        an unmodifiable 2d view of the input array where the first axis is time and the second axis is the window. Note that typical usage will use summary stats with axis=1.
     """
     if pad_const:
         arr_ext = np.concatenate([np.full(window, pad_const), arr, np.full(window, pad_const)])
@@ -21,12 +20,14 @@ def pad_sliding_window(arr: np.ndarray, window: int, pad_const: float = None) ->
     return np.lib.stride_tricks.sliding_window_view(arr_ext, window_shape=window * 2 + 1)
 
 def get_window_masks(sliding_window_view: np.ndarray, const: float) -> np.ndarray:
-    """
-    Creates a mask for invalid values in a sliding window matrix.
+    """Creates a mask for invalid values in a sliding window matrix.
 
-    :param sliding_window_view: sliding window matrix from `pad_sliding_window`
-    :param const: constant pad value
-    :return: matrix describing valid (0) and invalid (1) window values
+    Args:
+        sliding_window_view: sliding window matrix from `pad_sliding_window`
+        const: constant pad value
+
+    Returns:
+        matrix describing valid (0) and invalid (1) window values
     """
     if np.isnan(const):
         window_masks = ~np.isnan(sliding_window_view)
@@ -38,12 +39,14 @@ def get_window_masks(sliding_window_view: np.ndarray, const: float) -> np.ndarra
     return window_masks
 
 def window_mean(values: np.ndarray, window: int) -> np.ndarray:
-    """
-    Calculates a masked mean of a window
+    """Calculates a masked mean of a window
 
-    :param values: 1d np.ndarray of values
-    :param window: window size
-    :return: sliding window mean values
+    Args:
+        values: 1d np.ndarray of values
+        window: window size
+
+    Returns:
+        sliding window mean values
     """
     window_values = pad_sliding_window(values, window, pad_const=np.nan)
     with warnings.catch_warnings():
@@ -52,24 +55,28 @@ def window_mean(values: np.ndarray, window: int) -> np.ndarray:
     return return_values
 
 def window_median(values: np.ndarray, window: int) -> np.ndarray:
-    """
-    Calculates a masked median of a window
+    """Calculates a masked median of a window
 
-    :param values: 1d np.ndarray of values
-    :param window: window size
-    :return: sliding window median values
+    Args:
+        values: 1d np.ndarray of values
+        window: window size
+
+    Returns:
+        sliding window median values
     """
     window_values = pad_sliding_window(values, window, pad_const=np.nan)
     window_masks = get_window_masks(window_values, np.nan)
     return np.ma.median(np.ma.array(window_values, mask=~window_masks), axis=1).filled()
 
 def window_std_dev(values: np.ndarray, window: int) -> np.ndarray:
-    """
-    Calculates a masked standard deviation of a window
+    """Calculates a masked standard deviation of a window
 
-    :param values: 1d np.ndarray of values
-    :param window: window size
-    :return: sliding window standard deviation values
+    Args:
+        values: 1d np.ndarray of values
+        window: window size
+
+    Returns:
+        sliding window standard deviation values
     """
     window_values = pad_sliding_window(values, window, pad_const=np.nan)
     with warnings.catch_warnings():
@@ -78,12 +85,16 @@ def window_std_dev(values: np.ndarray, window: int) -> np.ndarray:
     return return_values
 
 def np_kurtosis(values: np.ndarray) -> np.ndarray:
-    """
-    Calculates kurtosis in a rolling window faster than scipy
+    """Calculates kurtosis in a rolling window faster than scipy
 
-    :param values: 2d array of with time and a window
-    :return: kurtosis values that match scipy.stats.kurtosis(values, axis, nan_policy='omit')
-    raises RuntimeWarning when an entire window is nans
+    Args:
+        values: 2d array of with time and a window
+
+    Returns:
+        kurtosis values that match scipy.stats.kurtosis(values, axis, nan_policy='omit')
+
+    Raises:
+        RuntimeWarning when an entire window is nans
     """
     mean = np.nanmean(values, axis=1)
     std = np.nanstd(values, axis=1)
@@ -91,12 +102,14 @@ def np_kurtosis(values: np.ndarray) -> np.ndarray:
     return np.nansum((values - np.tile(mean, [values.shape[1], 1]).T)**4, axis=1) / (counts * std**4)
 
 def window_kurtosis(values: np.ndarray, window: int) -> np.ndarray:
-    """
-    Calculates a masked kurtosis of a window
+    """Calculates a masked kurtosis of a window
 
-    :param values: 1d np.ndarray of values
-    :param window: window size
-    :return: sliding window kurtosis values
+    Args:
+        values: 1d np.ndarray of values
+        window: window size
+
+    Returns:
+        sliding window kurtosis values
     """
     window_values = pad_sliding_window(values, window, pad_const=np.nan)
     with warnings.catch_warnings():
@@ -105,12 +118,16 @@ def window_kurtosis(values: np.ndarray, window: int) -> np.ndarray:
     return return_values
 
 def np_skew(values: np.ndarray) -> np.ndarray:
-    """
-    Calculates skew in a rolling window faster than scipy
+    """Calculates skew in a rolling window faster than scipy
 
-    :param values: 2d array of with time and a window
-    :return: skew values that match scipy.stats.skew(values, axis, nan_policy='omit')
-    raises RuntimeWarning when an entire window is nans
+    Args:
+        values: 2d array of with time and a window
+
+    Returns:
+        skew values that match scipy.stats.skew(values, axis, nan_policy='omit')
+
+    Raises:
+        RuntimeWarning when an entire window is nans
     """
     mean = np.nanmean(values, axis=1)
     std = np.nanstd(values, axis=1)
@@ -118,12 +135,14 @@ def np_skew(values: np.ndarray) -> np.ndarray:
     return np.nansum((values - np.tile(mean, [values.shape[1], 1]).T)**3, axis=1) / (counts * std**3)
 
 def window_skew(values: np.ndarray, window: int) -> np.ndarray:
-    """
-    Calculates a masked skew of a window
+    """Calculates a masked skew of a window
 
-    :param values: 1d np.ndarray of values
-    :param window: window size
-    :return: sliding window skew values
+    Args:
+        values: 1d np.ndarray of values
+        window: window size
+
+    Returns:
+        sliding window skew values
     """
     window_values = pad_sliding_window(values, window, pad_const=np.nan)
     with warnings.catch_warnings():
@@ -132,12 +151,14 @@ def window_skew(values: np.ndarray, window: int) -> np.ndarray:
     return return_values
 
 def window_min(values: np.ndarray, window: int) -> np.ndarray:
-    """
-    Calculates a masked maximum of a window
+    """Calculates a masked maximum of a window
 
-    :param values: 1d np.ndarray of values
-    :param window: window size
-    :return: sliding window maximum values
+    Args:
+        values: 1d np.ndarray of values
+        window: window size
+
+    Returns:
+        sliding window maximum values
     """
     window_values = pad_sliding_window(values, window, pad_const=np.nan)
     window_masks = get_window_masks(window_values, np.nan)
@@ -146,12 +167,14 @@ def window_min(values: np.ndarray, window: int) -> np.ndarray:
     return np.min(window_values, axis=1, initial=np.nanmax(values), where=window_masks)
 
 def window_max(values: np.ndarray, window: int) -> np.ndarray:
-    """
-    Calculates a masked maximum of a window
+    """Calculates a masked maximum of a window
 
-    :param values: 1d np.ndarray of values
-    :param window: window size
-    :return: sliding window maximum values
+    Args:
+        values: 1d np.ndarray of values
+        window: window size
+
+    Returns:
+        sliding window maximum values
     """
     window_values = pad_sliding_window(values, window, pad_const=np.nan)
     window_masks = get_window_masks(window_values, np.nan)

--- a/src/jabs/pose_estimation/__init__.py
+++ b/src/jabs/pose_estimation/__init__.py
@@ -13,8 +13,7 @@ from .pose_est_v6 import PoseEstimationV6
 
 
 def open_pose_file(path: Path, cache_dir: typing.Optional[Path]=None):
-    """
-    open a pose file using the correct PoseEstimation subclass based on
+    """open a pose file using the correct PoseEstimation subclass based on
     the version implied by the filename
     """
     if path.name.endswith('v2.h5'):
@@ -32,12 +31,17 @@ def open_pose_file(path: Path, cache_dir: typing.Optional[Path]=None):
 
 
 def get_pose_path(video_path: Path):
-    """
-    take a path to a video file and return the path to the corresponding
+    """take a path to a video file and return the path to the corresponding
     pose_est h5 file
-    :param video_path: Path to video file in project
-    :return: Path object representing location of corresponding pose_est h5 file
-    :raises ValueError: if video_path does not have corresponding pose_est file
+
+    Args:
+        video_path: Path to video file in project
+
+    Returns:
+        Path object representing location of corresponding pose_est h5 file
+
+    Raises:
+        ValueError: if video_path does not have corresponding pose_est file
     """
 
     file_base = video_path.with_suffix('')
@@ -58,29 +62,35 @@ def get_pose_path(video_path: Path):
 
 
 def get_pose_file_major_version(path: Path):
-    """
-    get the major version of a pose file from the _filename_
+    """get the major version of a pose file from the _filename_
     (does not inspect contents of file), assumes file name matches
     video_name_v[version number].h5
-    :param path: path of pose file
-    :return: integer major version number
+
+    Args:
+        path: path of pose file
+
+    Returns:
+        integer major version number
     """
     v = re.search(r'_v([0-9])+\.h5', str(path)).group(1)
     return int(v)
 
 
 def get_frames_from_file(path: Path):
-    """ peek into a pose_est file to count number of frames """
+    """peek into a pose_est file to count number of frames"""
     with h5py.File(path, 'r') as pose_h5:
         vid_grp = pose_h5['poseest']
         return vid_grp['points'].shape[0]
 
 
 def get_static_objects_in_file(path: Path):
-    """
-    peek into a pose file to get a list of the static objects it contains
-    :param path: path of pose file
-    :return: list of static object names contained in pose file
+    """peek into a pose file to get a list of the static objects it contains
+
+    Args:
+        path: path of pose file
+
+    Returns:
+        list of static object names contained in pose file
     """
 
     if get_pose_file_major_version(path) >= 5:
@@ -90,8 +100,7 @@ def get_static_objects_in_file(path: Path):
     return []
 
 def get_points_per_lixit(path: Path) -> int:
-    """
-    inspect a pose file to get the number of keypoints per lixit
+    """inspect a pose file to get the number of keypoints per lixit
     returns zero if the pose file does not have any lixit keypoints.
     """
     points_per_lixit = 0

--- a/src/jabs/pose_estimation/pose_est.py
+++ b/src/jabs/pose_estimation/pose_est.py
@@ -18,12 +18,11 @@ class PoseHashException(Exception):
 
 
 class PoseEstimation(ABC):
-    """
-    abstract base class for PoseEstimation objects. Used as the base class for
+    """abstract base class for PoseEstimation objects. Used as the base class for
     PoseEstimationV2 and PoseEstimationV3
     """
     class KeypointIndex(enum.IntEnum):
-        """ enum defining the 12 keypoint indexes """
+        """enum defining the 12 keypoint indexes"""
         NOSE = 0
         LEFT_EAR = 1
         RIGHT_EAR = 2
@@ -39,12 +38,15 @@ class PoseEstimation(ABC):
 
     def __init__(self, file_path: Path, cache_dir: typing.Optional[Path] = None,
                  fps: int = 30):
-        """
-        initialize new object from h5 file
-        :param file_path: path to pose_est_v2.h5 file
-        :param cache_dir: optional cache directory, used to cache convex hulls
+        """initialize new object from h5 file
+
+        Args:
+            file_path: path to pose_est_v2.h5 file
+            cache_dir: optional cache directory, used to cache convex
+                hulls
+            fps: frames per second, used for scaling time series
+                features
         for faster loading
-        :param fps: frames per second, used for scaling time series features
         from "per frame" to "per second"
         """
         super().__init__()
@@ -62,12 +64,12 @@ class PoseEstimation(ABC):
 
     @property
     def num_frames(self) -> int:
-        """ return the number of frames in the pose_est file """
+        """return the number of frames in the pose_est file"""
         return self._num_frames
 
     @property
     def identities(self):
-        """ return list of integer identities generated from file """
+        """return list of integer identities generated from file"""
         return self._identities
 
     @property
@@ -93,45 +95,56 @@ class PoseEstimation(ABC):
     @abstractmethod
     def get_points(self, frame_index: int, identity: int,
                    scale: typing.Optional[float] = None):
-        """
-        return points and point masks for an individual frame
-        :param frame_index: frame index of points and masks to be returned
-        :param identity: identity to return points for
-        :param scale: optional scale factor, set to cm_per_pixel to convert
-        poses from pixel coordinates to cm coordinates
-        :return: numpy array of points (12,2), numpy array of point masks (12,)
+        """return points and point masks for an individual frame
+
+        Args:
+            frame_index: frame index of points and masks to be returned
+            identity: identity to return points for
+            scale: optional scale factor, set to cm_per_pixel to convert
+                poses from pixel coordinates to cm coordinates
+
+        Returns:
+            numpy array of points (12,2), numpy array of point masks (12,)
         """
         pass
 
     @abstractmethod
     def get_identity_poses(self, identity: int,
                            scale: typing.Optional[float] = None):
-        """
-        return all points and point masks
-        :param identity: identity to return points for
-        :param scale: optional scale factor, set to cm_per_pixel to convert
-        poses from pixel coordinates to cm coordinates
-        :return: numpy array of points (#frames, 12, 2), numpy array of point
-        masks (#frames, 12)
+        """return all points and point masks
+
+        Args:
+            identity: identity to return points for
+            scale: optional scale factor, set to cm_per_pixel to convert
+                poses from pixel coordinates to cm coordinates
+
+        Returns:
+            numpy array of points (#frames, 12, 2), numpy array of point masks (#frames, 12)
         """
         pass
 
     @abstractmethod
     def get_identity_point_mask(self, identity):
-        """
-        get the point mask array for a given identity
-        :param identity: identity to return point mask for
-        :return: array of point masks (#frames, 12)
+        """get the point mask array for a given identity
+
+        Args:
+            identity: identity to return point mask for
+
+        Returns:
+            array of point masks (#frames, 12)
         """
         pass
 
     @abstractmethod
     def identity_mask(self, identity):
-        """
-        get the identity mask (indicates if specified identity is present in
+        """get the identity mask (indicates if specified identity is present in
         each frame)
-        :param identity: identity to get masks for
-        :return: numpy array of size (#frames,)
+
+        Args:
+            identity: identity to get masks for
+
+        Returns:
+            numpy array of size (#frames,)
         """
         pass
 
@@ -143,9 +156,7 @@ class PoseEstimation(ABC):
     @property
     @abstractmethod
     def format_major_version(self):
-        """
-        an integer giving the major version of the format
-        """
+        """an integer giving the major version of the format"""
         pass
 
     @property
@@ -153,13 +164,16 @@ class PoseEstimation(ABC):
         return self._static_objects
 
     def get_identity_convex_hulls(self, identity):
-        """
-        A list of length #frames containing convex hulls for the given identity.
+        """A list of length #frames containing convex hulls for the given identity.
         The convex hulls are calculated using all valid points except for the
         middle of tail and tip of tail points.
-        :param identity: identity to return points for
-        :return: the convex hulls in pixel units (array elements will be None
-        if there is no valid convex hull for that frame)
+
+        Args:
+            identity: identity to return points for
+
+        Returns:
+            the convex hulls in pixel units (array elements will be None
+            if there is no valid convex hull for that frame)
         """
 
         if identity in self._convex_hull_cache:

--- a/src/jabs/pose_estimation/pose_est_v2.py
+++ b/src/jabs/pose_estimation/pose_est_v2.py
@@ -8,20 +8,19 @@ from .pose_est import PoseEstimation, MINIMUM_CONFIDENCE
 
 
 class PoseEstimationV2(PoseEstimation):
-    """
-    read in pose_est_v2.h5 file
-    """
+    """read in pose_est_v2.h5 file"""
 
     def __init__(self, file_path: Path,
                  cache_dir: typing.Optional[Path] = None,
                  fps: int = 30):
-        """
-        initialize new object from h5 file
-        :param file_path: path to pose_est_v2.h5 file
-        :param cache_dir: optional cache directory, used to cache convex hulls
-        for faster loading
-        :param fps: frames per second, used for scaling time series features
-        from "per frame" to "per second"
+        """initialize new object from h5 file
+
+        Args:
+            file_path: path to pose_est_v2.h5 file
+            cache_dir: optional cache directory, used to cache convex
+                hulls for faster loading
+            fps: frames per second, used for scaling time series
+                featuresfrom "per frame" to "per second"
         """
 
         super().__init__(file_path, cache_dir, fps)
@@ -67,14 +66,17 @@ class PoseEstimationV2(PoseEstimation):
 
     def get_points(self, frame_index: int, identity: int,
                    scale: typing.Optional[float] = None):
-        """
-        return points and point masks for an individual frame
-        :param frame_index: frame index of points and masks to be returned
-        :param identity: included for compatibility with pose_est_v3. Should
-        always be zero.
-        :param scale: optional scale factor, set to cm_per_pixel to convert
-        poses from pixel coordinates to cm coordinates
-        :return: numpy array of points (12,2), numpy array of point masks (12,)
+        """return points and point masks for an individual frame
+
+        Args:
+            frame_index: frame index of points and masks to be returned
+            identity: included for compatibility with pose_est_v3.
+                Should always be zero.
+            scale: optional scale factor, set to cm_per_pixel to convert
+                poses from pixel coordinates to cm coordinates
+
+        Returns:
+            numpy array of points (12,2), numpy array of point masks (12,)
         """
         if identity not in self.identities:
             raise ValueError("Invalid identity")
@@ -89,14 +91,16 @@ class PoseEstimationV2(PoseEstimation):
 
     def get_identity_poses(self, identity: int,
                            scale: typing.Optional[float] = None):
-        """
-        return all points and point masks
-        :param identity: included for compatibility with pose_est_v3. Should
-        always be zero.
-        :param scale: optional scale factor, set to cm_per_pixel to convert
-        poses from pixel coordinates to cm coordinates
-        :return: numpy array of points (#frames, 12, 2), numpy array of point
-        masks (#frames, 12)
+        """return all points and point masks
+
+        Args:
+            identity: included for compatibility with pose_est_v3.
+                Should always be zero.
+            scale: optional scale factor, set to cm_per_pixel to convert
+                poses from pixel coordinates to cm coordinates
+
+        Returns:
+            numpy array of points (#frames, 12, 2), numpy array of point masks (#frames, 12)
         """
         if identity not in self.identities:
             raise ValueError("Invalid identity")
@@ -107,21 +111,27 @@ class PoseEstimationV2(PoseEstimation):
             return self._points, self._point_mask
 
     def identity_mask(self, identity):
-        """
-        get the identity mask (indicates if specified identity is present in
+        """get the identity mask (indicates if specified identity is present in
         each frame)
-        :param identity: included for compatibility with pose_est_v3. Should
-        always be zero.
-        :return: numpy array of size (#frames,)
+
+        Args:
+            identity: included for compatibility with pose_est_v3.
+                Shouldalways be zero.
+
+        Returns:
+            numpy array of size (#frames,)
         """
         if identity not in self.identities:
             raise ValueError("Invalid identity")
         return self._identity_mask
 
     def get_identity_point_mask(self, identity):
-        """
-        get the point mask array for a given identity
-        :param identity: identity to return point mask for
-        :return: array of point masks (#frames, 12)
+        """get the point mask array for a given identity
+
+        Args:
+            identity: identity to return point mask for
+
+        Returns:
+            array of point masks (#frames, 12)
         """
         return self._point_mask

--- a/src/jabs/pose_estimation/pose_est_v3.py
+++ b/src/jabs/pose_estimation/pose_est_v3.py
@@ -13,9 +13,7 @@ class _CacheFileVersion(Exception):
 
 
 class PoseEstimationV3(PoseEstimation):
-    """
-    class for opening and parsing version 3 of the pose estimation HDF5 file
-    """
+    """class for opening and parsing version 3 of the pose estimation HDF5 file"""
 
     __CACHE_FILE_VERSION = 2
 
@@ -23,11 +21,13 @@ class PoseEstimationV3(PoseEstimation):
                  cache_dir: typing.Optional[Path] = None,
                  fps: int = 30):
         """
-        :param file_path: Path object representing the location of the pose file
-        :param cache_dir: optional cache directory, used to cache convex hulls
-        for faster loading
-        :param fps: frames per second, used for scaling time series features
-        from "per frame" to "per second"
+        Args:
+            file_path: Path object representing the location of the pose
+                file
+            cache_dir: optional cache directory, used to cache convex
+                hulls for faster loading
+            fps: frames per second, used for scaling time series
+                features from "per frame" to "per second"
         """
         super().__init__(file_path, cache_dir, fps)
 
@@ -162,13 +162,16 @@ class PoseEstimationV3(PoseEstimation):
 
     def get_points(self, frame_index: int, identity: int,
                    scale: typing.Optional[float] = None):
-        """
-        get points and mask for an identity for a given frame
-        :param frame_index: index of frame
-        :param identity: identity that we want the points for
-        :param scale: optional scale factor, set to cm_per_pixel to convert
-        poses from pixel coordinates to cm coordinates
-        :return: points, mask if identity has data for this frame
+        """get points and mask for an identity for a given frame
+
+        Args:
+            frame_index: index of frame
+            identity: identity that we want the points for
+            scale: optional scale factor, set to cm_per_pixel to convert
+                poses from pixel coordinates to cm coordinates
+
+        Returns:
+            points, mask if identity has data for this frame
         """
 
         if not self._identity_mask[identity, frame_index]:
@@ -187,14 +190,15 @@ class PoseEstimationV3(PoseEstimation):
 
     def get_identity_poses(self, identity: int,
                            scale: typing.Optional[float] = None):
-        """
-        return all points and point masks
-        :param identity: included for compatibility with pose_est_v3. Should
-        always be zero.
-        :param scale: optional scale factor, set to cm_per_pixel to convert
-        poses from pixel coordinates to cm coordinates
-        :return: numpy array of points (#frames, 12, 2), numpy array of point
-        masks (#frames, 12)
+        """return all points and point masks
+
+        Args:
+            identity: identity that we want the points for
+            scale: optional scale factor, set to cm_per_pixel to convert
+                poses from pixel coordinates to cm coordinates
+
+        Returns:
+            numpy array of points (#frames, 12, 2), numpy array of point masks (#frames, 12)
         """
 
         if scale is not None:
@@ -209,16 +213,19 @@ class PoseEstimationV3(PoseEstimation):
         return self._identity_mask[identity, :]
 
     def get_identity_point_mask(self, identity):
-        """
-        get the point mask array for a given identity
-        :param identity: identity to return point mask for
-        :return: array of point masks (#frames, 12)
+        """get the point mask array for a given identity
+
+        Args:
+            identity: identity to return point mask for
+
+        Returns:
+            array of point masks (#frames, 12)
         """
         return self._point_mask[identity, :]
 
     def _build_track_dict(self, all_points, all_confidence, all_instance_count,
                           all_track_id):
-        """ iterate through frames and build track dict """
+        """iterate through frames and build track dict"""
         all_points_mask = all_confidence > MINIMUM_CONFIDENCE
         track_dict = {}
 
@@ -255,7 +262,7 @@ class PoseEstimationV3(PoseEstimation):
         return track_dict
 
     def _build_identity_map(self, all_instance_count, all_track_id):
-        """ map individual tracks to identities """
+        """map individual tracks to identities"""
         free_identities = []
         identity_track_count = {}
         identity_map = {}

--- a/src/jabs/pose_estimation/pose_est_v4.py
+++ b/src/jabs/pose_estimation/pose_est_v4.py
@@ -14,8 +14,7 @@ class _CacheFileVersion(Exception):
 
 
 class PoseEstimationV4(PoseEstimation):
-    """
-    class for opening and parsing version 4 of the pose estimation HDF5 file
+    """class for opening and parsing version 4 of the pose estimation HDF5 file
 
     Note, because how we need to handle reordering points based on the identity information
     available in v4+ pose files, this does not inherit from the PoseEstimationV3 class, and
@@ -29,10 +28,14 @@ class PoseEstimationV4(PoseEstimation):
                  cache_dir: typing.Optional[Path] = None,
                  fps: int = 30):
         """
-        :param file_path: Path object representing the location of the pose file
-        :param cache_dir: optional cache directory, used to cache convex hulls
+        Args:
+            file_path: Path object representing the location of the pose
+                file
+            cache_dir: optional cache directory, used to cache convex
+                hulls
+            fps: frames per second, used for scaling time series
+                features
         for faster loading
-        :param fps: frames per second, used for scaling time series features
         from "per frame" to "per second"
         """
         super().__init__(file_path, cache_dir, fps)
@@ -146,14 +149,17 @@ class PoseEstimationV4(PoseEstimation):
 
     def get_points(self, frame_index: int, identity: int,
                    scale: typing.Optional[float] = None):
-        """
-        get points and mask for an identity for a given frame
-        :param frame_index: index of frame
-        :param identity: identity that we want the points for
-        :param scale: optional scale factor, set to cm_per_pixel to convert
+        """get points and mask for an identity for a given frame
+
+        Args:
+            frame_index: index of frame
+            identity: identity that we want the points for
+            scale: optional scale factor, set to cm_per_pixel to convert
+            fps: video frames per second
         poses from pixel coordinates to cm coordinates
-        :param fps: video frames per second
-        :return: points, mask if identity has data for this frame
+
+        Returns:
+            points, mask if identity has data for this frame
         """
         if not self._identity_mask[identity, frame_index]:
             return None, None
@@ -171,13 +177,17 @@ class PoseEstimationV4(PoseEstimation):
 
     def get_identity_poses(self, identity: int,
                            scale: typing.Optional[float] = None):
-        """
-        return all points and point masks
-        :param identity: included for compatibility with pose_est_v3. Should
+        """return all points and point masks
+
+        Args:
+            identity: included for compatibility with pose_est_v3.
+                Should
+            scale: optional scale factor, set to cm_per_pixel to convert
         always be zero.
-        :param scale: optional scale factor, set to cm_per_pixel to convert
         poses from pixel coordinates to cm coordinates
-        :return: numpy array of points (#frames, 12, 2), numpy array of point
+
+        Returns:
+            numpy array of points (#frames, 12, 2), numpy array of point
         masks (#frames, 12)
         """
         if scale is not None:
@@ -192,17 +202,22 @@ class PoseEstimationV4(PoseEstimation):
         return self._identity_mask[identity, :]
 
     def get_identity_point_mask(self, identity):
-        """
-        get the point mask array for a given identity
-        :param identity: identity to return point mask for
-        :return: array of point masks (#frames, 12)
+        """get the point mask array for a given identity
+
+        Args:
+            identity: identity to return point mask for
+
+        Returns:
+            array of point masks (#frames, 12)
         """
         return self._point_mask[identity, :]
 
     def _load_from_cache(self):
         """
-        :return: None
-        :raises: IOError, KeyError, _CacheFileVersion, PoseHashException
+        Load data from a cached pose file. We do some transformation of the pose files so that, for example,
+        we can index them by identity. The cache file allows us to avoid doing this every time the pose file is loaded.
+        Returns:
+            None
         """
         filename = self._path.name.replace('.h5', '_cache.h5')
         cache_file_path = self._cache_dir / filename
@@ -234,9 +249,10 @@ class PoseEstimationV4(PoseEstimation):
                 self._identity_mask = pose_grp['identity_mask'][:]
 
     def _cache_poses(self):
-        """
-        cache the pose data in an h5 file in the project cache directory
-        :return: None
+        """cache the pose data in an h5 file in the project cache directory
+
+        Returns:
+            None
         """
         filename = self._path.name.replace('.h5', '_cache.h5')
         cache_file_path = self._cache_dir / filename

--- a/src/jabs/pose_estimation/pose_est_v5.py
+++ b/src/jabs/pose_estimation/pose_est_v5.py
@@ -15,11 +15,13 @@ class PoseEstimationV5(PoseEstimationV4):
                  cache_dir: typing.Optional[Path] = None,
                  fps: int = 30):
         """
-        :param file_path: Path object representing the location of the pose file
-        :param cache_dir: optional cache directory, used to cache convex hulls
-        for faster loading
-        :param fps: frames per second, used for scaling time series features
-        from "per frame" to "per second"
+        Args:
+            file_path: Path object representing the location of the pose
+                file
+            cache_dir: optional cache directory, used to cache convex
+                hulls and transformed pose file for faster loading
+            fps: frames per second, used for scaling time series
+                features from "per frame" to "per second"
         """
         super().__init__(file_path, cache_dir, fps)
 

--- a/src/jabs/pose_estimation/pose_est_v6.py
+++ b/src/jabs/pose_estimation/pose_est_v6.py
@@ -15,12 +15,12 @@ class PoseEstimationV6(PoseEstimationV5):
                  cache_dir: typing.Optional[Path] = None,
                  fps: int = 30):
         """
-        :param file_path: Path object representing the location of the pose
-        file.
-        :param cache_dir: optional cache directory, used to cache convex hulls
-        for faster loading
-        :param fps: frames per second, used for scaling time series features
-        from "per frame" to "per second"
+        Args:
+            file_path: Path object representing the location of the pose file
+            cache_dir: optional cache directory, used to cache convex
+                hulls and transformed pose files for faster loading
+            fps: frames per second, used for scaling time series
+                features from "per frame" to "per second"
         """
         super().__init__(file_path, cache_dir, fps)
 
@@ -51,11 +51,16 @@ class PoseEstimationV6(PoseEstimationV5):
 
     @classmethod
     def _segmentation_sort(cls, seg_data: np.ndarray, longterm_seg_id: np.ndarray) -> np.ndarray:
-        """
-        This method attempts to sort the segmentation data according to the longterm segmentation id.
-        :param seg_data: segmentation data with the first 2 dimensions being [frame,animal]
-        :param longterm_seg_id: identities to sort by, beginning with 1 (0 reserved for invalid data)
-        :return: sorted segmentation data
+        """This method attempts to sort the segmentation data according to the longterm segmentation id.
+
+        Args:
+            seg_data: segmentation data with the first 2 dimensions
+                being [frame,animal]
+            longterm_seg_id: identities to sort by, beginning with 1 (0
+                reserved for invalid data)
+
+        Returns:
+            sorted segmentation data
         """
         # Copy the data into the new array, sorted
         # Note that the -1 is the default for missing data
@@ -70,11 +75,14 @@ class PoseEstimationV6(PoseEstimationV5):
         return sorted_seg_data
 
     def get_segmentation_data(self, identity: int) -> np.ndarray | None:
-        """
-        Given a particular identity, return the appropriate segmentation data.
-        :param identity: identity to return segmentation data for.
-        :return: the ndarray of segmentation data (if it exists) otherwise the
-            function returns None.
+        """Given a particular identity, return the appropriate segmentation data.
+
+        Args:
+            identity: identity to return segmentation data for.
+
+        Returns:
+            the ndarray of segmentation data (if it exists) otherwise
+            the function returns None.
         """
 
         if self._segmentation_dict["seg_data"] is None:
@@ -83,12 +91,15 @@ class PoseEstimationV6(PoseEstimationV5):
             return self._segmentation_dict['seg_data'][:, identity, ...]
 
     def get_segmentation_flags(self, identity: int) -> np.ndarray | None:
-        """
-        Given a particular identity, return the appropriate segmentation
+        """Given a particular identity, return the appropriate segmentation
         internal/external flags.
-        :param identity: identity to return segmentation flags for.
-        :return: the ndarray of segmentation flags (if it exists) otherwise the
-            function returns None.
+
+        Args:
+            identity: identity to return segmentation flags for.
+
+        Returns:
+            the ndarray of segmentation flags (if it exists) otherwise
+            the function returns None.
         """
 
         if self._segmentation_dict["seg_external_flag"] is None:
@@ -97,12 +108,16 @@ class PoseEstimationV6(PoseEstimationV5):
             return self._segmentation_dict['seg_external_flag'][:, identity, ...] 
 
     def get_segmentation_data_per_frame(self, frame_index, identity: int) -> np.ndarray | None:
-        """
-        Given a particular identity, return the appropriate segmentation data.
-        :param identity: identity to return segmentation data for.
-        :param frame_index: index of the frame to return segmentation data for.
-        :return: the ndarray of segmentation data (if it exists) otherwise the
-            function returns None.
+        """Given a particular identity, return the appropriate segmentation data.
+
+        Args:
+            identity: identity to return segmentation data for.
+            frame_index: index of the frame to return segmentation data
+                for.
+
+        Returns:
+            the ndarray of segmentation data (if it exists) otherwise
+            the function returns None.
         """
 
         if self._segmentation_dict["seg_data"] is None:

--- a/src/jabs/project/export_training.py
+++ b/src/jabs/project/export_training.py
@@ -1,5 +1,4 @@
-"""
-TODO: change exported training data from a single h5 file with pre-computed
+"""TODO: change exported training data from a single h5 file with pre-computed
  features to a bundle of pose files, labels, and list of features used for
  the classifier
 """
@@ -32,23 +31,27 @@ def export_training_data(
     training_seed: int,
     out_file: typing.Optional[Path] = None,
 ):
-    """
-    export training data from a project in a format that can be used to
+    """export training data from a project in a format that can be used to
     retrain a classifier elsewhere (for example, by the command line batch
     tool)
 
     writes exported data to the project directory
-    :param project: Project from which to export training data
-    :param behavior: Behavior to export
-    :param pose_version: Minimum required pose version for this classifier
-    :param classifier_type: Preferred classifier type
-    :param training_seed: random seed to use for training to get reproducable
-    results
-    :param out_file: optional output path, if None write to project dir
-    with a file name of the form {behavior}_training_YYYYMMDD_hhmmss.h5
-    :return: path of output file
-    :raises: OSError if unable to create output file (e.g. permission denied,
-    no such file or directory, etc)
+
+    Args:
+        project: Project from which to export training data
+        behavior: Behavior to export
+        pose_version: Minimum required pose version for this classifier
+        classifier_type: Preferred classifier type
+        training_seed: random seed to use for training to get
+            reproducable results
+        out_file: optional output path, if None write to project dir
+            with a file name of the form {behavior}_training_YYYYMMDD_hhmmss.h5
+
+    Returns:
+        path of output file
+
+    Raises:
+        OSError if unable to create output file (e.g. permission denied, no such file or directory, etc)
     """
 
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -97,12 +100,12 @@ def export_training_data(
 def write_project_settings(
     h5_file: typing.Union[h5py.File, h5py.Group], settings: dict, node: str = "settings"
 ):
-    """
-    write project settings to a training h5 file recursively
+    """write project settings to a training h5 file recursively
 
-    :param h5_file: open h5 file to write to
-    :param settings: dict of project settings
-    :param node: name of the node to write to
+    Args:
+        h5_file: open h5 file to write to
+        settings: dict of project settings
+        node: name of the node to write to
     """
     current_group = h5_file.require_group(node)
     for key, val in settings.items():

--- a/src/jabs/project/feature_manager.py
+++ b/src/jabs/project/feature_manager.py
@@ -11,8 +11,7 @@ from .project_paths import ProjectPaths
 
 
 class FeatureManager:
-    """
-    Class to manage task of determining which features are supported by an instance
+    """Class to manage task of determining which features are supported by an instance
     of a Project and storing this information so it can be accessed as necessary.
 
     Looks at the pose version and static objects in the project to
@@ -22,9 +21,7 @@ class FeatureManager:
     """
 
     def __init__(self, project_paths: ProjectPaths, videos: list[str]):
-        """
-        Initialize the FeatureManager.
-        """
+        """Initialize the FeatureManager."""
         self._lixit_keypoints = 0
 
         self._project_paths = project_paths
@@ -80,9 +77,10 @@ class FeatureManager:
                 break
 
     def __initialize_extended_features(self) -> dict:
-        """
-        Initialize extended features based on the pose version and static objects.
-        :return: Dictionary of enabled extended features.
+        """Initialize extended features based on the pose version and static objects.
+
+        Returns:
+            Dictionary of enabled extended features.
         """
         return feature_extraction.IdentityFeatures.get_available_extended_features(
             self._min_pose_version,
@@ -92,57 +90,66 @@ class FeatureManager:
 
     @property
     def can_use_social_features(self) -> bool:
-        """
-        Check if social features are available.
-        :return: True if social features are available, False otherwise.
+        """Check if social features are available.
+
+        Returns:
+            True if social features are available, False otherwise.
         """
         return self._can_use_social
 
     @property
     def can_use_segmentation_features(self) -> bool:
-        """
-        Check if segmentation features are available.
-        :return: True if segmentation features are available, False otherwise.
+        """Check if segmentation features are available.
+
+        Returns:
+            True if segmentation features are available, False
+            otherwise.
         """
         return self._can_use_segmentation
 
     @property
     def extended_features(self) -> dict:
-        """
-        Get the enabled extended features.
-        :return: Dictionary of enabled extended features.
+        """Get the enabled extended features.
+
+        Returns:
+            Dictionary of enabled extended features.
         """
         return self._extended_features
 
     @property
     def is_cm_unit(self) -> bool:
-        """
-        Check if the distance unit is in centimeters.
-        :return: True if the distance unit is in centimeters, False otherwise.
+        """Check if the distance unit is in centimeters.
+
+        Returns:
+            True if the distance unit is in centimeters, False
+            otherwise.
         """
         return self._distance_unit == ProjectDistanceUnit.CM
 
     @property
     def distance_unit(self) -> ProjectDistanceUnit:
-        """
-        Get the distance unit for the project.
-        :return: DistanceUnit enum value representing the distance unit.
+        """Get the distance unit for the project.
+
+        Returns:
+            DistanceUnit enum value representing the distance unit.
         """
         return self._distance_unit
 
     @property
     def min_pose_version(self) -> int:
-        """
-        Get the minimum pose version for the project.
-        :return: Minimum pose version.
+        """Get the minimum pose version for the project.
+
+        Returns:
+            Minimum pose version.
         """
         return self._min_pose_version
 
     @property
     def static_objects(self) -> set[str]:
-        """
-        Get the set of static objects in the project. This set contains all the static
+        """Get the set of static objects in the project. This set contains all the static
         objects that are present in all pose files in the project.
-        :return: Set of static objects.
+
+        Returns:
+            Set of static objects.
         """
         return self._static_objects

--- a/src/jabs/project/prediction_manager.py
+++ b/src/jabs/project/prediction_manager.py
@@ -18,17 +18,15 @@ class MissingBehaviorError(Exception):
 
 
 class PredictionManager:
-    """
-    Class to manage the loading and saving of predictions.
-    """
+    """Class to manage the loading and saving of predictions."""
 
     _PREDICTION_FILE_VERSION = 2
 
     def __init__(self, project: "Project"):
-        """
-        Initialize the PredictionManager with a project.
+        """Initialize the PredictionManager with a project.
 
-        :param project: JABS Project object
+        Args:
+            project: JABS Project object
         """
         self._project = project
 
@@ -43,15 +41,20 @@ class PredictionManager:
         classifier,
         external_identities: list[int] | None = None,
     ):
-        """
-        write predictions out to a file
-        :param behavior: string describing the behavior
-        :param output_path: name of file to write predictions to
-        :param predictions: matrix of prediction class data of shape [n_animals, n_frames]
-        :param probabilities: matrix of probability for the predicted class of shape [n_animals, n_frames]
-        :param poses: PoseEstimation object for which predictions were made
-        :param classifier: Classifier object for which was used to make predictions
-        :param external_identities: list of external identities that correspond to the jabs identities
+        """write predictions out to a file
+
+        Args:
+            behavior: string describing the behavior
+            output_path: name of file to write predictions to
+            predictions: matrix of prediction class data of shape
+                [n_animals, n_frames]
+            probabilities: matrix of probability for the predicted class
+                of shape [n_animals, n_frames]
+            poses: PoseEstimation object for which predictions were made
+            classifier: Classifier object for which was used to make
+                predictions
+            external_identities: list of external identities that
+                correspond to the jabs identities
         """
         # TODO catch exceptions
         with h5py.File(output_path, "a") as h5:
@@ -85,11 +88,15 @@ class PredictionManager:
                 del behavior_group["identity_to_track"]
 
     def load_predictions(self, video: str, behavior: str):
-        """
-        load predictions for a given video and behavior
-        :param video: name of video to load predictions for
-        :param behavior: behavior to load predictions for
-        :return: tuple of three dicts: (predictions, probabilities, frame_indexes)
+        """load predictions for a given video and behavior
+
+        Args:
+            video: name of video to load predictions for
+            behavior: behavior to load predictions for
+
+        Returns:
+            tuple of three dicts: (predictions, probabilities,
+            frame_indexes)
         each dict has identities present in the video for keys
         """
 

--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -26,11 +26,12 @@ class Project:
     """represents a JABS project"""
 
     def __init__(self, project_path, use_cache=True, enable_video_check=True):
-        """
-        Open a project at a given path. A project is a directory that contains
+        """Open a project at a given path. A project is a directory that contains
         avi files and their corresponding pose_est_v3.h5 files as well as json
         files containing project metadata and annotations.
-        :param project_path: path to project directory
+
+        Args:
+            project_path: path to project directory
         """
         self._paths = ProjectPaths(Path(project_path), use_cache=use_cache)
         self._paths.create_directories()
@@ -77,61 +78,57 @@ class Project:
 
     @property
     def settings(self):
-        """
-        get the project metadata and preferences.
+        """get the project metadata and preferences.
 
         """
         return self._settings_manager.project_settings
 
     @property
     def settings_manager(self) -> SettingsManager:
-        """
-        get the project settings manager
-        """
+        """get the project settings manager"""
         return self._settings_manager
 
     @property
     def total_project_identities(self):
-        """
-        sum the number of instances across all videos in the project
-        :return: integer sum
+        """sum the number of instances across all videos in the project
+
+        Returns:
+            integer sum
         """
         return self._video_manager.total_project_identities
 
     @property
     def prediction_manager(self) -> PredictionManager:
-        """
-        get the prediction manager for this project
-        """
+        """get the prediction manager for this project"""
         return self._prediction_manager
 
     @property
     def feature_manager(self) -> FeatureManager:
-        """
-        get the feature manager for this project
-        """
+        """get the feature manager for this project"""
         return self._feature_manager
 
     @property
     def video_manager(self) -> VideoManager:
-        """
-        get the video manager for this project
-        """
+        """get the video manager for this project"""
         return self._video_manager
 
     @property
     def project_paths(self) -> ProjectPaths:
-        """
-        get the project paths object for this project
-        """
+        """get the project paths object for this project"""
         return self._paths
 
     def load_pose_est(self, video_path: Path) -> PoseEstimation:
-        """
-        return a PoseEstimation object for a given video path
-        :param video_path: pathlib.Path containing location of video file
-        :return: PoseEstimation object (PoseEstimationV2 or PoseEstimationV3)
-        :raises ValueError: if video no in project or it does not have post file
+        """return a PoseEstimation object for a given video path
+
+        Args:
+            video_path: pathlib.Path containing location of video file
+
+        Returns:
+            PoseEstimation object (PoseEstimationV2 or PoseEstimationV3)
+
+        Raises:
+            ValueError: if video no in project or it does not have post
+                file
         """
         # ensure this video path is for a valid project video
         video_filename = Path(video_path).name
@@ -140,10 +137,13 @@ class Project:
         return open_pose_file(get_pose_path(video_path), self._paths.cache_dir)
 
     def save_annotations(self, annotations: VideoLabels):
-        """
-        save state of a VideoLabels object to the project directory
-        :param annotations: VideoLabels object
-        :return: None
+        """save state of a VideoLabels object to the project directory
+
+        Args:
+            annotations: VideoLabels object
+
+        Returns:
+            None
         """
         path = self._paths.annotations_dir / Path(annotations.filename).with_suffix(
             ".json"
@@ -156,9 +156,10 @@ class Project:
         self._settings_manager.update_version()
 
     def get_project_defaults(self):
-        """
-        obtain the default per-behavior settings
-        :return: dictionary of project settings
+        """obtain the default per-behavior settings
+
+        Returns:
+            dictionary of project settings
         """
         return self.settings_by_pose_version(
             self._feature_manager.min_pose_version,
@@ -172,11 +173,12 @@ class Project:
         distance_unit: ProjectDistanceUnit = ProjectDistanceUnit.PIXEL,
         static_objects: set[str] | None = None,
     ):
-        """
-        obtain project settings for a specified pose version
-        :param pose_version: pose version to indicate settings
-        :param distance_unit: distance unit for settings
-        :param static_objects: keys of static objects to include
+        """obtain project settings for a specified pose version
+
+        Args:
+            pose_version: pose version to indicate settings
+            distance_unit: distance unit for settings
+            static_objects: keys of static objects to include
         """
         if static_objects is None:
             static_objects = set()
@@ -197,10 +199,11 @@ class Project:
         }
 
     def save_classifier(self, classifier, behavior: str):
-        """
-        Save the classifier for the given behavior
-        :param classifier: the classifier to save
-        :param behavior: string behavior name. This affects the path we save to
+        """Save the classifier for the given behavior
+
+        Args:
+            classifier: the classifier to save
+            behavior: string behavior name. This affects the path we save to
         """
         classifier.save(
             self._paths.classifier_dir / (to_safe_name(behavior) + ".pickle")
@@ -210,11 +213,15 @@ class Project:
         self._settings_manager.update_version()
 
     def load_classifier(self, classifier, behavior: str):
-        """
-        Load cached classifier for the given behavior
-        :param classifier: the classifier to load
-        :param behavior: string behavior name.
-        :return: True if load is successful and False if the file doesn't exist
+        """Load cached classifier for the given behavior
+
+        Args:
+            classifier: the classifier to load
+            behavior: string behavior name.
+
+        Returns:
+            True if load is successful and False if the file doesn't
+            exist
         """
         classifier_path = self._paths.classifier_dir / (
             to_safe_name(behavior) + ".pickle"
@@ -228,23 +235,26 @@ class Project:
     def save_predictions(
         self, predictions, probabilities, frame_indexes, behavior: str, classifier
     ):
-        """
-        save predictions for the current project
-        :param predictions: predictions for all videos in project (dictionary
-        with each video name as a key and a numpy array (#identities, #frames))
-        :param probabilities: corresponding prediction probabilities, similar
-        structure to predictions parameter but with floating point values
-        :param frame_indexes: mapping of the predictions to video frames
-        :param behavior: string behavior name
-        :param classifier: Classifier object used to generate the predictions
+        """save predictions for the current project
 
-        Because the classifier does not run on every frame for every identity
-        (since an identity may not exist for every frame), we extract just
-        the features for the frames we need to classify. Now we want to map
-        these back to the corresponding frame.
-        predictions[video_name][identity, index] and
-        probabilities[video_name][identity, index] correspond to the frame
-        specified by frame_indexes[video][identity, index]
+        Args:
+            predictions: predictions for all videos in project
+                (dictionary with each video name as a key and a numpy array (#identities, #frames))
+            probabilities: corresponding prediction probabilities,
+                similar structure to predictions parameter but with floating point values
+            frame_indexes: mapping of the predictions to video frames
+            behavior: string behavior name
+            classifier: Classifier object used to generate the
+                predictions
+
+        Note:
+            Because the classifier does not run on every frame for every identity
+            (since an identity may not exist for every frame), we extract just
+            the features for the frames we need to classify. Now we want to map
+            these back to the corresponding frame.
+            predictions[video_name][identity, index] and
+            probabilities[video_name][identity, index] correspond to the frame
+            specified by frame_indexes[video][identity, index]
         """
 
         for video in self._video_manager.videos:
@@ -297,12 +307,15 @@ class Project:
         self._settings_manager.update_version()
 
     def archive_behavior(self, behavior: str):
-        """
-        Archive a behavior.
+        """Archive a behavior.
         Archives any labels for this behavior. Deletes any other files
         associated with this behavior.
-        :param behavior: string behavior name
-        :return: None
+
+        Args:
+            behavior: string behavior name
+
+        Returns:
+            None
         """
 
         safe_behavior = to_safe_name(behavior)
@@ -352,10 +365,11 @@ class Project:
         self._settings_manager.remove_behavior(behavior)
 
     def counts(self, behavior):
-        """
-        get the labeled frame counts and bout counts for each video in the
+        """get the labeled frame counts and bout counts for each video in the
         project
-        :return: dict where keys are video names and values are lists of
+
+        Returns:
+            dict where keys are video names and values are lists of
         (
             identity,
             (behavior frame count, not behavior frame count),
@@ -368,40 +382,41 @@ class Project:
         return counts
 
     def get_labeled_features(self, behavior=None, progress_callable=None):
-        """
-        the features for all labeled frames
+        """the features for all labeled frames
         NOTE: this will currently take a very long time to run if the features
         have not already been computed
 
-        :param behavior: the behavior settings to get labeled features for
-        if None, will use project defaults (all available features)
-        :param progress_callable: if provided this will be called
-        with no args every time an identity is processed to facilitate
-        progress tracking
+        Args:
+            behavior: the behavior settings to get labeled features for
+                if None, will use project defaults (all available features)
+            progress_callable: if provided this will be called
+                with no args every time an identity is processed to facilitate
+                progress tracking
 
-        :return: two dicts: features, group_mappings
+        Returns:
+            two dicts: features, group_mappings
 
-        The first dict contains features for all labeled frames and has the
-        following keys:
+            The first dict contains features for all labeled frames and has the
+            following keys:
 
-        {
-            'window': ,
-            'per_frame': ,
-            'labels': ,
-            'groups': ,
-        }
+            {
+                'window': ,
+                'per_frame': ,
+                'labels': ,
+                'groups': ,
+            }
 
-        The values contained in the first dict are suitable to pass as
-        arguments to the Classifier.leave_one_group_out() method.
+            The values contained in the first dict are suitable to pass as
+            arguments to the Classifier.leave_one_group_out() method.
 
-        The second dict in the tuple has group ids as the keys, and the
-        values are a dict containing the video and identity that corresponds to
-        that group id:
+            The second dict in the tuple has group ids as the keys, and the
+            values are a dict containing the video and identity that corresponds to
+            that group id:
 
-        {
-          <group id>: {'video': <video filename>, 'identity': <identity},
-          ...
-        }
+            {
+              <group id>: {'video': <video filename>, 'identity': <identity},
+              ...
+            }
         """
 
         all_per_frame = []
@@ -493,15 +508,16 @@ class Project:
         return True
 
     def __read_counts(self, video, behavior):
-        """
-        read labeled frame and bout counts from json file
-        :return: list of labeled frame and bout counts for each identity for the
-        specified behavior. Each element in the list is a tuple of the form
-        (
-            identity,
-            (behavior frame count, not behavior frame count)
-            (behavior bout count, not behavior bout count)
-        )
+        """read labeled frame and bout counts from json file
+
+        Returns:
+            list of labeled frame and bout counts for each identity for
+            the specified behavior. Each element in the list is a tuple of the form
+            (
+                identity,
+                (behavior frame count, not behavior frame count)
+                (behavior bout count, not behavior bout count)
+            )
         """
         video_filename = Path(video).name
         path = self._paths.annotations_dir / Path(video_filename).with_suffix(".json")

--- a/src/jabs/project/project_paths.py
+++ b/src/jabs/project/project_paths.py
@@ -2,9 +2,7 @@ from pathlib import Path
 
 
 class ProjectPaths:
-    """
-    Class to manage project paths.
-    """
+    """Class to manage project paths."""
 
     __JABS_DIR = "jabs"
     __PROJECT_FILE = "project.json"
@@ -24,71 +22,51 @@ class ProjectPaths:
 
     @property
     def project_dir(self) -> Path:
-        """
-        Get the base path of the project.
-        """
+        """Get the base path of the project."""
         return self._base_path
 
     @property
     def jabs_dir(self) -> Path:
-        """
-        Get the path to the JABS directory.
-        """
+        """Get the path to the JABS directory."""
         return self._jabs_dir
 
     @property
     def annotations_dir(self) -> Path:
-        """
-        Get the path to the annotations directory.
-        """
+        """Get the path to the annotations directory."""
         return self._annotations_dir
 
     @property
     def feature_dir(self) -> Path:
-        """
-        Get the path to the features directory.
-        """
+        """Get the path to the features directory."""
         return self._feature_dir
 
     @property
     def prediction_dir(self) -> Path:
-        """
-        Get the path to the predictions directory.
-        """
+        """Get the path to the predictions directory."""
         return self._prediction_dir
 
     @property
     def project_file(self) -> Path:
-        """
-        Get the path to the project file.
-        """
+        """Get the path to the project file."""
         return self._project_file
 
     @property
     def classifier_dir(self) -> Path:
-        """
-        Get the path to the classifiers directory.
-        """
+        """Get the path to the classifiers directory."""
         return self._classifier_dir
 
     @property
     def archive_dir(self) -> Path:
-        """
-        Get the path to the archive directory.
-        """
+        """Get the path to the archive directory."""
         return self._archive_dir
 
     @property
     def cache_dir(self) -> Path | None:
-        """
-        Get the path to the cache directory.
-        """
+        """Get the path to the cache directory."""
         return self._cache_dir
 
     def create_directories(self):
-        """
-        Create all necessary directories for the project.
-        """
+        """Create all necessary directories for the project."""
         self._annotations_dir.mkdir(parents=True, exist_ok=True)
         self._feature_dir.mkdir(parents=True, exist_ok=True)
         self._prediction_dir.mkdir(parents=True, exist_ok=True)

--- a/src/jabs/project/project_utils.py
+++ b/src/jabs/project/project_utils.py
@@ -4,11 +4,16 @@ import h5py
 
 
 def to_safe_name(behavior: str) -> str:
-    """
-    Create a version of the given behavior name that should be safe to use in filenames.
-    :param behavior: string behavior name
-    :returns: sanitized behavior name
-    :raises ValueError: if the behavior name is empty after sanitization
+    """Create a version of the given behavior name that should be safe to use in filenames.
+
+    Args:
+        behavior: string behavior name
+
+    Returns:
+        sanitized behavior name
+
+    Raises:
+        ValueError: if the behavior name is empty after sanitization
     """
 
     safe_behavior = re.sub(r"[^\w.-]+", "_", behavior, flags=re.UNICODE)

--- a/src/jabs/project/read_training.py
+++ b/src/jabs/project/read_training.py
@@ -7,23 +7,26 @@ from jabs.types import ProjectDistanceUnit
 
 
 def read_project_settings(h5_file: h5py.Group) -> dict:
-    """
-    read dict of project settings
+    """read dict of project settings
 
-    :param h5_file: open h5 file to read settings from
-    :return: dictionary of all project settings
+    Args:
+        h5_file: open h5 file to read settings from
+
+    Returns:
+        dictionary of all project settings
     """
     all_settings = {}
     root_len = len(h5_file.name) + 1
 
     def _walk_project_settings(name, node) -> dict:
-        """
-        read dict of project settings walker
+        """read dict of project settings walker
 
-        :param name: root where node is located
-        :param node: name of node currently visiting
-        :return: dictionary of walked setting (if valid node)
-        :raises: ValueError if settings have too much depth
+        Args:
+            name: root where node is located
+            node: name of node currently visiting
+
+        Returns:
+            dictionary of walked setting (if valid node)
 
         meant to be used with h5py's visititems
         this walk can't use return/yield, so we just mutate the dict each visit
@@ -44,13 +47,14 @@ def read_project_settings(h5_file: h5py.Group) -> dict:
 
 
 def load_training_data(training_file: Path):
-    """
-    load training data from file
+    """load training data from file
 
-    :param training_file: path to training h5 file
-    :return: features, group_mapping
-        features: dict containing training data with the following format:
-        {
+    Args:
+        training_file: path to training h5 file
+
+    Returns:
+        features, group_mapping features: dict containing training data
+        with the following format: {
             'per_frame': {}
             'window_features': {},
             'labels': [int],
@@ -67,7 +71,6 @@ def load_training_data(training_file: Path):
                 'video': str
             },
         }
-    :raises: OSError if unable to open h5 file for reading
     """
 
     features = {

--- a/src/jabs/project/settings_manager.py
+++ b/src/jabs/project/settings_manager.py
@@ -9,22 +9,22 @@ if typing.TYPE_CHECKING:
 
 
 class SettingsManager:
-    """
-    Class to manage project properties/settings.
-    """
+    """Class to manage project properties/settings."""
 
     def __init__(self, project_paths: "ProjectPaths"):
-        """
-        Initialize the ProjectProperties.
-        :param project_paths: ProjectPaths object to manage file paths.
+        """Initialize the ProjectProperties.
+
+        Args:
+            project_paths: ProjectPaths object to manage file paths.
         """
         self._paths = project_paths
         self._project_info = self._load_project_file()
 
     def _load_project_file(self) -> dict:
-        """
-        Load project properties from the project file.
-        :return: Dictionary of project properties.
+        """Load project properties from the project file.
+
+        Returns:
+            Dictionary of project properties.
         """
         try:
             with self._paths.project_file.open(mode="r", newline="\n") as f:
@@ -39,9 +39,10 @@ class SettingsManager:
         return settings
 
     def save_project_file(self, data: dict | None = None):
-        """
-        Save project properties & settings to the project file.
-        :param data: Dictionary with state information to save.
+        """Save project properties & settings to the project file.
+
+        Args:
+            data: Dictionary with state information to save.
         """
         # Merge data with current metadata
         if data is not None:
@@ -55,17 +56,19 @@ class SettingsManager:
 
     @property
     def project_settings(self) -> dict:
-        """
-        Get a copy of the current project properties and settings.
-        :return: dict
+        """Get a copy of the current project properties and settings.
+
+        Returns:
+            dict
         """
         return dict(self._project_info)
 
     def save_behavior(self, behavior: str, data: dict):
-        """
-        Save a behavior to project file.
-        :param behavior: Behavior name.
-        :param data: Dictionary of behavior settings.
+        """Save a behavior to project file.
+
+        Args:
+            behavior: Behavior name.
+            data: Dictionary of behavior settings.
         """
 
         defaults = self._project_info.get("defaults", {})
@@ -78,10 +81,13 @@ class SettingsManager:
         self.save_project_file({"behavior": all_behavior_data})
 
     def get_behavior(self, behavior: str) -> dict:
-        """
-        Get metadata specific to a requested behavior.
-        :param behavior: Behavior key to read.
-        :return: Dictionary of behavior metadata.
+        """Get metadata specific to a requested behavior.
+
+        Args:
+            behavior: Behavior key to read.
+
+        Returns:
+            Dictionary of behavior metadata.
         """
         return self._project_info.get("behavior", {}).get(behavior, {})
 
@@ -94,9 +100,7 @@ class SettingsManager:
             pass
 
     def update_version(self):
-        """
-        Update the version number in the metadata if it differs from the current version.
-        """
+        """Update the version number in the metadata if it differs from the current version."""
         current_version = self._project_info.get("version")
         if current_version != version_str():
             self.save_project_file({"version": version_str()})

--- a/src/jabs/project/track_labels.py
+++ b/src/jabs/project/track_labels.py
@@ -6,13 +6,12 @@ import numpy as np
 
 
 class TrackLabels:
-    """
-    Stores labels for a given identity and behavior. Requires one byte per
+    """Stores labels for a given identity and behavior. Requires one byte per
     frame to store labels (e.g. approx. 108KB per 1 hour of 30fps video)
     """
 
     class Label(enum.IntEnum):
-        """ label values """
+        """label values"""
         NONE = -1
         NOT_BEHAVIOR = 0
         BEHAVIOR = 1
@@ -26,26 +25,29 @@ class TrackLabels:
         self._labels = np.full(num_frames, self.Label.NONE.value, dtype=np.byte)
 
     def label_behavior(self, start, end, mask=None):
-        """ label range [start, end] as showing behavior """
+        """label range [start, end] as showing behavior"""
         self._set_labels(start, end, self.Label.BEHAVIOR, mask)
 
     def label_not_behavior(self, start, end, mask=None):
-        """ label range [start, end] of frames as not showing behavior """
+        """label range [start, end] of frames as not showing behavior"""
         self._set_labels(start, end, self.Label.NOT_BEHAVIOR, mask)
 
     def clear_labels(self, start, end):
-        """ clear labels for a range of frames [start, end] """
+        """clear labels for a range of frames [start, end]"""
         self._labels[start:end+1] = self.Label.NONE
 
     def _set_labels(self, start, end, label, mask=None):
-        """
-        set label value for a range of frames
-        :param start: start of range, inclusive
-        :param end: end of range, inclusive
-        :param label: label to apply to frames
-        :param mask: optional mask array, if present only set values where
-        the mask array is not zero
-        :return: None
+        """set label value for a range of frames
+
+        Args:
+            start: start of range, inclusive
+            end: end of range, inclusive
+            label: label to apply to frames
+            mask: optional mask array, if present only set values where
+                the mask array is not zero
+
+        Returns:
+            None
         """
         if mask is not None:
             self._labels[start:end + 1][mask != 0] = label
@@ -56,27 +58,29 @@ class TrackLabels:
         return self._labels
 
     def get_frame_label(self, frame_index):
-        """ get the label for a given frame """
+        """get the label for a given frame"""
         return self._labels[frame_index]
 
     @property
     def label_count(self):
-        """
-        property that returns a tuple with the count of the number of frames
+        """property that returns a tuple with the count of the number of frames
         for each label class
-        :return: (count of frames labeled as showing behavior,
-                  count of frames labeled as not showing behavior)
+
+        Returns:
+            (count of frames labeled as showing behavior, count of
+            frames labeled as not showing behavior)
         """
         return (np.count_nonzero(self._labels == self.Label.BEHAVIOR),
                 np.count_nonzero(self._labels == self.Label.NOT_BEHAVIOR))
 
     @property
     def bout_count(self):
-        """
-        property that returns a tuple with the count of the number of bouts
+        """property that returns a tuple with the count of the number of bouts
         of each label class
-        :return: (count of bouts of behavior,
-                  count of bouts of "not behavior")
+
+        Returns:
+            (count of bouts of behavior, count of bouts of "not
+            behavior")
         """
         blocks = self._array_to_blocks(self._labels)
         bouts_behavior = 0
@@ -91,29 +95,24 @@ class TrackLabels:
 
     @property
     def counts(self):
-        """
-        return the label and bout counts
-        """
+        """return the label and bout counts"""
         return self.label_count, self.bout_count
 
     def get_blocks(self):
-        """
-        get blocks for entire label array
+        """get blocks for entire label array
         see _array_to_blocks() for return type
         """
         return self._array_to_blocks(self._labels)
 
     def get_slice_blocks(self, start, end):
-        """
-        get label blocks for a slice of frames
+        """get label blocks for a slice of frames
         block start and end frame numbers will be relative to the slice start
         """
         return self._array_to_blocks(self._labels[start:end+1])
 
     @classmethod
     def downsample(cls, labels, size):
-        """
-        Downsample the label array for a "zoomed out" view. We use a custom
+        """Downsample the label array for a "zoomed out" view. We use a custom
         downsampling algorithm. Each element in the downsampled array is
         assigned one of the following values:
             Label.NONE: all elements in the bin have the value of Label.NONE
@@ -122,9 +121,13 @@ class TrackLabels:
             Label.MIX: bin contains Label.BEHAVIOR and Label.NOT_BEHAVIOR
             Label.PAD: bin consists entirely of padding added to input array to
             make it evenly divisible by output size
-        :param labels: numpy label array
-        :param size: size of the resulting downsampled label array
-        :return: numpy array of size 'size' with downsampled values
+
+        Args:
+            labels: numpy label array
+            size: size of the resulting downsampled label array
+
+        Returns:
+            numpy array of size 'size' with downsampled values
         """
 
         def bincount(array):
@@ -167,8 +170,7 @@ class TrackLabels:
 
     @classmethod
     def load(cls, num_frames, blocks):
-        """
-        return a TrackLabels object initialized with data from a list of blocks
+        """return a TrackLabels object initialized with data from a list of blocks
         :param num_frames total number of frames in the video
         :param blocks - blocks to use to initialize frame label array. see
         _array_to_blocks() for format
@@ -184,12 +186,13 @@ class TrackLabels:
 
     @classmethod
     def _array_to_blocks(cls, array):
-        """
-            return label blocks as something that can easily be exported as json
-            for saving to disk
-            :param array numpy label array to encode as blocks. Each element
-            should be one of TrackLabels.Label enum values.
-            :return:  list of blocks of frames that have been labeled as having
+        """return label blocks as something that can easily be exported as json
+        for saving to disk
+        :param array numpy label array to encode as blocks. Each element
+        should be one of TrackLabels.Label enum values.
+
+        Returns:
+            list of blocks of frames that have been labeled as having
             the behavior or not having the behavior. Each block has the
             following representation:
             {

--- a/src/jabs/project/video_labels.py
+++ b/src/jabs/project/video_labels.py
@@ -2,8 +2,7 @@ from .track_labels import TrackLabels
 
 
 class VideoLabels:
-    """
-    store the labels associated with a video file.
+    """store the labels associated with a video file.
 
     labels are organized by "identity". Each identity may have multiple
     behaviors labeled. An identity and behavior uniquely identifies a
@@ -21,7 +20,7 @@ class VideoLabels:
 
     @property
     def filename(self):
-        """ return filename of video this object represents """
+        """return filename of video this object represents"""
         return self._filename
 
     @property
@@ -29,14 +28,17 @@ class VideoLabels:
         return self._num_frames
 
     def get_track_labels(self, identity, behavior):
-        """
-        return a TrackLabels for an identity & behavior
-        :param identity: string representation of identity
-        :param behavior: string behavior label
-        :return: TrackLabels object for this identity and behavior
-        :raises: ValueError if identity is not a valid string
+        """return a TrackLabels for an identity & behavior
 
-        # TODO handle integer identity
+        Args:
+            identity: string representation of identity
+            behavior: string behavior label
+
+        Returns:
+            TrackLabels object for this identity and behavior
+
+        TODO:
+            handle integer identity
         """
 
         # require identity to be a string for serialization
@@ -61,16 +63,19 @@ class VideoLabels:
         return self._identity_labels[identity][behavior]
 
     def counts(self, behavior):
-        """
-           get the count of labeled frames and bouts for each identity in this
-           video for a specified behavior
-           :param behavior: behavior to get label counts for
-           :return: list of tuples with the following form
-           (
-               identity,
-               (behavior frame count, not behavior frame count),
-               (behavior bout count, not behavior bout count)
-           )
+        """get the count of labeled frames and bouts for each identity in this
+        video for a specified behavior
+
+        Args:
+            behavior: behavior to get label counts for
+
+        Returns:
+            list of tuples with the following form
+            (
+                identity,
+                (behavior frame count, not behavior frame count),
+                (behavior bout count, not behavior bout count)
+            )
         """
         counts = []
         for identity in self._identity_labels:
@@ -80,8 +85,7 @@ class VideoLabels:
         return counts
 
     def as_dict(self) -> dict:
-        """
-        return dict representation of self, useful for JSON serialization and
+        """return dict representation of self, useful for JSON serialization and
         saving to disk or caching in memory without storing the full
         numpy label array when user switches to a different video
 
@@ -130,8 +134,7 @@ class VideoLabels:
 
     @classmethod
     def load(cls, video_label_dict):
-        """
-        return a VideoLabels object initialized with data from a dict previously
+        """return a VideoLabels object initialized with data from a dict previously
         exported using the export() method
         """
         labels = cls(video_label_dict['file'], video_label_dict['num_frames'])

--- a/src/jabs/project/video_manager.py
+++ b/src/jabs/project/video_manager.py
@@ -11,19 +11,17 @@ from .video_labels import VideoLabels
 
 
 class VideoManager:
-    """
-    Class to manage list of video files in a project.
-    """
+    """Class to manage list of video files in a project."""
     def __init__(
         self,
         paths: ProjectPaths,
         settings_manager: SettingsManager,
         enable_video_check: bool = True,
     ):
-        """
-        Initialize the VideoManager with paths.
+        """Initialize the VideoManager with paths.
 
-        :param paths: ProjectPaths object containing project directory paths
+        Args:
+            paths: ProjectPaths object containing project directory paths
         """
         self._paths = paths
         self._settings_manager = settings_manager
@@ -53,11 +51,15 @@ class VideoManager:
         return self._total_project_identities
 
     def load_video_labels(self, video_name) -> VideoLabels | None:
-        """
-        load labels for a video from the project directory or from a cached of
+        """load labels for a video from the project directory or from a cached of
         annotations that have previously been opened and not yet saved
-        :param video_name: filename of the video: string or pathlib.Path
-        :return: initialized VideoLabels object if annotations exist, otherwise None
+
+        Args:
+            video_name: filename of the video: string or pathlib.Path
+
+        Returns:
+            initialized VideoLabels object if annotations exist,
+            otherwise None
         """
 
         video_filename = Path(video_name).name
@@ -74,13 +76,15 @@ class VideoManager:
             return None
 
     def check_video_name(self, video_filename):
-        """
-        make sure the video name actually matches one in the project, this
+        """make sure the video name actually matches one in the project, this
         function will raise a ValueError if the video name is not valid,
         otherwise the function has no effect
-        :param video_filename:
-        :return: None
-        :raises: ValueError if the filename is not a valid video in this project
+
+        Args:
+            video_filename
+
+        Returns:
+            None
         """
         if video_filename not in self._videos:
             raise ValueError(f"{video_filename} not in project")
@@ -91,11 +95,13 @@ class VideoManager:
         return [f.name for f in dir_path.glob("*") if f.suffix in [".avi", ".mp4"]]
 
     def get_video_identity_count(self, video_name: str) -> int:
-        """
-        Get the number of identity count for a specific video.
+        """Get the number of identity count for a specific video.
 
-        :param video_name: Name of the video file
-        :return: Number of identities in the video
+        Args:
+            video_name: Name of the video file
+
+        Returns:
+            Number of identities in the video
         """
         return self._video_identity_count.get(video_name, 0)
 
@@ -145,7 +151,7 @@ class VideoManager:
             raise ValueError("Project missing pose file for one or more video")
 
     def _has_pose(self, vid: str) -> bool:
-        """ check to see if a video has a corresponding pose file """
+        """check to see if a video has a corresponding pose file"""
         path = self._paths.project_dir / vid
 
         try:

--- a/src/jabs/scripts/classify.py
+++ b/src/jabs/scripts/classify.py
@@ -23,8 +23,7 @@ __CLASSIFIER_CHOICES = Classifier().classifier_choices()
 
 
 def get_pose_stem(pose_path: Path):
-    """
-    takes a pose path as input and returns the name component
+    """takes a pose path as input and returns the name component
     with the '_pose_est_v#.h5' suffix removed
     """
     m = re.match(r'^(.+)(_pose_est_v[0-9]+\.h5)$', pose_path.name)

--- a/src/jabs/scripts/convert_parquet.py
+++ b/src/jabs/scripts/convert_parquet.py
@@ -1,5 +1,4 @@
-"""
-Convert Apache Parquet pose file with identity to HDF5 pose file that can be read by JABS
+"""Convert Apache Parquet pose file with identity to HDF5 pose file that can be read by JABS
 
 Example:
     $ python convert_parquet.py --lixit-csv lixit.csv input1.parquet
@@ -101,8 +100,7 @@ def convert(
     lixit_predictions: dict[str, tuple[float, float]] | None,
     num_frames: int,
 ) -> None:
-    """
-    Convert a parquet file to JABS Pose format.
+    """Convert a parquet file to JABS Pose format.
     Args:
         parquet_path: path to input parquet file
         output_path: output path for the converted h5 file
@@ -124,8 +122,7 @@ def convert_data_frame(
     lixit_predictions: dict[str, tuple[float, float]] | None,
     num_frames: int,
 ) -> None:
-    """
-    Convert a pandas dataframe to JABS Pose format.
+    """Convert a pandas dataframe to JABS Pose format.
     Args:
         df: pandas dataframe with required columns
         output_path: output path for the converted h5 file
@@ -205,8 +202,7 @@ def convert_data_frame(
 
 
 def read_lixit_csv(path: Path) -> dict[str, tuple[float, float]]:
-    """
-    Read the csv file with the lixit predictions and return the average x and y coordinates of the three key
+    """Read the csv file with the lixit predictions and return the average x and y coordinates of the three key
     points (tip, left side, and right side).
     Args:
         path (Path): Path to the csv file

--- a/src/jabs/scripts/generate_features.py
+++ b/src/jabs/scripts/generate_features.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
-"""
-initialize JABS features for a pose file
+"""initialize JABS features for a pose file
 
 computes features if they do not exist
 """

--- a/src/jabs/scripts/initialize_project.py
+++ b/src/jabs/scripts/initialize_project.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
-"""
-initialize a JABS project directory
+"""initialize a JABS project directory
 
 computes features if they do not exist
 optional regenerate and overwrite existing feature h5 files
@@ -24,7 +23,7 @@ DEFAULT_WINDOW_SIZE = 5
 
 
 def generate_files_worker(params: dict):
-    """ worker function used for generating project feature and cache files """
+    """worker function used for generating project feature and cache files"""
     project = params['project']
     pose_est = project.load_pose_est(
         project.video_manager.video_path(params['video']))
@@ -53,7 +52,7 @@ def generate_files_worker(params: dict):
 
 
 def validate_video_worker(params: dict):
-    """ worker function for validating project video """
+    """worker function for validating project video"""
 
     vid_path = params['project_dir'] / params['video']
 
@@ -81,7 +80,7 @@ def validate_video_worker(params: dict):
 
 
 def match_to_pose(video: str, project_dir: Path):
-    """ make sure a video has a corresponding h5 file """
+    """make sure a video has a corresponding h5 file"""
     path = project_dir / video
 
     try:
@@ -205,7 +204,7 @@ def main():
     distance_unit = project.feature_manager.distance_unit
 
     def feature_job_producer():
-        """ producer for Pool.imap_unordered """
+        """producer for Pool.imap_unordered"""
         for video in project.video_manager.videos:
             for identity in project.load_pose_est(
                     project.video_manager.video_path(video)).identities:

--- a/src/jabs/ui/about_dialog.py
+++ b/src/jabs/ui/about_dialog.py
@@ -5,7 +5,7 @@ from jabs.version import version_str
 
 
 class AboutDialog(QDialog):
-    """ dialog that shows application info such as version and copyright """
+    """dialog that shows application info such as version and copyright"""
 
     def __init__(self, app_name, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/jabs/ui/archive_behavior_dialog.py
+++ b/src/jabs/ui/archive_behavior_dialog.py
@@ -3,9 +3,7 @@ from PySide6 import QtCore
 
 
 class ArchiveBehaviorDialog(QDialog):
-    """
-    dialog to allow a user to select a behavior to archive from the project
-    """
+    """dialog to allow a user to select a behavior to archive from the project"""
 
     behavior_archived = QtCore.Signal(str)
 

--- a/src/jabs/ui/central_widget.py
+++ b/src/jabs/ui/central_widget.py
@@ -23,9 +23,7 @@ from .main_control_widget import MainControlWidget
 _CLICK_THRESHOLD = 20
 
 class CentralWidget(QtWidgets.QWidget):
-    """
-    QT Widget implementing our main window contents
-    """
+    """QT Widget implementing our main window contents"""
 
     export_training_status_change = QtCore.Signal(bool)
 
@@ -116,17 +114,17 @@ class CentralWidget(QtWidgets.QWidget):
 
     @property
     def behavior(self):
-        """ get the currently selected behavior """
+        """get the currently selected behavior"""
         return self._controls.current_behavior
 
     @property
     def classifier_type(self):
-        """ get the current classifier type """
+        """get the current classifier type"""
         return self._classifier.classifier_type
 
     @property
     def window_size(self):
-        """ get current window size """
+        """get current window size"""
         return self._window_size
 
     @property
@@ -143,9 +141,7 @@ class CentralWidget(QtWidgets.QWidget):
 
     @property
     def classify_button_enabled(self):
-        """
-        return true if the classify button is currently enabled, false otherwise
-        """
+        """return true if the classify button is currently enabled, false otherwise"""
         return self._controls.classify_button_enabled
 
     @property
@@ -153,7 +149,7 @@ class CentralWidget(QtWidgets.QWidget):
         return self._controls.behaviors
 
     def set_project(self, project):
-        """ set the currently opened project """
+        """set the currently opened project"""
         self._project = project
 
         # This will get set when the first video in the project is loaded, but
@@ -166,11 +162,13 @@ class CentralWidget(QtWidgets.QWidget):
         self._controls.update_project_settings(project.settings)
 
     def load_video(self, path):
-        """
-        load a new video file into self._player_widget
-        :param path: path to video file
-        :return: None
-        :raises: OSError if unable to open video
+        """load a new video file into self._player_widget
+
+        Args:
+            path: path to video file
+
+        Returns:
+            None
         """
 
         if self._labels is not None:
@@ -236,7 +234,7 @@ class CentralWidget(QtWidgets.QWidget):
             raise e
 
     def keyPressEvent(self, event):
-        """ handle key press events """
+        """handle key press events"""
 
         def begin_select_mode():
             if not self._controls.select_button_is_checked:
@@ -298,9 +296,7 @@ class CentralWidget(QtWidgets.QWidget):
         return self._controls
 
     def _change_behavior(self, new_behavior):
-        """
-        make UI changes to reflect the currently selected behavior
-        """
+        """make UI changes to reflect the currently selected behavior"""
         if self._project is None:
             return
 
@@ -324,8 +320,7 @@ class CentralWidget(QtWidgets.QWidget):
         self._project.settings_manager.save_project_file({'selected_behavior': self.behavior})
 
     def _start_selection(self, pressed):
-        """
-        handle click on "select" button. If button was previously "unchecked"
+        """handle click on "select" button. If button was previously "unchecked"
         then grab the current frame to begin selecting a range. If the
         button was in the checked state, clicking cancels the current selection.
 
@@ -341,7 +336,7 @@ class CentralWidget(QtWidgets.QWidget):
         self.manual_labels.update()
 
     def _label_behavior(self):
-        """ Apply behavior label to currently selected range of frames """
+        """Apply behavior label to currently selected range of frames"""
         start, end = sorted([self._selection_start,
                              self._player_widget.current_frame()])
         mask = self._player_widget.get_identity_mask()
@@ -349,7 +344,7 @@ class CentralWidget(QtWidgets.QWidget):
         self._label_button_common()
 
     def _label_not_behavior(self):
-        """ apply _not_ behavior label to currently selected range of frames """
+        """apply _not_ behavior label to currently selected range of frames"""
         start, end = sorted([self._selection_start,
                              self._player_widget.current_frame()])
         mask = self._player_widget.get_identity_mask()
@@ -358,15 +353,14 @@ class CentralWidget(QtWidgets.QWidget):
         self._label_button_common()
 
     def _clear_behavior_label(self):
-        """ clear all behavior/not behavior labels from current selection """
+        """clear all behavior/not behavior labels from current selection"""
         label_range = sorted([self._selection_start,
                               self._player_widget.current_frame()])
         self._get_label_track().clear_labels(*label_range)
         self._label_button_common()
 
     def _label_button_common(self):
-        """
-        functionality shared between _label_behavior(), _label_not_behavior(),
+        """functionality shared between _label_behavior(), _label_not_behavior(),
         and _clear_behavior_label(). to be called after the labels are changed
         for the current selection
         """
@@ -379,20 +373,18 @@ class CentralWidget(QtWidgets.QWidget):
         self._set_train_button_enabled_state()
 
     def _set_identities(self, identities):
-        """ populate the identity_selection combobox """
+        """populate the identity_selection combobox"""
         self._controls.set_identities(identities)
 
     def _change_identity(self):
-        """ handle changing value of identity_selection """
+        """handle changing value of identity_selection"""
         self._player_widget.set_active_identity(
             self._controls.current_identity_index)
         self._set_label_track()
         self._update_label_counts()
 
     def _frame_change(self, new_frame):
-        """
-        called when the video player widget emits its updateFrameNumber signal
-        """
+        """called when the video player widget emits its updateFrameNumber signal"""
         self._curr_frame_index = new_frame
         self.manual_labels.set_current_frame(new_frame)
         self.prediction_vis.set_current_frame(new_frame)
@@ -401,8 +393,7 @@ class CentralWidget(QtWidgets.QWidget):
         self.frame_ticks.set_current_frame(new_frame)
 
     def _set_label_track(self):
-        """
-        loads new set of labels in self.manual_labels when the selected
+        """loads new set of labels in self.manual_labels when the selected
         behavior or identity is changed
         """
         behavior = self._controls.current_behavior
@@ -417,8 +408,7 @@ class CentralWidget(QtWidgets.QWidget):
         self._set_prediction_vis()
 
     def _get_label_track(self):
-        """
-        get the current label track for the currently selected identity and
+        """get the current label track for the currently selected identity and
         behavior
         """
         return self._labels.get_track_labels(
@@ -427,9 +417,7 @@ class CentralWidget(QtWidgets.QWidget):
         )
 
     def _update_classifier_controls(self):
-        """
-        Called when settings related to a loaded classifier should be updated
-        """
+        """Called when settings related to a loaded classifier should be updated"""
         self._controls.set_classifier_selection(self._classifier.classifier_type)
 
         # does the classifier match the current settings?
@@ -448,7 +436,7 @@ class CentralWidget(QtWidgets.QWidget):
             self._controls.classify_button_set_enabled(False)
 
     def _train_button_clicked(self):
-        """ handle user click on "Train" button """
+        """handle user click on "Train" button"""
         # make sure video playback is stopped
         self._player_widget.stop()
 
@@ -484,17 +472,17 @@ class CentralWidget(QtWidgets.QWidget):
         self._training_thread.start()
 
     def _training_thread_complete(self):
-        """ enable classify button once the training is complete """
+        """enable classify button once the training is complete"""
         self._progress_dialog.reset()
         self.parent().display_status_message("Training Complete", 3000)
         self._controls.classify_button_set_enabled(True)
 
     def _update_training_progress(self, step):
-        """ update progress bar with the number of completed tasks """
+        """update progress bar with the number of completed tasks"""
         self._progress_dialog.setValue(step)
 
     def _classify_button_clicked(self):
-        """ handle user click on "Classify" button """
+        """handle user click on "Classify" button"""
         # make sure video playback is stopped
         self._player_widget.stop()
 
@@ -521,7 +509,7 @@ class CentralWidget(QtWidgets.QWidget):
         self._classify_thread.start()
 
     def _classify_thread_complete(self, output: dict):
-        """ update the gui when the classification is complete """
+        """update the gui when the classification is complete"""
         # display the new predictions
         self._predictions = output['predictions']
         self._probabilities = output['probabilities']
@@ -530,13 +518,11 @@ class CentralWidget(QtWidgets.QWidget):
         self._set_prediction_vis()
 
     def _update_classify_progress(self, step):
-        """ update progress bar with the number of completed tasks """
+        """update progress bar with the number of completed tasks"""
         self._progress_dialog.setValue(step)
 
     def _set_prediction_vis(self):
-        """
-        update data being displayed by the prediction visualization widget
-        """
+        """update data being displayed by the prediction visualization widget"""
 
         if self._loaded_video is None:
             return
@@ -566,13 +552,14 @@ class CentralWidget(QtWidgets.QWidget):
         self.inference_timeline_widget.update_labels()
 
     def _set_train_button_enabled_state(self):
-        """
-        set the enabled property of the train button to True or False depending
+        """set the enabled property of the train button to True or False depending
         whether the labeling meets some threshold set by the classifier module
 
         NOTE: must be called after _update_label_counts() so that it has the
         correct counts for the current video
-        :return: None
+
+        Returns:
+            None
         """
 
         if Classifier.label_threshold_met(self._counts,
@@ -584,10 +571,10 @@ class CentralWidget(QtWidgets.QWidget):
             self.export_training_status_change.emit(False)
 
     def _update_label_counts(self):
-        """
-        update the widget with the labeled frame / bout counts
+        """update the widget with the labeled frame / bout counts
 
-        :return: None
+        Returns:
+            None
         """
 
         if self._loaded_video is None:
@@ -631,15 +618,14 @@ class CentralWidget(QtWidgets.QWidget):
                                         bout_not_behavior_project)
 
     def _classifier_changed(self):
-        """ handle classifier selection change """
+        """handle classifier selection change"""
         if self._classifier.classifier_type != self._controls.classifier_type:
             # changing classifier type, disable until retrained
             self._controls.classify_button_set_enabled(False)
             self._classifier.set_classifier(self._controls.classifier_type)
 
     def _pixmap_clicked(self, event):
-        """
-        handle event where user clicked on the video -- if they click
+        """handle event where user clicked on the video -- if they click
         on one of the mice, make that one active
         """
         clicked_identity = None
@@ -674,18 +660,18 @@ class CentralWidget(QtWidgets.QWidget):
             self._controls.set_identity_index(clicked_identity)
 
     def _window_feature_size_changed(self, new_size):
-        """ handle window feature size change """
+        """handle window feature size change"""
         if new_size is not None and new_size != self._window_size:
             self._window_size = new_size
             self.update_behavior_settings('window_size', new_size)
             self._update_classifier_controls()
 
     def _save_window_sizes(self, window_sizes):
-        """ save the window sizes to the project settings """
+        """save the window sizes to the project settings"""
         self._project.settings_manager.save_project_file({'window_sizes': window_sizes})
 
     def update_behavior_settings(self, key, val):
-        """ propagates an updated setting to the project """
+        """propagates an updated setting to the project"""
         # early exit if no behavior selected
         if self.behavior == '':
             return

--- a/src/jabs/ui/classification_thread.py
+++ b/src/jabs/ui/classification_thread.py
@@ -7,9 +7,7 @@ from jabs.video_reader.utilities import get_fps
 
 
 class ClassifyThread(QtCore.QThread):
-    """
-    thread to run the classification to keep the main GUI thread responsive
-    """
+    """thread to run the classification to keep the main GUI thread responsive"""
 
     done = QtCore.Signal(dict)
     update_progress = QtCore.Signal(int)
@@ -24,8 +22,7 @@ class ClassifyThread(QtCore.QThread):
         self._current_video = current_video
 
     def run(self):
-        """
-        thread's main function. runs the classifier for each identity in each
+        """thread's main function. runs the classifier for each identity in each
         video
         """
         self._tasks_complete = 0

--- a/src/jabs/ui/frame_labels_widget.py
+++ b/src/jabs/ui/frame_labels_widget.py
@@ -4,8 +4,7 @@ from PySide6.QtWidgets import QWidget, QSizePolicy, QApplication
 
 
 class FrameLabelsWidget(QWidget):
-    """
-    draws ticks and frame labels, intended to be used under one or more
+    """draws ticks and frame labels, intended to be used under one or more
     ManualLabelsWidget
     """
 
@@ -43,8 +42,7 @@ class FrameLabelsWidget(QWidget):
         self._font_height = self._font_metrics.height()
 
     def sizeHint(self):
-        """
-        Override QWidget.sizeHint to give an initial starting size.
+        """Override QWidget.sizeHint to give an initial starting size.
         Width hint is not so important because we allow the widget to resize
         horizontally to fill the available container. The height is fixed,
         so the value used here sets the height of the widget.
@@ -57,8 +55,7 @@ class FrameLabelsWidget(QWidget):
         self._offset = (self.size().width() - self._adjusted_width) / 2
 
     def paintEvent(self, event):
-        """
-        override QWidget paintEvent
+        """override QWidget paintEvent
 
         This draws the widget.
         """
@@ -75,12 +72,13 @@ class FrameLabelsWidget(QWidget):
         qp.end()
 
     def _draw_ticks(self, painter, start, end):
-        """
-        draw ticks draw ticks at the proper interval and draw the frame
+        """draw ticks draw ticks at the proper interval and draw the frame
         number under the tick
-        :param painter: active QPainter
-        :param start: starting frame number
-        :param end: ending frame number
+
+        Args:
+            painter: active QPainter
+            start: starting frame number
+            end: ending frame number
         """
 
         for i in range(start, end + 1):
@@ -96,14 +94,13 @@ class FrameLabelsWidget(QWidget):
                                  self._font_height + 8, label_text)
 
     def set_current_frame(self, current_frame):
-        """ called to reposition the view around new current frame """
+        """called to reposition the view around new current frame"""
         self._current_frame = current_frame
         # force redraw
         self.update()
 
     def set_num_frames(self, num_frames):
-        """
-        set number of frames in current video, needed to keep from drawing
+        """set number of frames in current video, needed to keep from drawing
         ticks past the end of the video (pace that is drawn as padding by
         ManualLabelsWidget
         """

--- a/src/jabs/ui/global_inference_widget.py
+++ b/src/jabs/ui/global_inference_widget.py
@@ -7,8 +7,7 @@ from .timeline_label_widget import TimelineLabelWidget
 
 
 class GlobalInferenceWidget(TimelineLabelWidget):
-    """
-    subclass of TimelineLabeWidget with one primary modification:
+    """subclass of TimelineLabeWidget with one primary modification:
     self._labels will be a numpy array and not a TrackLabels object
     """
 
@@ -16,8 +15,7 @@ class GlobalInferenceWidget(TimelineLabelWidget):
         super().__init__()
 
     def _update_bar(self):
-        """
-        Updates the bar pixmap. Downsamples with the current size and updates
+        """Updates the bar pixmap. Downsamples with the current size and updates
         self._pixmap
         """
         width = self.size().width()
@@ -51,8 +49,7 @@ class GlobalInferenceWidget(TimelineLabelWidget):
         qp.end()
 
     def set_num_frames(self, num_frames):
-        """
-        sets the number of frames in the current video, and resets the display
+        """sets the number of frames in the current video, and resets the display
         with a blank track
         """
         self._labels = np.full(num_frames, TrackLabels.Label.NONE.value,

--- a/src/jabs/ui/identity_combo_box.py
+++ b/src/jabs/ui/identity_combo_box.py
@@ -2,8 +2,7 @@ from PySide6 import QtWidgets, QtCore
 
 
 class IdentityComboBox(QtWidgets.QComboBox):
-    """
-    Subclass the combo box to emit a signal that indicates if it has been
+    """Subclass the combo box to emit a signal that indicates if it has been
     opened or closed. This is used to tell the PlayerWidget to switch to the
     "label identities mode".
     """
@@ -19,8 +18,7 @@ class IdentityComboBox(QtWidgets.QComboBox):
         self._signal_handler_connected = False
 
     def showPopup(self):
-        """
-        showPopup is overridden so that we can emit a signal every time
+        """showPopup is overridden so that we can emit a signal every time
         it is shown
         """
         self.pop_up_visible.emit(True)
@@ -47,8 +45,7 @@ class IdentityComboBox(QtWidgets.QComboBox):
     #     super(IdentityComboBox, self).hidePopup()
 
     def cancel_popup(self):
-        """
-        Part of the work around described in showPopup. This is connected to
+        """Part of the work around described in showPopup. This is connected to
         the resetButton signal for the QComboBoxPrivateContainer. This lets us
         emit the signal when the user dismisses the popup by clicking outside
         the QComboBox drop down. This can be removed if the behavior of

--- a/src/jabs/ui/k_fold_slider_widget.py
+++ b/src/jabs/ui/k_fold_slider_widget.py
@@ -3,8 +3,7 @@ from PySide6.QtCore import Qt, Signal
 
 
 class KFoldSliderWidget(QtWidgets.QWidget):
-    """
-    widget to allow user to select k parameter for k-fold cross validation
+    """widget to allow user to select k parameter for k-fold cross validation
 
     basically consists of a QSlider and three QLabel widgets with
     no spacing/margins
@@ -44,5 +43,5 @@ class KFoldSliderWidget(QtWidgets.QWidget):
         self.setLayout(slider_vbox)
 
     def value(self):
-        """ return the slider value """
+        """return the slider value"""
         return self._slider.value()

--- a/src/jabs/ui/label_count_widget.py
+++ b/src/jabs/ui/label_count_widget.py
@@ -6,8 +6,7 @@ from PySide6.QtCore import Qt
 
 
 class FrameLabelCountWidget(QtWidgets.QWidget):
-    """
-    widget to show the number of frames and bouts for behavior, not behavior
+    """widget to show the number of frames and bouts for behavior, not behavior
     label classes for the currently selected identity/video as well as
     project-wide totals
     """
@@ -86,23 +85,23 @@ class FrameLabelCountWidget(QtWidgets.QWidget):
                    frame_behavior_project, frame_not_behavior_project,
                    bout_behavior_current, bout_not_behavior_current,
                    bout_behavior_project, bout_not_behavior_project):
-        """
-        update counts and redraw widget
+        """update counts and redraw widget
 
-        :param frame_behavior_current: #frames labeled behavior for current
+        Args:
+            frame_behavior_current: #frames labeled behavior for current
+            frame_not_behavior_current: #frames labeled not behavior for
+            frame_behavior_project: #frames labeled behavior for project
+            frame_not_behavior_project: #frames labeled not behavior for
+            bout_behavior_current: #bouts of behavior for current
+                identity
+            bout_not_behavior_current: #bouts not behavior for current
+            bout_behavior_project: #bouts behavior for project
+            bout_not_behavior_project: #bouts not behavior for project
         identity (in current video)
-        :param frame_not_behavior_current: #frames labeled not behavior for
         current identity (in current video)
-        :param frame_behavior_project:  #frames labeled behavior for project
-        :param frame_not_behavior_project: #frames labeled not behavior for
         project
-        :param bout_behavior_current: #bouts of behavior for current identity
         (in current video)
-        :param bout_not_behavior_current: #bouts not behavior for current
         identity (in current video)
-        :param bout_behavior_project: #bouts behavior for project
-        :param bout_not_behavior_project: #bouts not behavior for project
-        :return:
         """
         self._frame_labels['behavior_current'].setText(
             f"{frame_behavior_current}")

--- a/src/jabs/ui/label_count_widget.py
+++ b/src/jabs/ui/label_count_widget.py
@@ -88,20 +88,22 @@ class FrameLabelCountWidget(QtWidgets.QWidget):
         """update counts and redraw widget
 
         Args:
-            frame_behavior_current: #frames labeled behavior for current
-            frame_not_behavior_current: #frames labeled not behavior for
-            frame_behavior_project: #frames labeled behavior for project
-            frame_not_behavior_project: #frames labeled not behavior for
-            bout_behavior_current: #bouts of behavior for current
-                identity
-            bout_not_behavior_current: #bouts not behavior for current
-            bout_behavior_project: #bouts behavior for project
-            bout_not_behavior_project: #bouts not behavior for project
-        identity (in current video)
-        current identity (in current video)
-        project
-        (in current video)
-        identity (in current video)
+            frame_behavior_current:
+              #frames labeled behavior for current identity (in current video)
+            frame_not_behavior_current:
+              #frames labeled not behavior for current identity (in current video)
+            frame_behavior_project:
+              #frames labeled behavior for project
+            frame_not_behavior_project:
+              #frames labeled not behavior for project
+            bout_behavior_current:
+              #bouts of behavior for current identity (in current video)
+            bout_not_behavior_current:
+              #bouts not behavior for current identity (in current video)
+            bout_behavior_project:
+              #bouts behavior for project
+            bout_not_behavior_project:
+              #bouts not behavior for project
         """
         self._frame_labels['behavior_current'].setText(
             f"{frame_behavior_current}")

--- a/src/jabs/ui/main_control_widget.py
+++ b/src/jabs/ui/main_control_widget.py
@@ -236,20 +236,19 @@ class MainControlWidget(QtWidgets.QWidget):
 
     @property
     def behaviors(self):
-        """ return a copy of the current list of behaviors """
+        """return a copy of the current list of behaviors"""
         return list(self._behaviors)
 
     @property
     def current_identity(self) -> str:
-        """
-        this will be the external identity
+        """this will be the external identity
         if the pose file doesn't have external identities this will be the string representation of the jabs identity
         """
         return self.identity_selection.currentText()
 
     @property
     def current_identity_index(self) -> int:
-        """ identity index is the same as the JABS identity """
+        """identity index is the same as the JABS identity"""
         return self.identity_selection.currentIndex()
 
     @property
@@ -299,7 +298,7 @@ class MainControlWidget(QtWidgets.QWidget):
         return self._all_kfold_checkbox.isChecked()
 
     def disable_label_buttons(self):
-        """ disable labeling buttons that require a selected range of frames """
+        """disable labeling buttons that require a selected range of frames"""
         self._label_behavior_button.setEnabled(False)
         self._label_not_behavior_button.setEnabled(False)
         self._clear_label_button.setEnabled(False)
@@ -365,10 +364,13 @@ class MainControlWidget(QtWidgets.QWidget):
         self.identity_selection.setCurrentIndex(i)
 
     def update_project_settings(self, project_settings: dict):
-        """
-        update controls from project settings
-        :param project_settings: dict containing project settings
-        :return: None
+        """update controls from project settings
+
+        Args:
+            project_settings: dict containing project settings
+
+        Returns:
+            None
         """
 
         # TODO: This is one of the major locations where project settings
@@ -408,7 +410,7 @@ class MainControlWidget(QtWidgets.QWidget):
         self._behavior_changed()
 
     def set_identities(self, identities):
-        """ populate the identity_selection combobox """
+        """populate the identity_selection combobox"""
         self.identity_selection.currentIndexChanged.disconnect()
         self.identity_selection.clear()
         self.identity_selection.currentIndexChanged.connect(
@@ -416,7 +418,7 @@ class MainControlWidget(QtWidgets.QWidget):
         self.identity_selection.addItems([str(i) for i in identities])
 
     def set_window_size(self, size: int):
-        """ set the current window size """
+        """set the current window size"""
         if self._window_size.findData(size) == -1:
             self._add_window_size(size)
         self._window_size.setCurrentText(str(size))
@@ -431,14 +433,13 @@ class MainControlWidget(QtWidgets.QWidget):
             self._get_first_label()
 
     def _set_window_sizes(self, sizes: List[int]):
-        """ set the list of available window sizes """
+        """set the list of available window sizes"""
         self._window_size.clear()
         for w in sizes:
             self._window_size.addItem(str(w), userData=w)
 
     def _new_label(self):
-        """
-        callback for the "new behavior" button
+        """callback for the "new behavior" button
         opens a modal dialog to allow the user to enter a new behavior label,
         if user clicks ok, add that behavior to the combo box, and select it
         """
@@ -454,8 +455,7 @@ class MainControlWidget(QtWidgets.QWidget):
             self.behavior_selection.setCurrentText(text)
 
     def _get_first_label(self):
-        """
-        show the new label dialog.
+        """show the new label dialog.
         Used when opening a new project for the fist time or if a user archives all behaviors in a project.
 
         dialog is customized to hide the window close button. The only way to close the dialog is to create a new
@@ -480,8 +480,7 @@ class MainControlWidget(QtWidgets.QWidget):
             sys.exit(0)
 
     def _new_window_size(self):
-        """
-        callback for the "new window size" button
+        """callback for the "new window size" button
         opens a modal dialog to allow the user to enter a new window size,
         if user clicks ok, add that window size and select it
         """

--- a/src/jabs/ui/main_window.py
+++ b/src/jabs/ui/main_window.py
@@ -193,8 +193,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self._export_training.setEnabled)
 
     def keyPressEvent(self, event: QKeyEvent):
-        """
-        override keyPressEvent so we can pass some key press events on
+        """override keyPressEvent so we can pass some key press events on
         to the centralWidget
         """
         key = event.key()
@@ -224,7 +223,7 @@ class MainWindow(QtWidgets.QMainWindow):
             super(MainWindow, self).keyPressEvent(event)
 
     def open_project(self, project_path: str):
-        """ open a new project directory """
+        """open a new project directory"""
         self._progress_dialog = QtWidgets.QProgressDialog(
             "Loading project...", None, 0, 0, self)
         self._progress_dialog.setWindowModality(QtCore.Qt.WindowModal)
@@ -235,7 +234,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._project_loader_thread.start()
 
     def behavior_changed_event(self, new_behavior: str):
-        """ menu items to change when a new behavior is selected. """
+        """menu items to change when a new behavior is selected."""
         # skip if no behavior assigned (only should occur during new project)
         if new_behavior is None or new_behavior == '':
             return
@@ -252,7 +251,7 @@ class MainWindow(QtWidgets.QMainWindow):
             menu_item.setChecked(static_settings.get(static_object, False))
 
     def behavior_label_add_event(self, behaviors: list[str]):
-        """ handle project updates required when user adds new behavior labels """
+        """handle project updates required when user adds new behavior labels"""
 
         # check for new behaviors
         for behavior in behaviors:
@@ -261,26 +260,30 @@ class MainWindow(QtWidgets.QMainWindow):
                 self._project.settings_manager.save_behavior(behavior, {})
 
     def display_status_message(self, message: str, duration: int = 3000):
-        """
-        display a message in the main window status bar
-        :param message: message to display
-        :param duration: duration of the message in milliseconds. Use 0 to
-        display the message until clear_status_bar() is called
-        :return: None
+        """display a message in the main window status bar
+
+        Args:
+            message: message to display
+            duration: duration of the message in milliseconds. Use 0 to
+                display the message until clear_status_bar() is called
+
+        Returns:
+            None
         """
         if duration < 0:
             raise ValueError("duration must be >= 0")
         self._status_bar.showMessage(message, duration)
 
     def clear_status_bar(self):
-        """
-        clear the status bar message
-        :return: None
+        """clear the status bar message
+
+        Returns:
+            None
         """
         self._status_bar.clearMessage()
 
     def _show_project_open_dialog(self):
-        """ prompt the user to select a project directory and open it """
+        """prompt the user to select a project directory and open it"""
         options = QtWidgets.QFileDialog.Options()
         if not USE_NATIVE_FILE_DIALOG:
             options |= QtWidgets.QFileDialog.DontUseNativeDialog
@@ -300,7 +303,7 @@ class MainWindow(QtWidgets.QMainWindow):
         dialog.exec_()
 
     def _open_user_guide(self):
-        """ show the user guide document in a separate window """
+        """show the user guide document in a separate window"""
         if self._user_guide_window is None:
             self._user_guide_window = UserGuideDialog(
                 f"{self._app_name_long} ({self._app_name})")
@@ -329,7 +332,7 @@ class MainWindow(QtWidgets.QMainWindow):
             print(f"Unable to export training data: {e}", file=sys.stderr)
 
     def _toggle_video_list(self, checked: bool):
-        """ show/hide video list """
+        """show/hide video list"""
         if not checked:
             # user unchecked
             self.video_list.hide()
@@ -338,44 +341,44 @@ class MainWindow(QtWidgets.QMainWindow):
             self.video_list.show()
 
     def _toggle_track(self, checked: bool):
-        """ show/hide track overlay for subject. """
+        """show/hide track overlay for subject."""
         self._central_widget.show_track(checked)
 
     def _toggle_pose_overlay(self, checked: bool):
-        """ show/hide pose overlay for subject. """
+        """show/hide pose overlay for subject."""
         self._central_widget.overlay_pose(checked)
 
     def _toggle_landmark_overlay(self, checked: bool):
-        """ show/hide landmark features. """
+        """show/hide landmark features."""
         self._central_widget.overlay_landmarks(checked)
 
     def _toggle_segmentation_overlay(self, checked: bool):
-        """ show/hide segmentation overlay for subject. """
+        """show/hide segmentation overlay for subject."""
         self._central_widget.overlay_segmentation(checked)
 
     def _toggle_cm_units(self, checked: bool):
-        """ toggle project to use pixel units. """
+        """toggle project to use pixel units."""
         # TODO: Warn the user that features may need to be re-calculated
         self._project.save_behavior(self._central_widget.behavior, {'cm_units': checked})
 
     def _toggle_social_features(self, checked: bool):
-        """ toggle project to use social features. """
+        """toggle project to use social features."""
         self._project.save_behavior(self._central_widget.behavior, {'social': checked})
 
     def _toggle_window_features(self, checked: bool):
-        """ toggle project to use window features. """
+        """toggle project to use window features."""
         self._project.save_behavior(self._central_widget.behavior, {'window': checked})
 
     def _toggle_fft_features(self, checked: bool):
-        """ toggle project to use fft features. """
+        """toggle project to use fft features."""
         self._project.save_behavior(self._central_widget.behavior, {'fft': checked})
 
     def _toggle_segmentation_features(self, checked: bool):
-        """ toggle project to use segmentation features. """
+        """toggle project to use segmentation features."""
         self._project.save_behavior(self._central_widget.behavior, {'segmentation': checked})
 
     def _toggle_static_object_feature(self, checked: bool):
-        """ toggle project to use a specific static object feature set. """
+        """toggle project to use a specific static object feature set."""
         # get the key from the caller
         key = self.sender().text().split(' ')[1].lower()
         all_object_settings = self._project.get_behavior(self._central_widget.behavior).get('static_objects', {})
@@ -383,8 +386,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._project.save_behavior(self._central_widget.behavior, {'static_objects': all_object_settings})
 
     def _video_list_selection(self, filename: str):
-        """
-        handle a click on a new video in the list loaded into the main
+        """handle a click on a new video in the list loaded into the main
         window dock
         """
         try:
@@ -403,9 +405,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._central_widget.remove_behavior(behavior)
 
     def _project_loaded_callback(self):
-        """
-        Callback function to be called when the project is loaded.
-        """
+        """Callback function to be called when the project is loaded."""
         self._project = self._project_loader_thread.project
         self._project_loader_thread = None
 
@@ -430,16 +430,14 @@ class MainWindow(QtWidgets.QMainWindow):
         self._progress_dialog.close()
 
     def _project_load_error_callback(self, error: Exception):
-        """
-        Callback function to be called when the project fails to load.
-        """
+        """Callback function to be called when the project fails to load."""
         self._project_loader_thread = None
         self._progress_dialog.close()
         QtWidgets.QMessageBox.critical(
             self, "Error loading project", str(error))
 
     def show_license_dialog(self):
-        """ prompt the user to accept the license agreement if they haven't already """
+        """prompt the user to accept the license agreement if they haven't already"""
 
         # check to see if user already accepted the license
         if self._settings.value(LICENSE_ACCEPTED_KEY, False, type=bool):
@@ -458,7 +456,7 @@ class MainWindow(QtWidgets.QMainWindow):
         return result
 
     def _update_recent_projects(self):
-        """ update the contents of the Recent Projects menu """
+        """update the contents of the Recent Projects menu"""
         self._open_recent_menu.clear()
         recent_projects = self._settings.value(RECENT_PROJECTS_KEY, [], type=list)
 
@@ -469,7 +467,7 @@ class MainWindow(QtWidgets.QMainWindow):
             action.triggered.connect(self._open_recent_project)
 
     def _add_recent_project(self, project_path: Path):
-        """ add a project to the recent projects list """
+        """add a project to the recent projects list"""
 
         # project path in the _project_loaded_callback is a Path object, Qt needs a string to add to the menu
         path_str = str(project_path)
@@ -493,7 +491,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._update_recent_projects()
 
     def _open_recent_project(self):
-        """ open a recent project """
+        """open a recent project"""
         action  = self.sender()
         if action:
             project_path = action.data()

--- a/src/jabs/ui/manual_label_widget.py
+++ b/src/jabs/ui/manual_label_widget.py
@@ -9,9 +9,7 @@ from .colors import (BEHAVIOR_COLOR, NOT_BEHAVIOR_COLOR, BACKGROUND_COLOR,
 
 
 class ManualLabelWidget(QWidget):
-    """
-    widget used to show labels for a range of frames around the current frame
-    """
+    """widget used to show labels for a range of frames around the current frame"""
 
     _BORDER_COLOR = QColor(212, 212, 212)
     _SELECTION_COLOR = QColor(*SELECTION_COLOR)
@@ -58,8 +56,7 @@ class ManualLabelWidget(QWidget):
         self._padding_brush = QBrush(self._BACKGROUND_COLOR, Qt.Dense6Pattern)
 
     def sizeHint(self):
-        """
-        Override QWidget.sizeHint to give an initial starting size.
+        """Override QWidget.sizeHint to give an initial starting size.
         Width hint is not so important because we allow the widget to resize
         horizontally to fill the available container. The height is fixed,
         so the value used here sets the height of the widget.
@@ -72,8 +69,7 @@ class ManualLabelWidget(QWidget):
         self._offset = (self.size().width() - self._adjusted_width) // 2
 
     def paintEvent(self, event):
-        """
-        override QWidget paintEvent
+        """override QWidget paintEvent
 
         This draws the widget.
         TODO: this could could be broken up into a few logical steps
@@ -189,11 +185,12 @@ class ManualLabelWidget(QWidget):
         qp.end()
 
     def _draw_second_ticks(self, painter, start, end):
-        """
-        draw ticks at one second intervals
-        :param painter: active QPainter
-        :param start: starting frame number
-        :param end: ending frame number
+        """draw ticks at one second intervals
+
+        Args:
+            painter: active QPainter
+            start: starting frame number
+            end: ending frame number
         """
 
         # can't draw if we don't know the frame rate yet
@@ -209,41 +206,40 @@ class ManualLabelWidget(QWidget):
                 painter.drawRect(offset, 0, self._frame_width - 1, 4)
 
     def set_labels(self, labels, mask=None):
-        """ load label track to display """
+        """load label track to display"""
         self._labels = labels
         self._identity_mask = mask
         self.update()
 
     def set_current_frame(self, current_frame):
-        """ called to reposition the view around new current frame """
+        """called to reposition the view around new current frame"""
         self._current_frame = current_frame
         # force redraw
         self.repaint()
 
     def set_num_frames(self, num_frames):
-        """ set number of frames in current video, needed to properly render """
+        """set number of frames in current video, needed to properly render"""
         self._num_frames = num_frames
 
     def set_framerate(self, fps):
-        """
-        set the frame rate for the currently loaded video, needed to draw the
+        """set the frame rate for the currently loaded video, needed to draw the
         ticks at one second intervals
-        :param fps: frame rate in frames per second
+
+        Args:
+            fps: frame rate in frames per second
         """
         self._framerate = fps
 
     def start_selection(self, start_frame):
-        """
-        start highlighting selection from start_frame to self._current_frame
-        """
+        """start highlighting selection from start_frame to self._current_frame"""
         self._selection_start = start_frame
 
     def clear_selection(self):
-        """ stop highlighting selection """
+        """stop highlighting selection"""
         self._selection_start = None
 
     def _get_gap_blocks(self, start, end):
-        """ generate blocks for gaps in the current identity track """
+        """generate blocks for gaps in the current identity track"""
         block_start = 0
         blocks = []
 

--- a/src/jabs/ui/player_widget/player_thread.py
+++ b/src/jabs/ui/player_widget/player_thread.py
@@ -10,8 +10,7 @@ from jabs.video_reader import VideoReader, label_all_identities, label_identity,
 
 
 class PlayerThread(QtCore.QThread):
-    """
-    thread used to grab frames (numpy arrays) from a video stream and convert
+    """thread used to grab frames (numpy arrays) from a video stream and convert
     them to a QImage for display by the frame widget
 
     handles timing to get correct playback speed
@@ -40,16 +39,17 @@ class PlayerThread(QtCore.QThread):
         self._identities = identities if identities is not None else []
 
     def stop_playback(self):
-        """
-        tell run thread to stop playback
-        """
+        """tell run thread to stop playback"""
         self.requestInterruption()
 
     def set_identity(self, identity):
-        """
-        set the active identity
-        :param identity: new selected identity
-        :return: None
+        """set the active identity
+
+        Args:
+            identity: new selected identity
+
+        Returns:
+            None
         """
         self._identity = identity
 
@@ -140,8 +140,7 @@ class PlayerThread(QtCore.QThread):
             self._identities = identities
 
     def run(self):
-        """
-        method to be run as a thread during playback
+        """method to be run as a thread during playback
         handles grabbing the next frame from the buffer, converting to a QImage,
         and sending to the UI component for display.
         """

--- a/src/jabs/ui/player_widget/player_widget.py
+++ b/src/jabs/ui/player_widget/player_widget.py
@@ -8,8 +8,7 @@ from jabs.video_reader import VideoReader
 
 
 class _FrameWidget(QtWidgets.QLabel):
-    """
-    widget that implements a resizable pixmap label, will initialize to the
+    """widget that implements a resizable pixmap label, will initialize to the
     full size of the video frame, but then will be resizable after that
     """
 
@@ -35,8 +34,7 @@ class _FrameWidget(QtWidgets.QLabel):
         QtWidgets.QLabel.mousePressEvent(self, event)
 
     def _frame_xy_to_pixmap_xy(self, x, y):
-        """
-        Convert the given x, y coordinates from _FrameWidget coordinates
+        """Convert the given x, y coordinates from _FrameWidget coordinates
         to pixmap coordinates. Ie which pixel did the user click on?
         We account for image scaling and translation
         """
@@ -59,21 +57,18 @@ class _FrameWidget(QtWidgets.QLabel):
         return x, y
 
     def sizeHint(self):
-        """
-        Override QLabel.sizeHint to give an initial starting size.
-        """
+        """Override QLabel.sizeHint to give an initial starting size."""
         return QtCore.QSize(800, 800)
 
     def reset(self):
-        """ reset state of frame widget  """
+        """reset state of frame widget"""
         self.clear()
         self.setSizePolicy(QtWidgets.QSizePolicy.Expanding,
                            QtWidgets.QSizePolicy.Expanding)
         self.firstFrame = True
 
     def paintEvent(self, event: QPaintEvent):
-        """
-        override the paintEvent() handler to scale the image if the widget is
+        """override the paintEvent() handler to scale the image if the widget is
         resized.
         Don't enable resizing until after  the first frame has been drawn so
         that the widget will be expanded to fit the actual size of the frame.
@@ -123,8 +118,7 @@ class _FrameWidget(QtWidgets.QLabel):
 
 
 class PlayerWidget(QtWidgets.QWidget):
-    """
-    Video Player Widget. Consists of a QLabel to display a frame image, and
+    """Video Player Widget. Consists of a QLabel to display a frame image, and
     basic player controls below the frame (play/pause button, position slider,
     previous/next frame buttons.
 
@@ -252,26 +246,24 @@ class PlayerWidget(QtWidgets.QWidget):
         self.setLayout(player_layout)
 
     def cleanup(self):
-        """
-        cleanup function to stop the player thread if it is running
-        """
+        """cleanup function to stop the player thread if it is running"""
         if self._player_thread is not None:
             self._player_thread.stop_playback()
             self._player_thread.wait()
             self._player_thread = None
 
     def current_frame(self):
-        """ return the current frame """
+        """return the current frame"""
         assert self._video_stream is not None
         return self._position_slider.value()
 
     def num_frames(self):
-        """ get total number of frames in the loaded video  """
+        """get total number of frames in the loaded video"""
         assert self._video_stream is not None
         return self._video_stream.num_frames
 
     def reset(self):
-        """ reset video player """
+        """reset video player"""
         self._video_stream = None
         self._identities = None
         self._pose_est = None
@@ -285,14 +277,12 @@ class PlayerWidget(QtWidgets.QWidget):
         self._frame_widget.reset()
 
     def stream_fps(self):
-        """ get frames per second from loaded video """
+        """get frames per second from loaded video"""
         assert self._video_stream is not None
         return self._video_stream.fps
 
     def show_closest(self, enabled: bool | None = None):
-        """
-        change "show closest" state. Accepts a new boolean value, or toggles
-        """
+        """change "show closest" state. Accepts a new boolean value, or toggles"""
         if enabled is None:
             self._label_closest = not self._label_closest
         else:
@@ -306,8 +296,7 @@ class PlayerWidget(QtWidgets.QWidget):
                 self._seek(self._position_slider.value())
 
     def show_track(self, enabled: bool | None = None):
-        """
-        change "show track" state. Accepts a new boolean value, or toggles
+        """change "show track" state. Accepts a new boolean value, or toggles
         current state if no value given.
         """
         if enabled is None:
@@ -323,8 +312,7 @@ class PlayerWidget(QtWidgets.QWidget):
                 self._seek(self._position_slider.value())
 
     def overlay_pose(self, enabled: bool | None = None):
-        """
-        change "overlay pose" state. Accepts a new boolean value, or toggles
+        """change "overlay pose" state. Accepts a new boolean value, or toggles
         current state if no value given.
         """
         if enabled is None:
@@ -340,8 +328,7 @@ class PlayerWidget(QtWidgets.QWidget):
                 self._seek(self._position_slider.value())
 
     def overlay_segmentation(self, enabled: bool | None = None):
-        """
-        change "overlay segmentation" state. Accepts a new boolean value, or toggles
+        """change "overlay segmentation" state. Accepts a new boolean value, or toggles
         current state if no value given.
         """
         if enabled is None:
@@ -357,8 +344,7 @@ class PlayerWidget(QtWidgets.QWidget):
                 self._seek(self._position_slider.value())
 
     def overlay_landmarks(self, enabled: bool | None = None):
-        """
-        change "overlay landmarks" state. Accepts a new boolean value, or
+        """change "overlay landmarks" state. Accepts a new boolean value, or
         toggles current state if no value given.
         """
         if enabled is None:
@@ -379,10 +365,11 @@ class PlayerWidget(QtWidgets.QWidget):
             self._player_thread.set_identities(self._identities)
 
     def load_video(self, path: Path, pose_est):
-        """
-        load a new video source
-        :param path: path to video file
-        :param pose_est: pose file for this video
+        """load a new video source
+
+        Args:
+            path: path to video file
+            pose_est: pose file for this video
         """
 
         # if we already have a video loaded make sure it is stopped
@@ -420,9 +407,7 @@ class PlayerWidget(QtWidgets.QWidget):
         self._enable_frame_buttons()
 
     def stop(self):
-        """
-        stop playing and reset the play button to its initial state
-        """
+        """stop playing and reset the play button to its initial state"""
         # if we have an active player thread, terminate
         if self._player_thread:
             self._player_thread.stop_playback()
@@ -443,8 +428,7 @@ class PlayerWidget(QtWidgets.QWidget):
         self._update_time_display(position)
 
     def _position_slider_clicked(self):
-        """
-        Click event for position slider.
+        """Click event for position slider.
         Seek to the new position of the slider. If the video is playing we will temporarily stop playback and
         playback will resume when slider is released.
         New frame is displayed with the updated position.
@@ -462,14 +446,11 @@ class PlayerWidget(QtWidgets.QWidget):
         self._seek(pos)
 
     def _position_slider_moved(self):
-        """
-        position slider move event. seek the video to the new frame and display it
-        """
+        """position slider move event. seek the video to the new frame and display it"""
         self._seek(self._position_slider.value())
 
     def _position_slider_release(self):
-        """
-        release event for the position slider.
+        """release event for the position slider.
         The new position gets updated for the final time. If we were playing
         when we clicked the slider then we resume playing after releasing.
         """
@@ -481,8 +462,7 @@ class PlayerWidget(QtWidgets.QWidget):
             self._start_player_thread()
 
     def _next_frame_clicked(self):
-        """
-        handle "clicked" signal for the next frame button. Need to wrap
+        """handle "clicked" signal for the next frame button. Need to wrap
         self.next_frame because it takes an optional parameter and Qt always
         passes a boolean argument to the click signal handler that is
         meaningless unless the button is "checkable"
@@ -490,8 +470,7 @@ class PlayerWidget(QtWidgets.QWidget):
         self.next_frame()
 
     def _previous_frame_clicked(self):
-        """
-        handle "clicked" signal for the previous frame button. Need to wrap
+        """handle "clicked" signal for the previous frame button. Need to wrap
         self.previous_frame because it takes an optional parameter and Qt always
         passes a boolean argument to the click signal handler that is
         meaningless unless the button is "checkable"
@@ -499,8 +478,7 @@ class PlayerWidget(QtWidgets.QWidget):
         self.previous_frame()
 
     def toggle_play(self):
-        """
-        handle clicking on the play/pause button
+        """handle clicking on the play/pause button
 
         don't do anything if a video hasn't been loaded, or if we are seeking
         (user clicks space bar while dagging slider)
@@ -521,9 +499,10 @@ class PlayerWidget(QtWidgets.QWidget):
             self._start_player_thread()
 
     def next_frame(self, frames=1):
-        """
-        advance to the next frame and display it
-        :param frames: optional, number of frames to advance
+        """advance to the next frame and display it
+
+        Args:
+            frames: optional, number of frames to advance
         """
 
         # don't do anything if a video hasn't been loaded or if the video is playing
@@ -541,9 +520,10 @@ class PlayerWidget(QtWidgets.QWidget):
             self._player_thread.seek(new_frame)
 
     def previous_frame(self, frames=1):
-        """
-        go back to the previous frame and display it
-        :param frames: optional number of frames to move back
+        """go back to the previous frame and display it
+
+        Args:
+            frames: optional number of frames to move back
         """
 
         # don't do anything if a video hasn't been loaded or if the video is playing
@@ -560,7 +540,7 @@ class PlayerWidget(QtWidgets.QWidget):
             self._player_thread.seek(new_frame)
 
     def set_active_identity(self, identity):
-        """ set an active identity, which will be labeled in the video """
+        """set an active identity, which will be labeled in the video"""
 
         # don't do anything if a video isn't loaded
         if self._player_thread is None:
@@ -576,31 +556,29 @@ class PlayerWidget(QtWidgets.QWidget):
         return self._frame_widget.pixmap_clicked
 
     def get_identity_mask(self):
-        """
-        get an array that indicates if an identity is present in a given
+        """get an array that indicates if an identity is present in a given
         frame or not for the currently selected identity
-        :return: numpy uint8 array of length num_frames
+
+        Returns:
+            numpy uint8 array of length num_frames
         """
         return self._pose_est.identity_mask(self._active_identity)
 
     def _enable_frame_buttons(self):
-        """
-        enable the previous/next frame buttons
-        """
+        """enable the previous/next frame buttons"""
         self._next_frame_button.setEnabled(True)
         self._previous_frame_button.setEnabled(True)
 
     def _disable_frame_buttons(self):
-        """
-        disable the previous/next frame buttons
-        """
+        """disable the previous/next frame buttons"""
         self._next_frame_button.setEnabled(False)
         self._previous_frame_button.setEnabled(False)
 
     def _update_time_display(self, frame_number):
-        """
-        update the time and current frame labels with current frame
-        :param frame_number: current frame number
+        """update the time and current frame labels with current frame
+
+        Args:
+            frame_number: current frame number
         """
 
         self._frame_label.setText(
@@ -610,9 +588,10 @@ class PlayerWidget(QtWidgets.QWidget):
 
     @QtCore.Slot(dict)
     def _display_image(self, data: dict):
-        """
-        display a new QImage sent from the player thread
-        :param data: dict emitted by player thread
+        """display a new QImage sent from the player thread
+
+        Args:
+            data: dict emitted by player thread
 
         data dict includes QImage to display as next frame as well as the source video
         """
@@ -626,10 +605,11 @@ class PlayerWidget(QtWidgets.QWidget):
 
     @QtCore.Slot(int)
     def _set_position(self, data: dict):
-        """
-        update the value of the position slider to the frame number sent from
+        """update the value of the position slider to the frame number sent from
         the player thread
-        :param frame_number: new value for the progress slider
+
+        Args:
+            frame_number: new value for the progress slider
         """
 
         # ignore events from previous videos that haven't been processed yet
@@ -647,8 +627,6 @@ class PlayerWidget(QtWidgets.QWidget):
         self._update_time_display(frame_number)
 
     def _start_player_thread(self):
-        """
-        start video playback in player thread
-        """
+        """start video playback in player thread"""
         self._player_thread.start()
         self._playing = True

--- a/src/jabs/ui/prediction_vis_widget.py
+++ b/src/jabs/ui/prediction_vis_widget.py
@@ -8,8 +8,7 @@ from .colors import (BEHAVIOR_COLOR, NOT_BEHAVIOR_COLOR, BACKGROUND_COLOR,
 
 
 class PredictionVisWidget(QWidget):
-    """
-    widget used to show predicted class for a range of frames around the
+    """widget used to show predicted class for a range of frames around the
     current frame
     """
 
@@ -53,8 +52,7 @@ class PredictionVisWidget(QWidget):
         self._padding_brush = QBrush(self._BACKGROUND_COLOR, Qt.Dense6Pattern)
 
     def sizeHint(self):
-        """
-        Override QWidget.sizeHint to give an initial starting size.
+        """Override QWidget.sizeHint to give an initial starting size.
         Width hint is not so important because we allow the widget to resize
         horizontally to fill the available container. The height is fixed,
         so the value used here sets the height of the widget.
@@ -67,8 +65,7 @@ class PredictionVisWidget(QWidget):
         self._offset = (self.size().width() - self._adjusted_width) // 2
 
     def paintEvent(self, event):
-        """
-        override QWidget paintEvent
+        """override QWidget paintEvent
 
         This draws the widget.
         """
@@ -142,17 +139,17 @@ class PredictionVisWidget(QWidget):
         qp.end()
 
     def set_predictions(self, predictions, probabilities):
-        """ set prediction data to display """
+        """set prediction data to display"""
         self._predictions = predictions
         self._probabilities = probabilities
         self.update()
 
     def set_current_frame(self, current_frame):
-        """ called to reposition the view around new current frame """
+        """called to reposition the view around new current frame"""
         self._current_frame = current_frame
         # force redraw
         self.repaint()
 
     def set_num_frames(self, num_frames):
-        """ set number of frames in current video, needed to properly render """
+        """set number of frames in current video, needed to properly render"""
         self._num_frames = num_frames

--- a/src/jabs/ui/project_loader_thread.py
+++ b/src/jabs/ui/project_loader_thread.py
@@ -4,8 +4,7 @@ from jabs.project import Project
 
 
 class ProjectLoaderThread (QThread):
-    """
-    JABS Project Loader Thread
+    """JABS Project Loader Thread
 
     This thread is used to load a JABS project in the background so that the main
     GUI thread remains responsive. It emits signals when the project is loaded.
@@ -20,9 +19,7 @@ class ProjectLoaderThread (QThread):
         self._project = None
 
     def run(self):
-        """
-        Run the thread.
-        """
+        """Run the thread."""
         # Open the project, this can take a while
         try:
             self._project = Project(self._project_path)
@@ -34,7 +31,5 @@ class ProjectLoaderThread (QThread):
 
     @property
     def project(self):
-        """
-        Return the loaded project.
-        """
+        """Return the loaded project."""
         return self._project

--- a/src/jabs/ui/timeline_label_widget.py
+++ b/src/jabs/ui/timeline_label_widget.py
@@ -12,8 +12,7 @@ from .colors import (BEHAVIOR_COLOR, NOT_BEHAVIOR_COLOR, BACKGROUND_COLOR,
 
 
 class TimelineLabelWidget(QWidget):
-    """
-    Widget that shows a "zoomed out" overview of labels for the entire video.
+    """Widget that shows a "zoomed out" overview of labels for the entire video.
     Because each pixel along the width ends up representing multiple frames,
     you can't see fine detail, but you can see where manual labels have been
     applied. This can be useful for seeking through the video to a location of
@@ -55,8 +54,7 @@ class TimelineLabelWidget(QWidget):
         self._num_frames = 0
 
     def sizeHint(self):
-        """
-        Override QWidget.sizeHint to give an initial starting size.
+        """Override QWidget.sizeHint to give an initial starting size.
         Width hint is not so important because we allow the widget to resize
         horizontally to fill the available container. The height is fixed,
         so the value used here sets the height of the widget.
@@ -64,8 +62,7 @@ class TimelineLabelWidget(QWidget):
         return QSize(400, self._height)
 
     def resizeEvent(self, event):
-        """
-        handle resize event. Recalculates scaling factors and calls
+        """handle resize event. Recalculates scaling factors and calls
         update_bar() to downsample current label array and rerender the bar
         """
 
@@ -78,7 +75,7 @@ class TimelineLabelWidget(QWidget):
         self._update_bar()
 
     def paintEvent(self, event):
-        """ override QWidget paintEvent """
+        """override QWidget paintEvent"""
 
         # make sure we have something to draw
         if self._pixmap is None or self._bin_size == 0:
@@ -100,19 +97,17 @@ class TimelineLabelWidget(QWidget):
         qp.drawPixmap(0 + self._pixmap_offset, 0, self._pixmap)
 
     def set_labels(self, labels):
-        """ load label track to display """
+        """load label track to display"""
         self._labels = labels
         self.update_labels()
 
     def set_current_frame(self, current_frame):
-        """ called to reposition the view """
+        """called to reposition the view"""
         self._current_frame = current_frame
         self.update()
 
     def set_num_frames(self, num_frames):
-        """
-        sets the number of frames in the current video
-        """
+        """sets the number of frames in the current video"""
         self._num_frames = num_frames
         self._update_scale()
         self._update_bar()
@@ -127,8 +122,7 @@ class TimelineLabelWidget(QWidget):
         self._update_bar()
 
     def _update_bar(self):
-        """
-        Updates the bar pixmap. Downsamples label array with the current size
+        """Updates the bar pixmap. Downsamples label array with the current size
         and updates self._pixmap
         """
 
@@ -174,7 +168,7 @@ class TimelineLabelWidget(QWidget):
         qp.end()
 
     def _update_scale(self):
-        """ update scale factor and bin size """
+        """update scale factor and bin size"""
         width = self.size().width()
 
         pad_size = math.ceil(

--- a/src/jabs/ui/training_thread.py
+++ b/src/jabs/ui/training_thread.py
@@ -7,9 +7,7 @@ from jabs.utils import FINAL_TRAIN_SEED
 
 
 class TrainingThread(QtCore.QThread):
-    """
-    Thread used to run the training to keep the Qt main GUI thread responsive.
-    """
+    """Thread used to run the training to keep the Qt main GUI thread responsive."""
 
     # signal so that the main GUI thread can be notified when the training is
     # complete
@@ -32,8 +30,7 @@ class TrainingThread(QtCore.QThread):
         self._k = k
 
     def run(self):
-        """
-        thread's main function. Will get the feature set for all labeled frames,
+        """thread's main function. Will get the feature set for all labeled frames,
         do the leave one group out train/test split, run the training, run the
         trained classifier on the test data, print some performance metrics,
         and print the most important features

--- a/src/jabs/ui/user_guide_viewer_widget/user_guide_dialog.py
+++ b/src/jabs/ui/user_guide_viewer_widget/user_guide_dialog.py
@@ -8,7 +8,7 @@ from PySide6.QtCore import Qt, QUrl
 
 
 class UserGuideDialog(QDialog):
-    """ dialog that shows html rendering of user guide """
+    """dialog that shows html rendering of user guide"""
 
     _doc_dir = Path(os.path.realpath(__file__)).parent / 'docs'
 

--- a/src/jabs/ui/video_list_widget.py
+++ b/src/jabs/ui/video_list_widget.py
@@ -2,8 +2,7 @@ from PySide6 import QtWidgets, QtCore
 
 
 class _VideoListWidget(QtWidgets.QListWidget):
-    """
-    QListView that has been modified to not allow deselecting current selection
+    """QListView that has been modified to not allow deselecting current selection
     without selecting a new row
     """
     def __init__(self):
@@ -21,7 +20,7 @@ class _VideoListWidget(QtWidgets.QListWidget):
             QtWidgets.QAbstractItemView.NoEditTriggers)
 
     def selectionCommand(self, index, event=None):
-        """ override QListView """
+        """override QListView"""
         selected = self.selectedIndexes()
         if len(selected) == 1 and selected[0].row() == index.row():
             # don't allow "no selection", so ignore clicks on the already
@@ -32,8 +31,7 @@ class _VideoListWidget(QtWidgets.QListWidget):
 
 
 class VideoListDockWidget(QtWidgets.QDockWidget):
-    """
-    dock for listing video files associated with the project.
+    """dock for listing video files associated with the project.
     dock is floating and can
     """
 
@@ -51,13 +49,12 @@ class VideoListDockWidget(QtWidgets.QDockWidget):
         self.file_list.currentItemChanged.connect(self._selection_changed)
 
     def _selection_changed(self, current, previous):
-        """ signal main window that use changed selected video """
+        """signal main window that use changed selected video"""
         if current:
             self.selectionChanged.emit(current.text())
 
     def set_project(self, project):
-        """
-        set currently active project and update list contents with videos
+        """set currently active project and update list contents with videos
         from new active project
         """
         self._project = project

--- a/src/jabs/utils/utilities.py
+++ b/src/jabs/utils/utilities.py
@@ -52,18 +52,21 @@ def smooth(vec, smoothing_window):
 
 
 def n_choose_r(n, r):
-    """
-    compute number of unique selections (disregarding order) of r items from
+    """compute number of unique selections (disregarding order) of r items from
     a set of n items
-    :param n: number of elements to select from
-    :param r: number of elements to select
-    :return: total number of combinations disregarding order
+
+    Args:
+        n: number of elements to select from
+        r: number of elements to select
+
+    Returns:
+        total number of combinations disregarding order
     """
     return math.factorial(n) // (math.factorial(r) * math.factorial(n - r))
 
 
 def hash_file(file: Path):
-    """ return hash """
+    """return hash"""
     chunk_size = 8192
     with file.open('rb') as f:
         h = hashlib.blake2b(digest_size=20)
@@ -75,13 +78,15 @@ def hash_file(file: Path):
 
 
 def get_bool_env_var(var_name, default_value=False) -> bool:
-    """
-    Gets a boolean value from an environment variable.
+    """Gets a boolean value from an environment variable.
 
-    :param var_name: The name of the environment variable.
-    :param default_value: The default value to return if the variable is not set or invalid.
+    Args:
+        var_name: The name of the environment variable.
+        default_value: The default value to return if the variable is
+            not set or invalid.
 
-    :return: A boolean value.
+    Returns:
+        A boolean value.
     """
 
     value = os.getenv(var_name)

--- a/src/jabs/version/__init__.py
+++ b/src/jabs/version/__init__.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 
 def version_str():
-    """ return version string using the version specified in the pyproject.toml file """
+    """return version string using the version specified in the pyproject.toml file"""
     try:
         # if the jabs package is installed, return version from package metadata
         return importlib.metadata.version("jabs-behavior-classifier")

--- a/src/jabs/video_reader/frame_annotation.py
+++ b/src/jabs/video_reader/frame_annotation.py
@@ -37,12 +37,16 @@ __CONNECTED_SEGMENTS = [
 
 
 def __gen_line_fragments(exclude_points: np.ndarray):
-    """
-    generate line fragments from the connected segments. will break up
+    """generate line fragments from the connected segments. will break up
     segments if a point within the segment is excluded, or will remove the
     segment completely if it does not have at least two points
-    :param exclude_points: list of points to exclude when generating segments
-    :return: yields lists of Keypoint indexes that make up the segments to draw
+
+    Args:
+        exclude_points: list of points to exclude when generating
+            segments
+
+    Returns:
+        yields lists of Keypoint indexes that make up the segments to draw
     """
     curr_fragment = []
     for curr_pt_indexes in __CONNECTED_SEGMENTS:
@@ -65,15 +69,17 @@ def label_identity(
     frame_index: int,
     color: tuple[int] = _ID_COLOR,
 ):
-    """
-    label the identity on an image
-    :param img: image to label
-    :param pose_est: pose estimations for this video
-    :param identity: identity to label
-    :param frame_index: index of frame to label
-    :param color: color to use for label
-    If point = None, use center of mass.
-    :return: None
+    """label the identity on an image
+
+    Args:
+        img: image to label
+        pose_est: pose estimations for this video
+        identity: identity to label
+        frame_index: index of frame to label
+        color: color to use for label
+
+    Returns:
+        None
     """
 
     shape = pose_est.get_identity_convex_hulls(identity)[frame_index]
@@ -94,14 +100,17 @@ def label_all_identities(
     frame_index: int,
     subject: int | None = None,
 ):
-    """
-    label all the identities in the frame
-    :param img: image to draw the labels on
-    :param pose_est: pose estimations for this video
-    :param identities: list of identity names
-    :param frame_index: index of frame, used to get all poses for frame
-    :param subject: identity to label as 'subject'
-    :return: None
+    """label all the identities in the frame
+
+    Args:
+        img: image to draw the labels on
+        pose_est: pose estimations for this video
+        identities: list of identity names
+        frame_index: index of frame, used to get all poses for frame
+        subject: identity to label as 'subject'
+
+    Returns:
+        None
     """
 
     for identity in identities:
@@ -138,19 +147,17 @@ def draw_track(
     past_points: int = 5,
     point_index=PoseEstimation.KeypointIndex.NOSE,
 ):
-    """
-    draw a track for a specified identity
+    """draw a track for a specified identity
 
-    :param img: image to draw track on
-    :param pose_est: pose estimations for this video
-    :param identity: subject identity
-    :param frame_index: index of the current frame
-    :param future_points: number of frames after current frame to use
-    for drawing the track
-    :param past_points: number of frames before current frame to use for
-    drawing the track
-    :param point_index: index of pose key point to use for drawing track,
-    if None use center of mass rather than a point. default to nose
+    Args:
+        img: image to draw track on
+        pose_est: pose estimations for this video
+        identity: subject identity
+        frame_index: index of the current frame
+        future_points: number of frames after current frame to use for drawing the track
+        past_points: number of frames before current frame to use for drawing the track
+        point_index: index of pose key point to use for drawing track,
+            if None use center of mass rather than a point. default to nose
     """
 
     slice_start = max(frame_index - past_points, 0)
@@ -221,12 +228,11 @@ def overlay_pose(
     img: np.ndarray, points: np.ndarray, mask: np.ndarray, color=(255, 255, 255)
 ):
     """
-
-    :param img:
-    :param points:
-    :param mask:
-    :param color:
-    :return:
+    Args:
+        img
+        points
+        mask
+        color
     """
 
     if points is None:
@@ -268,11 +274,13 @@ def overlay_pose(
 
 
 def trim_seg(arr: np.ndarray) -> np.ndarray | None:
-    """
-    Trims a single contour.  Returns an opencv-complaint contour (dtype = int).
+    """Trims a single contour.  Returns an opencv-complaint contour (dtype = int).
 
-    :param arr: A numpy array with contour data.
-    :return: np.ndarray
+    Args:
+        arr: A numpy array with contour data.
+
+    Returns:
+        np.ndarray
     """
     assert arr.ndim == 2
     return_arr = arr[np.all(arr != -1, axis=1), :]
@@ -282,11 +290,13 @@ def trim_seg(arr: np.ndarray) -> np.ndarray | None:
 
 
 def trim_seg_list(arr: np.ndarray) -> List:
-    """
-    Trims all contours for an individual.
+    """Trims all contours for an individual.
 
-    :param arr: A numpy array with contour data.
-    :return: List
+    Args:
+        arr: A numpy array with contour data.
+
+    Returns:
+        List
     """
     assert arr.ndim == 3
     return [trim_seg(x) for x in arr if np.any(x != -1)]
@@ -295,13 +305,16 @@ def trim_seg_list(arr: np.ndarray) -> List:
 def draw_all_contours(
     img: np.ndarray, seg_data: np.ndarray, color: Tuple[int, int, int]
 ):
-    """
-    Draw all contours given data for a particular mouse in a particular video frame.
+    """Draw all contours given data for a particular mouse in a particular video frame.
 
-    :param img: The current video frame.
-    :param seg_data: This will be the segmentation for a particular frame and indentity.
-    :param color: color of segmentation contours rendered on the GUI.
-    :return: None
+    Args:
+        img: The current video frame.
+        seg_data: This will be the segmentation for a particular frame
+            and identity.
+        color: color of segmentation contours rendered on the GUI.
+
+    Returns:
+        None
     """
     trimmed_contours = trim_seg_list(seg_data)
     cv2.drawContours(img, trimmed_contours, -1, color, 2)
@@ -311,11 +324,16 @@ def overlay_segmentation(
     img: np.ndarray, pose_est: PoseEstimationV6, identity: int, frame_index: int
 ):
     """
-    :param img: The current video frame.
-    :param pose_est: This will be a pose estimation object >= v6.
-    :param identity: This integer identifies which mouse the segmentation will be applied to.
-    :param frame_index: This integer identifies the current video frame index.
-    :return: None
+    Args:
+        img: The current video frame.
+        pose_est: This will be a pose estimation object >= v6.
+        identity: This integer identifies which mouse the segmentation
+            will be applied to.
+        frame_index: This integer identifies the current video frame
+            index.
+
+    Returns:
+        None
     """
     # No segmentation data to display
     if pose_est.format_major_version < 6:
@@ -388,8 +406,7 @@ def overlay_landmarks(img: np.ndarray, pose_est: PoseEstimation):
 
 
 def __scale_annotation_size(img: np.ndarray, size: int | float) -> int | float:
-    """
-    Scale the size of the landmark markers based on the size of the image. 800x800 is the video size
+    """Scale the size of the landmark markers based on the size of the image. 800x800 is the video size
     jabs was developed with, so we use that as a reference.
     """
     if type(size) == int:

--- a/src/jabs/video_reader/utilities.py
+++ b/src/jabs/video_reader/utilities.py
@@ -2,12 +2,14 @@ import cv2
 
 
 def get_frame_count(video_path: str):
-    """
-    Get the number of frames in a video file. Raises an IOError if unable to
+    """Get the number of frames in a video file. Raises an IOError if unable to
     open the video specified
-    :param video_path: string containing path to video file
-    :return: Integer number of frames in video.
-    :raises: IOError if unable to open video file
+
+    Args:
+        video_path: string containing path to video file
+
+    Returns:
+        Integer number of frames in video.
     """
     # open video file
     stream = cv2.VideoCapture(video_path)

--- a/src/jabs/video_reader/video_reader.py
+++ b/src/jabs/video_reader/video_reader.py
@@ -5,8 +5,7 @@ import cv2
 
 
 class VideoReader:
-    """
-    VideoReader.
+    """VideoReader.
 
     Uses OpenCV to open a video file and read frames.
     """
@@ -15,9 +14,8 @@ class VideoReader:
 
     def __init__(self, path: Path):
         """
-
-        :param path: path to video file
-        :raises: IOError if unable to open video file
+        Args:
+            path: path to video file
         """
         # open video file
         self.stream = cv2.VideoCapture(str(path))
@@ -41,32 +39,31 @@ class VideoReader:
 
     @property
     def num_frames(self):
-        """ get total number of frames in the video """
+        """get total number of frames in the video"""
         return self._num_frames
 
     @property
     def fps(self):
-        """ get frames per second from video """
+        """get frames per second from video"""
         return self._fps
 
     @property
     def dimensions(self):
-        """ return width, height of video frames """
+        """return width, height of video frames"""
         return self._width, self._height
 
     @property
     def filename(self):
-        """ return the name of the video file """
+        """return the name of the video file"""
         return self._filename
 
     def get_frame_time(self, frame_number):
-        """ return a formatted string of the time of a given frame """
+        """return a formatted string of the time of a given frame"""
         return time.strftime('%H:%M:%S',
                              time.gmtime(frame_number * self._duration))
 
     def seek(self, index):
-        """
-        Seek to a specific frame.
+        """Seek to a specific frame.
         This will clear the buffer and insert the frame at the new position.
 
         NOTE:
@@ -78,7 +75,7 @@ class VideoReader:
             self._frame_index = index
 
     def load_next_frame(self) -> dict:
-        """ grab the next frame from the file """
+        """grab the next frame from the file"""
         (grabbed, frame) = self.stream.read()
         if grabbed:
 
@@ -94,17 +91,19 @@ class VideoReader:
 
     @staticmethod
     def _resize_image(image, width=None, height=None, interpolation=None):
-        """
-        resize an image, allow passing only desired width or height to
+        """resize an image, allow passing only desired width or height to
         maintain current aspect ratio
 
-        :param image: image to resize
-        :param width: new width, if None compute to maintain aspect ratio
-        :param height: new height, if None compute to maintain aspect ratio
-        :param interpolation: type of interpolation to use for resize. If None,
-        we will default to cv2.INTER_AREA for shrinking cv2.INTER_CUBIC when
-        expanding
-        :return: resized image
+        Args:
+            image: image to resize
+            width: new width, if None compute to maintain aspect ratio
+            height: new height, if None compute to maintain aspect ratio
+            interpolation: type of interpolation to use for resize. If
+                None, we will default to cv2.INTER_AREA for shrinking cv2.INTER_CUBIC when
+                expanding
+
+        Returns:
+            resized image
         """
         # current size
         (h, w) = image.shape[:2]


### PR DESCRIPTION
the Kumar Lab is standardizing on google format for Python docstrings 

most of the existing code base used re-Structured Text (for formatted docstrings, many docstrings are just an unstructured string comment)

This pull request uses the docconvert package to automatically reformat docstrings. 

The auto formatter might have gotten a few things wrong for docstrings that were almost but not quite re-Structured Text, but we'll correct those as we find them. 
