### PR TITLE
fix ruff check errors

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -20,6 +20,8 @@ lint.ignore = [
     "D415",  # ignore doc punctuation
 ]
 
+target-version = "py310"
+
 [lint.pydocstyle]
 convention = "google"
 

--- a/src/jabs/__init__.py
+++ b/src/jabs/__init__.py
@@ -1,0 +1,1 @@
+"""JABS Behavior Classifier"""

--- a/src/jabs/types/__init__.py
+++ b/src/jabs/types/__init__.py
@@ -1,2 +1,4 @@
+"""Module for defining enums used in JABS"""
+
 from .classifier_types import ClassifierType
 from .units import ProjectDistanceUnit

--- a/src/jabs/types/classifier_types.py
+++ b/src/jabs/types/classifier_types.py
@@ -2,6 +2,8 @@ from enum import IntEnum
 
 
 class ClassifierType(IntEnum):
+    """Classifier type for the project."""
+
     RANDOM_FOREST = 1
     GRADIENT_BOOSTING = 2
     XGBOOST = 3

--- a/src/jabs/types/units.py
+++ b/src/jabs/types/units.py
@@ -2,5 +2,7 @@ import enum
 
 
 class ProjectDistanceUnit(enum.IntEnum):
+    """Distance unit for the project."""
+
     PIXEL = 0
     CM = 1

--- a/src/jabs/utils/__init__.py
+++ b/src/jabs/utils/__init__.py
@@ -1,3 +1,5 @@
+"""JABS utilities"""
+
 from .utilities import get_bool_env_var, hash_file, hide_stderr
 
 # a hard coded random seed used for the final training done with all
@@ -6,8 +8,8 @@ from .utilities import get_bool_env_var, hash_file, hide_stderr
 FINAL_TRAIN_SEED = 0xAB3BDB
 
 __all__ = [
+    "FINAL_TRAIN_SEED",
     "get_bool_env_var",
     "hash_file",
     "hide_stderr",
-    "FINAL_TRAIN_SEED",
 ]

--- a/src/jabs/utils/sampleposeintervals.py
+++ b/src/jabs/utils/sampleposeintervals.py
@@ -1,8 +1,9 @@
 import argparse
-import cv2
-import h5py
 import os
 import random
+
+import cv2
+import h5py
 
 # Command line example of using this script:
 #
@@ -67,6 +68,7 @@ import random
 
 
 def main():
+    """sample pose intervals"""
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
@@ -151,10 +153,7 @@ def main():
                     last_candidate_frame = frame_count - args.out_frame_count
                     if last_candidate_frame <= 0:
                         print(
-                            "WARNING: {} skipped because it only contains {} frames".format(
-                                vid_filename,
-                                frame_count,
-                            )
+                            f"WARNING: {vid_filename} skipped because it only contains {frame_count} frames"
                         )
                         continue
 
@@ -243,15 +242,13 @@ def main():
                         try:
                             cap = cv2.VideoCapture(vid_path)
                             if not cap.isOpened():
-                                print("WARNING: failed to open {}".format(vid_filename))
+                                print(f"WARNING: failed to open {vid_filename}")
                                 continue
 
                             cap.set(cv2.CAP_PROP_POS_FRAMES, out_start_frame_index)
                             if not cap.isOpened():
                                 print(
-                                    "WARNING: failed to seek to start frame {}".format(
-                                        vid_filename
-                                    )
+                                    f"WARNING: failed to seek to start frame {vid_filename}"
                                 )
                                 continue
 
@@ -266,22 +263,14 @@ def main():
                             )
                             for _ in range(args.out_frame_count):
                                 if not cap.isOpened():
-                                    print(
-                                        "WARNING: {} ended prematurely".format(
-                                            vid_filename
-                                        )
-                                    )
+                                    print(f"WARNING: {vid_filename} ended prematurely")
                                     break
 
                                 ret, frame = cap.read()
                                 if ret:
                                     writer.write(frame)
                                 else:
-                                    print(
-                                        "WARNING: {} ended prematurely".format(
-                                            vid_filename
-                                        )
-                                    )
+                                    print(f"WARNING: {vid_filename} ended prematurely")
                                     break
 
                         finally:

--- a/src/jabs/utils/utilities.py
+++ b/src/jabs/utils/utilities.py
@@ -9,7 +9,15 @@ import numpy as np
 
 
 @contextmanager
-def hide_stderr():
+def hide_stderr() -> int:
+    """Context manager to temporarily suppress output to standard error (stderr).
+
+    Redirects all output sent to stderr to os.devnull while the context is active,
+    restoring stderr to its original state upon exit.
+
+    Yields:
+        int: The file descriptor for stderr.
+    """
     fd = sys.stderr.fileno()
 
     # copy fd before it is overwritten
@@ -28,12 +36,43 @@ def hide_stderr():
 
 
 def rolling_window(a, window, step_size=1):
+    """Creates a rolling window view of a 1D numpy array.
+
+    Generates a view of the input array with overlapping windows of the specified size,
+    optionally with a custom step size between windows.
+
+    Args:
+        a (np.ndarray): Input 1D array.
+        window (int): Size of each rolling window.
+        step_size (int, optional): Step size between windows. Defaults to 1.
+
+    Returns:
+        np.ndarray: A 2D array where each row is a windowed view of the input.
+
+    Raises:
+        ValueError: If the window size is larger than the input array.
+    """
     shape = a.shape[:-1] + (a.shape[-1] - window + 1 - step_size + 1, window)
-    strides = a.strides + (a.strides[-1] * step_size,)
+    strides = (*a.strides, a.strides[-1] * step_size)
     return np.lib.stride_tricks.as_strided(a, shape=shape, strides=strides)
 
 
 def smooth(vec, smoothing_window):
+    """Smooths a 1D numpy array using a moving average with edge padding.
+
+    Pads the input vector at both ends with its edge values, then applies a moving average
+    of the specified window size. The window size must be odd.
+
+    Args:
+        vec (np.ndarray): Input 1D array to smooth.
+        smoothing_window (int): Size of the moving average window (must be odd).
+
+    Returns:
+        np.ndarray: Smoothed array as float values.
+
+    Raises:
+        AssertionError: If `smoothing_window` is not odd.
+    """
     if smoothing_window <= 1 or len(vec) == 0:
         return vec.astype(np.float)
     else:
@@ -54,8 +93,7 @@ def smooth(vec, smoothing_window):
 
 
 def n_choose_r(n, r):
-    """compute number of unique selections (disregarding order) of r items from
-    a set of n items
+    """compute number of unique selections (disregarding order) of r items from a set of n items
 
     Args:
         n: number of elements to select from
@@ -90,7 +128,6 @@ def get_bool_env_var(var_name, default_value=False) -> bool:
     Returns:
         A boolean value.
     """
-
     value = os.getenv(var_name)
     if value is None:
         return default_value

--- a/src/jabs/version/__init__.py
+++ b/src/jabs/version/__init__.py
@@ -1,6 +1,9 @@
+"""jabs version"""
+
 import importlib.metadata
-import toml
 from pathlib import Path
+
+import toml
 
 
 def version_str():

--- a/src/jabs/video_reader/__init__.py
+++ b/src/jabs/video_reader/__init__.py
@@ -1,19 +1,25 @@
+"""video reader
+
+This package handles reading frames from a video file as well as applying various
+annotations (such as idenity or pose overlay)
+"""
+
 from .frame_annotation import (
-    label_identity,
-    label_all_identities,
     draw_track,
-    overlay_pose,
+    label_all_identities,
+    label_identity,
     overlay_landmarks,
+    overlay_pose,
     overlay_segmentation,
 )
 from .video_reader import VideoReader
 
 __all__ = [
     "VideoReader",
-    "label_identity",
-    "label_all_identities",
     "draw_track",
-    "overlay_pose",
+    "label_all_identities",
+    "label_identity",
     "overlay_landmarks",
+    "overlay_pose",
     "overlay_segmentation",
 ]

--- a/src/jabs/video_reader/frame_annotation.py
+++ b/src/jabs/video_reader/frame_annotation.py
@@ -264,7 +264,7 @@ def overlay_pose(
         )
 
     # draw points at each keypoint of the pose (if it exists at this frame)
-    for point, point_mask in zip(points, mask):
+    for point, point_mask in zip(points, mask, strict=True):
         if point_mask:
             cv2.circle(
                 img,

--- a/src/jabs/video_reader/frame_annotation.py
+++ b/src/jabs/video_reader/frame_annotation.py
@@ -1,6 +1,6 @@
 import cv2
 import numpy as np
-from typing import Tuple, List
+
 from jabs.pose_estimation import PoseEstimation, PoseEstimationV6
 
 _ID_COLOR = (215, 222, 0)
@@ -37,9 +37,10 @@ __CONNECTED_SEGMENTS = [
 
 
 def __gen_line_fragments(exclude_points: np.ndarray):
-    """generate line fragments from the connected segments. will break up
-    segments if a point within the segment is excluded, or will remove the
-    segment completely if it does not have at least two points
+    """generate line fragments from the connected segments.
+
+    This will break up segments if a point within the segment is excluded,
+    or will remove the segment completely if it does not have at least two points
 
     Args:
         exclude_points: list of points to exclude when generating
@@ -81,7 +82,6 @@ def label_identity(
     Returns:
         None
     """
-
     shape = pose_est.get_identity_convex_hulls(identity)[frame_index]
 
     if shape is not None:
@@ -117,17 +117,12 @@ def label_all_identities(
     Returns:
         None
     """
-
     for identity in identities:
         shape = pose_est.get_identity_convex_hulls(identity)[frame_index]
         if shape is not None:
             center = shape.centroid
 
-            if identity == subject:
-                color = _ACTIVE_COLOR
-            else:
-                color = _ID_COLOR
-
+            color = _ACTIVE_COLOR if identity == subject else _ID_COLOR
             label = (
                 str(identity)
                 if not pose_est.external_identities
@@ -168,7 +163,6 @@ def draw_track(
         point_index: index of pose key point to use for drawing track,
             if None use center of mass rather than a point. default to nose
     """
-
     slice_start = max(frame_index - past_points, 0)
 
     if point_index is None:
@@ -236,14 +230,14 @@ def draw_track(
 def overlay_pose(
     img: np.ndarray, points: np.ndarray, mask: np.ndarray, color=(255, 255, 255)
 ):
-    """
-    Args:
-        img
-        points
-        mask
-        color
-    """
+    """Overlay pose on a frame.
 
+    Args:
+        img: frame image
+        points: pose points to overlay
+        mask: points mask to indicate which points are valid
+        color: color for overlay, defaults to white
+    """
     if points is None:
         return
 
@@ -298,21 +292,21 @@ def trim_seg(arr: np.ndarray) -> np.ndarray | None:
     return None
 
 
-def trim_seg_list(arr: np.ndarray) -> List:
+def trim_seg_list(arr: np.ndarray) -> list:
     """Trims all contours for an individual.
 
     Args:
         arr: A numpy array with contour data.
 
     Returns:
-        List
+        list
     """
     assert arr.ndim == 3
     return [trim_seg(x) for x in arr if np.any(x != -1)]
 
 
 def draw_all_contours(
-    img: np.ndarray, seg_data: np.ndarray, color: Tuple[int, int, int]
+    img: np.ndarray, seg_data: np.ndarray, color: tuple[int, int, int]
 ):
     """Draw all contours given data for a particular mouse in a particular video frame.
 
@@ -332,7 +326,8 @@ def draw_all_contours(
 def overlay_segmentation(
     img: np.ndarray, pose_est: PoseEstimationV6, identity: int, frame_index: int
 ):
-    """
+    """overlay the segmentation on a frame fo ra given identity
+
     Args:
         img: The current video frame.
         pose_est: This will be a pose estimation object >= v6.
@@ -358,6 +353,7 @@ def overlay_segmentation(
 
 
 def overlay_landmarks(img: np.ndarray, pose_est: PoseEstimation):
+    """overlay landmarks on a frame"""
     static_objects = pose_est.static_objects
 
     # label arena corners if they were included in the pose file
@@ -415,13 +411,18 @@ def overlay_landmarks(img: np.ndarray, pose_est: PoseEstimation):
 
 
 def __scale_annotation_size(img: np.ndarray, size: int | float) -> int | float:
-    """Scale the size of the landmark markers based on the size of the image. 800x800 is the video size
-    jabs was developed with, so we use that as a reference.
+    """Scale the size of the landmark markers based on the size of the image.
+
+    800x800 is the video size jabs was developed with, so we use that as a reference
+
+    Args:
+        img: image
+        size: unscaled size
     """
-    if type(size) == int:
+    if type(size) is int:
         # scale an integer size, add half of the baseline image size so it effectively rounds up
         return (img.shape[0] + 400) // 800 * size
-    elif type(size) == float:
+    elif type(size) is float:
         return img.shape[0] / 800.0 * size
     else:
         raise ValueError("size must be int or float")

--- a/src/jabs/video_reader/utilities.py
+++ b/src/jabs/video_reader/utilities.py
@@ -2,27 +2,30 @@ import cv2
 
 
 def get_frame_count(video_path: str):
-    """Get the number of frames in a video file. Raises an IOError if unable to
-    open the video specified
+    """Get the number of frames in a video file.
 
     Args:
         video_path: string containing path to video file
 
     Returns:
         Integer number of frames in video.
+
+    Raises:
+        OSError: if unable to open specified video
     """
     # open video file
     stream = cv2.VideoCapture(video_path)
     if not stream.isOpened():
-        raise IOError(f"unable to open {video_path}")
+        raise OSError(f"unable to open {video_path}")
 
     return int(stream.get(cv2.CAP_PROP_FRAME_COUNT))
 
 
 def get_fps(video_path: str):
+    """get the frames per second from a video file"""
     # open video file
     stream = cv2.VideoCapture(video_path)
     if not stream.isOpened():
-        raise IOError(f"unable to open {video_path}")
+        raise OSError(f"unable to open {video_path}")
 
     return stream.get(cv2.CAP_PROP_FPS)

--- a/src/jabs/video_reader/video_reader.py
+++ b/src/jabs/video_reader/video_reader.py
@@ -1,4 +1,5 @@
 import time
+import typing
 from pathlib import Path
 
 import cv2
@@ -10,17 +11,18 @@ class VideoReader:
     Uses OpenCV to open a video file and read frames.
     """
 
-    _EOF = {"data": None, "index": -1}
+    _EOF: typing.ClassVar[dict] = {"data": None, "index": -1}
 
     def __init__(self, path: Path):
-        """
+        """Initialize a VideoReader object.
+
         Args:
             path: path to video file
         """
         # open video file
         self.stream = cv2.VideoCapture(str(path))
         if not self.stream.isOpened():
-            raise IOError(f"unable to open {path}")
+            raise OSError(f"unable to open {path}")
 
         self._frame_index = 0
         self._num_frames = int(self.stream.get(cv2.CAP_PROP_FRAME_COUNT))
@@ -63,9 +65,10 @@ class VideoReader:
 
     def seek(self, index):
         """Seek to a specific frame.
+
         This will clear the buffer and insert the frame at the new position.
 
-        NOTE:
+        Note:
             some video formats might not be able to seek to an exact frame
             position so this could be slow in those cases. Our avi files have
             reasonable seek times.
@@ -89,8 +92,7 @@ class VideoReader:
 
     @staticmethod
     def _resize_image(image, width=None, height=None, interpolation=None):
-        """resize an image, allow passing only desired width or height to
-        maintain current aspect ratio
+        """resize an image, allow passing only desired width or height to maintain current aspect ratio
 
         Args:
             image: image to resize
@@ -127,12 +129,7 @@ class VideoReader:
             dim = (width, height)
 
         if interpolation is None:
-            if dim[0] * dim[1] < w * h:
-                # new image size is larger than the original, default to
-                # INTER_AREA
-                inter = cv2.INTER_AREA
-            else:
-                inter = cv2.INTER_CUBIC
+            inter = cv2.INTER_AREA if dim[0] * dim[1] < w * h else cv2.INTER_CUBIC
         else:
             inter = interpolation
 
@@ -144,9 +141,10 @@ class VideoReader:
 
     @classmethod
     def get_nframes_from_file(cls, path: Path):
+        """get the number of frames by inspecting the video file"""
         # open video file
         stream = cv2.VideoCapture(str(path))
         if not stream.isOpened():
-            raise IOError(f"unable to open {path}")
+            raise OSError(f"unable to open {path}")
 
         return int(stream.get(cv2.CAP_PROP_FRAME_COUNT))


### PR DESCRIPTION
first round of ruff linter error fixes

src/jabs/utils
src/jabs/version
src/jabs/video_reader
src/jabs/types


also sets target version to py310 since we want to ensure code is compatible with Python 3.10 or greater. Older versions are no longer supported. 