### PR TITLE
save username in annotation .json files

### DIFF
--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -139,8 +139,8 @@ class Project:
         return self._paths
 
     @property
-    def username(self) -> str:
-        """return username
+    def labeler(self) -> str:
+        """return name of labeler
 
         For now, this is just the username of the user running JABS.
         """
@@ -179,7 +179,7 @@ class Project:
         )
 
         annotations = annotations.as_dict()
-        annotations["labeler"] = self.username
+        annotations["labeler"] = self.labeler
 
         with path.open(mode="w", newline="\n") as f:
             json.dump(annotations, f, indent=2)

--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -1,4 +1,5 @@
 import contextlib
+import getpass
 import gzip
 import json
 import shutil
@@ -137,6 +138,14 @@ class Project:
         """get the project paths object for this project"""
         return self._paths
 
+    @property
+    def username(self) -> str:
+        """return username
+
+        For now, this is just the username of the user running JABS.
+        """
+        return getpass.getuser()
+
     def load_pose_est(self, video_path: Path) -> PoseEstimation:
         """return a PoseEstimation object for a given video path
 
@@ -169,8 +178,11 @@ class Project:
             ".json"
         )
 
+        annotations = annotations.as_dict()
+        annotations["labeler"] = self.username
+
         with path.open(mode="w", newline="\n") as f:
-            json.dump(annotations.as_dict(), f, indent=2)
+            json.dump(annotations, f, indent=2)
 
         # update app version saved in project metadata if necessary
         self._settings_manager.update_version()

--- a/src/jabs/resources/docs/user_guide/user_guide.md
+++ b/src/jabs/resources/docs/user_guide/user_guide.md
@@ -355,12 +355,14 @@ While not in select mode:
 ### Other
 
 Switching subject:
+
 - shift + up arrow: switch to the next subject
 - shift + down arrow: switch to the previous subject
 
 Note: next/previous subject is determined by the order of subjects in the "Identity Selection" dropdown. 
 
 Overlays:
+
 - t: toggle track overlay for subject
 - p: toggle pose overlay for subject
 - l: toggle landmark overlay


### PR DESCRIPTION
saves the username in the annotation .json files

currently is saved in a top-level field called "labeler" (I could change this to "username" or "user" based on group consensus)

