### PR TITLE
fix ruff check errors in src/jabs/project

### DIFF
--- a/src/jabs/project/__init__.py
+++ b/src/jabs/project/__init__.py
@@ -1,5 +1,7 @@
+"""jabs project module"""
+
+from .export_training import export_training_data
+from .project import Project
+from .read_training import load_training_data
 from .track_labels import TrackLabels
 from .video_labels import VideoLabels
-from .project import Project
-from .export_training import export_training_data
-from .read_training import load_training_data

--- a/src/jabs/project/export_training.py
+++ b/src/jabs/project/export_training.py
@@ -1,14 +1,8 @@
-"""TODO: change exported training data from a single h5 file with pre-computed
-features to a bundle of pose files, labels, and list of features used for
-the classifier
-"""
-
-import h5py
-import typing
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
 from typing import TYPE_CHECKING
 
+import h5py
 import numpy as np
 
 import jabs.feature_extraction
@@ -29,31 +23,30 @@ def export_training_data(
     pose_version: int,
     classifier_type: "ClassifierType",
     training_seed: int,
-    out_file: typing.Optional[Path] = None,
+    out_file: Path | None = None,
 ):
-    """export training data from a project in a format that can be used to
-    retrain a classifier elsewhere (for example, by the command line batch
-    tool)
+    """
+    Export labeled training data from a JABS project for classifier retraining.
 
-    writes exported data to the project directory
+    This function extracts features and labels for a specified behavior and writes them,
+    along with relevant project and classifier metadata, to an HDF5 file. The exported
+    file can be used for retraining classifiers outside the current environment.
 
     Args:
-        project: Project from which to export training data
-        behavior: Behavior to export
-        pose_version: Minimum required pose version for this classifier
-        classifier_type: Preferred classifier type
-        training_seed: random seed to use for training to get
-            reproducable results
-        out_file: optional output path, if None write to project dir
-            with a file name of the form {behavior}_training_YYYYMMDD_hhmmss.h5
+        project (Project): The JABS project to export data from.
+        behavior (str): Name of the behavior to export.
+        pose_version (int): Minimum required pose version for the classifier.
+        classifier_type (ClassifierType): The classifier type for which data is exported.
+        training_seed (int): Random seed to ensure reproducible training splits.
+        out_file (Path, optional): Output file path. If None, a file is created in the
+            project directory with a timestamped name.
 
     Returns:
-        path of output file
+        Path: The path to the exported HDF5 file.
 
     Raises:
-        OSError if unable to create output file (e.g. permission denied, no such file or directory, etc)
+        OSError: If the output file cannot be created or written.
     """
-
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
     features, group_mapping = project.get_labeled_features(behavior)
 
@@ -98,7 +91,7 @@ def export_training_data(
 
 
 def write_project_settings(
-    h5_file: typing.Union[h5py.File, h5py.Group], settings: dict, node: str = "settings"
+    h5_file: h5py.File | h5py.Group, settings: dict, node: str = "settings"
 ):
     """write project settings to a training h5 file recursively
 

--- a/src/jabs/project/feature_manager.py
+++ b/src/jabs/project/feature_manager.py
@@ -7,17 +7,20 @@ from jabs.pose_estimation import (
     get_static_objects_in_file,
 )
 from jabs.types import ProjectDistanceUnit
+
 from .project_paths import ProjectPaths
 
 
 class FeatureManager:
-    """Class to manage task of determining which features are supported by an instance
-    of a Project and storing this information so it can be accessed as necessary.
+    """Manages feature support and metadata for a JABS project.
 
-    Looks at the pose version and static objects in the project to
-    determine the common set of features supported (for example, if one pose files
-    has social features and another does not, then those features will be disabled
-    for the project).
+    Determines which features are available for a project by analyzing pose file versions
+    and static objects across all videos. Provides access to feature availability, distance
+    units, and extended feature support, ensuring consistency across the project.
+
+    Args:
+        project_paths (ProjectPaths): Paths object for the project.
+        videos (list[str]): List of video filenames in the project.
     """
 
     def __init__(self, project_paths: ProjectPaths, videos: list[str]):
@@ -30,10 +33,10 @@ class FeatureManager:
 
         # determine if this project can use social features or not
         # social data is available for V3+
-        self._can_use_social = True if self._min_pose_version >= 3 else False
+        self._can_use_social = self._min_pose_version >= 3
 
         # segmentation data is available for V6+
-        self._can_use_segmentation = True if self._min_pose_version >= 6 else False
+        self._can_use_segmentation = self._min_pose_version >= 6
 
         self._extended_features = self.__initialize_extended_features()
 
@@ -146,10 +149,11 @@ class FeatureManager:
 
     @property
     def static_objects(self) -> set[str]:
-        """Get the set of static objects in the project. This set contains all the static
-        objects that are present in all pose files in the project.
+        """Get the set of static objects in the project.
+
+        This set contains all the static objects that are present in all pose files in the project.
 
         Returns:
-            Set of static objects.
+            Set of static object names.
         """
         return self._static_objects

--- a/src/jabs/project/project_utils.py
+++ b/src/jabs/project/project_utils.py
@@ -1,7 +1,5 @@
 import re
 
-import h5py
-
 
 def to_safe_name(behavior: str) -> str:
     """Create a version of the given behavior name that should be safe to use in filenames.
@@ -15,7 +13,6 @@ def to_safe_name(behavior: str) -> str:
     Raises:
         ValueError: if the behavior name is empty after sanitization
     """
-
     safe_behavior = re.sub(r"[^\w.-]+", "_", behavior, flags=re.UNICODE)
     # get rid of consecutive underscores
     safe_behavior = re.sub("_{2,}", "_", safe_behavior)

--- a/src/jabs/project/read_training.py
+++ b/src/jabs/project/read_training.py
@@ -1,9 +1,9 @@
 from pathlib import Path
+
 import h5py
 import pandas as pd
 
-from jabs.types import ClassifierType
-from jabs.types import ProjectDistanceUnit
+from jabs.types import ClassifierType, ProjectDistanceUnit
 
 
 def read_project_settings(h5_file: h5py.Group) -> dict:
@@ -72,7 +72,6 @@ def load_training_data(training_file: Path):
             },
         }
     """
-
     features = {"per_frame": {}, "window": {}}
     group_mapping = {}
 

--- a/src/jabs/project/settings_manager.py
+++ b/src/jabs/project/settings_manager.py
@@ -70,7 +70,6 @@ class SettingsManager:
             behavior: Behavior name.
             data: Dictionary of behavior settings.
         """
-
         defaults = self._project_info.get("defaults", {})
 
         all_behavior_data = self._project_info.get("behavior", {})
@@ -92,7 +91,7 @@ class SettingsManager:
         return self._project_info.get("behavior", {}).get(behavior, {})
 
     def remove_behavior(self, behavior: str) -> None:
-        # remove from project settings
+        """remove behavior from project settings"""
         try:
             del self._project_info["behavior"][behavior]
             self.save_project_file()

--- a/src/jabs/project/track_labels.py
+++ b/src/jabs/project/track_labels.py
@@ -6,8 +6,15 @@ import numpy as np
 
 
 class TrackLabels:
-    """Stores labels for a given identity and behavior. Requires one byte per
-    frame to store labels (e.g. approx. 108KB per 1 hour of 30fps video)
+    """
+    Stores and manages frame-level labels for a single identity and behavior.
+
+    Each frame can be labeled as NONE, BEHAVIOR, or NOT_BEHAVIOR. The class provides methods to set, clear,
+    and query labels over frame ranges, as well as utilities for counting labeled frames and bouts, exporting
+    label blocks, and downsampling label arrays for visualization or analysis.
+
+    Args:
+        num_frames (int): Number of frames to allocate for label storage.
     """
 
     class Label(enum.IntEnum):
@@ -56,6 +63,11 @@ class TrackLabels:
             self._labels[start : end + 1] = label
 
     def get_labels(self):
+        """Return the full label array for all frames.
+
+        Todo:
+         - make this a property
+        """
         return self._labels
 
     def get_frame_label(self, frame_index):
@@ -64,12 +76,10 @@ class TrackLabels:
 
     @property
     def label_count(self):
-        """property that returns a tuple with the count of the number of frames
-        for each label class
+        """Return a tuple with the count of frames for each label class.
 
         Returns:
-            (count of frames labeled as showing behavior, count of
-            frames labeled as not showing behavior)
+            tuple: (number of frames labeled as BEHAVIOR, number of frames labeled as NOT_BEHAVIOR)
         """
         return (
             np.count_nonzero(self._labels == self.Label.BEHAVIOR),
@@ -78,12 +88,11 @@ class TrackLabels:
 
     @property
     def bout_count(self):
-        """property that returns a tuple with the count of the number of bouts
-        of each label class
+        """Return a tuple with the number of contiguous bouts for each label class.
 
         Returns:
-            (count of bouts of behavior, count of bouts of "not
-            behavior")
+            tuple: (number of behavior bouts, number of not behavior bouts)
+                - A bout is a contiguous block of frames labeled as BEHAVIOR or NOT_BEHAVIOR.
         """
         blocks = self._array_to_blocks(self._labels)
         bouts_behavior = 0
@@ -103,34 +112,35 @@ class TrackLabels:
 
     def get_blocks(self):
         """get blocks for entire label array
+
         see _array_to_blocks() for return type
         """
         return self._array_to_blocks(self._labels)
 
     def get_slice_blocks(self, start, end):
         """get label blocks for a slice of frames
+
         block start and end frame numbers will be relative to the slice start
         """
         return self._array_to_blocks(self._labels[start : end + 1])
 
     @classmethod
-    def downsample(cls, labels, size):
-        """Downsample the label array for a "zoomed out" view. We use a custom
-        downsampling algorithm. Each element in the downsampled array is
-        assigned one of the following values:
-            Label.NONE: all elements in the bin have the value of Label.NONE
-            Label.BEHAVIOR: all elements are either zero or Label.BEHAVIOR
-            Label.NOT_BEHAVIOR: all elements are either zero or Label.NOT_BEHAVIOR
-            Label.MIX: bin contains Label.BEHAVIOR and Label.NOT_BEHAVIOR
-            Label.PAD: bin consists entirely of padding added to input array to
-            make it evenly divisible by output size
+    def downsample(cls, labels: np.ndarray, size: int):
+        """Downsample a label array to a specified size using custom binning rules.
+
+        Each output element summarizes a bin of input frames:
+            - Label.NONE: All frames in the bin are NONE.
+            - Label.BEHAVIOR: All frames are BEHAVIOR or NONE.
+            - Label.NOT_BEHAVIOR: All frames are NOT_BEHAVIOR or NONE.
+            - Label.MIX: Bin contains both BEHAVIOR and NOT_BEHAVIOR.
+            - Label.PAD: Bin consists entirely of padding added to fit the output size.
 
         Args:
-            labels: numpy label array
-            size: size of the resulting downsampled label array
+            labels (np.ndarray): Input label array.
+            size (int): Desired output array size.
 
         Returns:
-            numpy array of size 'size' with downsampled values
+            np.ndarray: Downsampled label array of length `size`.
         """
 
         def bincount(array):
@@ -180,12 +190,16 @@ class TrackLabels:
         return downsampled
 
     @classmethod
-    def load(cls, num_frames, blocks):
-        """return a TrackLabels object initialized with data from a list of blocks
-        :param num_frames total number of frames in the video
-        :param blocks - blocks to use to initialize frame label array. see
-        _array_to_blocks() for format
-        :return initialized TrackLabels object
+    def load(cls, num_frames: int, blocks: list[dict]) -> "TrackLabels":
+        """Create a TrackLabels object from a list of labeled blocks.
+
+        Args:
+            num_frames (int): Total number of frames in the video.
+            blocks (list[dict]): List of label blocks, where each block is a dict with
+                'start', 'end', and 'present' fields as produced by get_blocks().
+
+        Returns:
+            TrackLabels: Initialized TrackLabels object with labels set according to the provided blocks.
         """
         labels = cls(num_frames)
         for block in blocks:
@@ -196,27 +210,20 @@ class TrackLabels:
         return labels
 
     @classmethod
-    def _array_to_blocks(cls, array):
-        """return label blocks as something that can easily be exported as json
-        for saving to disk
-        :param array numpy label array to encode as blocks. Each element
-        should be one of TrackLabels.Label enum values.
+    def _array_to_blocks(cls, array: np.ndarray) -> list[dict]:
+        """Convert a label array into a list of labeled blocks for export or serialization.
+
+        Args:
+            array (np.ndarray): Numpy array of TrackLabels.Label values for each frame.
 
         Returns:
-            list of blocks of frames that have been labeled as having
-            the behavior or not having the behavior. Each block has the
-            following representation:
-            {
-                'start': block_start_frame,
-                'end': block_end_frame,
-                'present': boolean
-            }
-            where 'present' is True if the block has been labeled as showing the
-            behavior and False if it has been labeled as not showing the
-            behavior. Unlabeled frames are not included, so the total number of
-            frames is also required to reconstruct the labels array.
-        """
+            list[dict]: Each dict represents a contiguous block of labeled frames (excluding NONE), with:
+                - 'start': Start frame index of the block.
+                - 'end': End frame index of the block.
+                - 'present': True if the block is labeled as BEHAVIOR, False if labeled as NOT_BEHAVIOR.
 
+            Unlabeled (NONE) frames are omitted from the output.
+        """
         block_start = 0
         blocks = []
 
@@ -227,7 +234,7 @@ class TrackLabels:
                     {
                         "start": block_start,
                         "end": block_start + count - 1,
-                        "present": True if val == cls.Label.BEHAVIOR else False,
+                        "present": val == cls.Label.BEHAVIOR,
                     }
                 )
             block_start += count

--- a/src/jabs/project/video_labels.py
+++ b/src/jabs/project/video_labels.py
@@ -2,15 +2,20 @@ from .track_labels import TrackLabels
 
 
 class VideoLabels:
-    """store the labels associated with a video file.
+    """Stores and manages frame-level behavior labels for each identity in a video.
 
-    labels are organized by "identity". Each identity may have multiple
-    behaviors labeled. An identity and behavior uniquely identifies a
-    TrackLabels object, which stores labels for each frame in the video. Each
-    frame can have one of three label values: TrackLabels.Label.NONE,
-    Tracklabels.Label.BEHAVIOR, and TrackLabels.Label.NOT_BEHAVIOR
+    Each identity in the video can have multiple behaviors labeled, with each (identity, behavior) pair
+    corresponding to a TrackLabels object that tracks frame-wise annotations. Labels are organized such that
+    each frame can be marked as NONE, BEHAVIOR, or NOT_BEHAVIOR. The class provides methods for accessing,
+    counting, serializing, and loading these labels.
 
-    TODO stop using str for identities in method parameters, switch to int
+    Args:
+        filename: Name of the video file this object represents.
+        num_frames: Total number of frames in the video.
+        external_identities (list[int] | None, optional): Optional mapping of external identity indices.
+
+    Note:
+        in several places, identities are currently handled as strings for serialization compatibility.
     """
 
     def __init__(
@@ -28,6 +33,7 @@ class VideoLabels:
 
     @property
     def num_frames(self):
+        """return number of frames in video this object represents"""
         return self._num_frames
 
     def get_track_labels(self, identity, behavior):
@@ -40,10 +46,9 @@ class VideoLabels:
         Returns:
             TrackLabels object for this identity and behavior
 
-        TODO:
+        Todo:
             handle integer identity
         """
-
         # require identity to be a string for serialization
         if not isinstance(identity, str):
             raise ValueError("Identity must be a string")
@@ -65,8 +70,7 @@ class VideoLabels:
         return self._identity_labels[identity][behavior]
 
     def counts(self, behavior):
-        """get the count of labeled frames and bouts for each identity in this
-        video for a specified behavior
+        """get the count of labeled frames and bouts for each identity in this video for a specified behavior
 
         Args:
             behavior: behavior to get label counts for
@@ -87,8 +91,9 @@ class VideoLabels:
         return counts
 
     def as_dict(self) -> dict:
-        """return dict representation of self, useful for JSON serialization and
-        saving to disk or caching in memory without storing the full
+        """return dict representation of video labels
+
+        useful for JSON serialization and saving to disk or caching in memory without storing the full
         numpy label array when user switches to a different video
 
         example return value:
@@ -112,7 +117,6 @@ class VideoLabels:
         }
 
         """
-
         label_dict = {
             "file": self._filename,
             "num_frames": self._num_frames,
@@ -135,9 +139,7 @@ class VideoLabels:
 
     @classmethod
     def load(cls, video_label_dict):
-        """return a VideoLabels object initialized with data from a dict previously
-        exported using the export() method
-        """
+        """return a VideoLabels object initialized with data from a dict previously exported using the export() method"""
         labels = cls(video_label_dict["file"], video_label_dict["num_frames"])
         for identity in video_label_dict["labels"]:
             labels._identity_labels[identity] = {}

--- a/src/jabs/project/video_manager.py
+++ b/src/jabs/project/video_manager.py
@@ -2,16 +2,28 @@ import json
 import sys
 from pathlib import Path
 
-from jabs.pose_estimation import get_pose_path, get_frames_from_file, open_pose_file
+from jabs.pose_estimation import get_frames_from_file, get_pose_path, open_pose_file
 from jabs.video_reader import VideoReader
-from jabs.video_reader.utilities import get_frame_count
+
 from .project_paths import ProjectPaths
 from .settings_manager import SettingsManager
 from .video_labels import VideoLabels
 
 
 class VideoManager:
-    """Class to manage list of video files in a project."""
+    """Manages video files and their associated metadata within a project.
+
+    Handles initialization, validation, and metadata management for videos,
+    including checking for corresponding pose files, verifying frame counts,
+    and tracking the number of identities per video. Provides methods to
+    retrieve video lists, load video labels, and access video-related
+    information required for project processing.
+
+    Args:
+        paths (ProjectPaths): Object containing project directory paths.
+        settings_manager (SettingsManager): Manages project settings and metadata.
+        enable_video_check (bool, optional): Whether to validate video frame counts. Defaults to True.
+    """
 
     def __init__(
         self,
@@ -19,11 +31,6 @@ class VideoManager:
         settings_manager: SettingsManager,
         enable_video_check: bool = True,
     ):
-        """Initialize the VideoManager with paths.
-
-        Args:
-            paths: ProjectPaths object containing project directory paths
-        """
         self._paths = paths
         self._settings_manager = settings_manager
         self._videos = []
@@ -45,24 +52,26 @@ class VideoManager:
 
     @property
     def videos(self):
+        """Get the list of video filenames in the project."""
         return self._videos
 
     @property
     def total_project_identities(self) -> int:
+        """Get the total number of identities across all videos."""
         return self._total_project_identities
 
     def load_video_labels(self, video_name) -> VideoLabels | None:
-        """load labels for a video from the project directory or from a cached of
-        annotations that have previously been opened and not yet saved
+        """load labels for a video
+
+        Labels can be loaded either from the project directory or from a cache of annotations that have previously
+        been opened and not yet saved
 
         Args:
             video_name: filename of the video: string or pathlib.Path
 
         Returns:
-            initialized VideoLabels object if annotations exist,
-            otherwise None
+            initialized VideoLabels object if annotations exist, otherwise None
         """
-
         video_filename = Path(video_name).name
         self.check_video_name(video_filename)
 
@@ -76,16 +85,17 @@ class VideoManager:
         else:
             return None
 
-    def check_video_name(self, video_filename):
-        """make sure the video name actually matches one in the project, this
-        function will raise a ValueError if the video name is not valid,
-        otherwise the function has no effect
+    def check_video_name(self, video_filename: str):
+        """check that a video name matches one in the project
 
         Args:
-            video_filename
+            video_filename (str): name of the video file
 
         Returns:
             None
+
+        Raises:
+            ValueError: if the video is not in the project
         """
         if video_filename not in self._videos:
             raise ValueError(f"{video_filename} not in project")


### PR DESCRIPTION
fixes ruff check errors

also fixes some docstrings that were either formatted poorly by the automated doctoring style formatting or were lacking in content