### PR TITLE
enable k-fold cross validation slider when project is loaded

### DIFF
--- a/src/jabs/ui/central_widget.py
+++ b/src/jabs/ui/central_widget.py
@@ -160,6 +160,7 @@ class CentralWidget(QtWidgets.QWidget):
         self._loaded_video = None
 
         self._controls.update_project_settings(project.settings)
+        self._controls.kslider_set_enabled(True)
 
     def load_video(self, path):
         """load a new video file into self._player_widget


### PR DESCRIPTION
closes #113 

This change enables the cross validation k slider once a project is loaded.

Before project loaded:
![image](https://github.com/user-attachments/assets/eb29a092-ddd2-4907-ac1f-c551cc5bb658)

After project loaded:
![image](https://github.com/user-attachments/assets/9cde1945-b91d-4043-bafa-ac8226bce280)


Note, adjusting the slider value changes the labeling threshold for enabling the train button

Train button is enabled with k-1:
![image](https://github.com/user-attachments/assets/e472e04b-3d55-41be-9170-b7d77aa8bd26)

Setting k to a higher value disables the Train button because the threshold is higher:
![image](https://github.com/user-attachments/assets/ed98d263-cd98-4b68-8c04-7900c2c3bd41)

