### PR TITLE
fix exception loading pose file with no identities

### DIFF
--- a/src/jabs/pose_estimation/pose_est_v4.py
+++ b/src/jabs/pose_estimation/pose_est_v4.py
@@ -78,9 +78,14 @@ class PoseEstimationV4(PoseEstimation):
                     )
 
             self._num_frames = len(all_points)
-            self._num_identities = np.max(
-                np.ma.array(instance_embed_id[...], mask=id_mask[...])
-            )
+
+            if instance_embed_id.shape[1] > 0:
+                self._num_identities = np.max(
+                    np.ma.array(instance_embed_id[...], mask=id_mask[...])
+                )
+            else:
+                print(f"Warning: No identities found in pose file: {file_path}")
+                self._num_identities = 0
 
             # generate list of identities based on the max number of instances
             # in the pose file
@@ -104,9 +109,7 @@ class PoseEstimationV4(PoseEstimation):
                 points_tmp = np.transpose(points_tmp, [1, 0, 2, 3])
 
                 # transform confidence values for mask as well
-                confidence_by_id_tmp = np.zeros(
-                    tmp_shape[:3], dtype=all_confidence.dtype
-                )
+                confidence_by_id_tmp = np.zeros(tmp_shape[:3], dtype=all_confidence.dtype)
                 confidence_by_id_tmp[
                     np.where(id_mask == 0)[0], instance_embed_id[id_mask == 0] - 1, :
                 ] = all_confidence[id_mask == 0, :]


### PR DESCRIPTION
I had a project that included a few videos where the mice were hidden under nesting material for the entire 1 minute segment.  This causes an exception and prevented JABS from loading the project. 

This change makes it so that JABS won't raise an exception when reading the pose file so the project can still be opened. 

Not sure if there might be other bugs when training / predicting on this project, but for now this will at least allow us to open the project and label other videos. 