### PR TITLE
make the GUI handle exceptions raised in training and classification threads

### DIFF
--- a/src/jabs/ui/central_widget.py
+++ b/src/jabs/ui/central_widget.py
@@ -614,7 +614,7 @@ class CentralWidget(QtWidgets.QWidget):
     def _classify_thread_error_callback(self, error: Exception) -> None:
         """handle an error in the classification thread"""
         self._print_exception(error)
-        self._cleanup_training_thread()
+        self._cleanup_classify_thread()
         self._cleanup_progress_dialog()
         self.status_message.emit("Classification Failed", 3000)
         self._controls.train_button_enabled = True
@@ -646,6 +646,12 @@ class CentralWidget(QtWidgets.QWidget):
         if self._training_thread:
             self._training_thread.deleteLater()
             self._training_thread = None
+
+    def _cleanup_classify_thread(self) -> None:
+        """clean up the training thread"""
+        if self._classify_thread:
+            self._classify_thread.deleteLater()
+            self._classify_thread = None
 
     def _update_training_progress(self, step: int) -> None:
         """update progress bar with the number of completed tasks"""
@@ -681,9 +687,8 @@ class CentralWidget(QtWidgets.QWidget):
         self._predictions = output["predictions"]
         self._probabilities = output["probabilities"]
         self._frame_indexes = output["frame_indexes"]
-        self._progress_dialog.close()
-        self._progress_dialog.deleteLater()
-        self._progress_dialog = None
+        self._cleanup_progress_dialog()
+        self._cleanup_classify_thread()
         self.status_message.emit("Classification Complete", 3000)
         self._set_prediction_vis()
 

--- a/src/jabs/ui/central_widget.py
+++ b/src/jabs/ui/central_widget.py
@@ -1,4 +1,5 @@
 import sys
+from pathlib import Path
 
 import numpy as np
 from PySide6 import QtCore, QtGui, QtWidgets
@@ -8,8 +9,9 @@ from shapely.geometry import Point
 import jabs.feature_extraction
 from jabs.behavior_search import SearchHit
 from jabs.classifier import Classifier
-from jabs.project import VideoLabels
+from jabs.project import Project, VideoLabels
 from jabs.project.track_labels import TrackLabels
+from jabs.types import ClassifierType
 from jabs.ui.search_bar_widget import SearchBarWidget
 
 from .classification_thread import ClassifyThread
@@ -29,7 +31,7 @@ class CentralWidget(QtWidgets.QWidget):
     status_message = QtCore.Signal(str, int)  # message, timeout (ms)
     search_hit_loaded = QtCore.Signal(SearchHit)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         # search bar
@@ -66,7 +68,8 @@ class CentralWidget(QtWidgets.QWidget):
         self._probabilities = {}
         self._frame_indexes = {}
 
-        self._selection_start = 0
+        self._selection_start = None
+        self._selection_end = None
 
         # options
         self._frame_jump = 10
@@ -122,11 +125,11 @@ class CentralWidget(QtWidgets.QWidget):
         for child in self.findChildren(QtWidgets.QWidget):
             child.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
 
-    def update_behavior_search_query(self, search_query):
+    def update_behavior_search_query(self, search_query) -> None:
         """Update the search query for the search bar widget"""
         self._search_bar_widget.update_search(search_query)
 
-    def eventFilter(self, source, event):
+    def eventFilter(self, source, event) -> bool:
         """filter events emitted by progress dialog
 
         The main purpose of this is to prevent the progress dialog from closing if the user presses the escape key.
@@ -144,42 +147,42 @@ class CentralWidget(QtWidgets.QWidget):
         return super().eventFilter(source, event)
 
     @property
-    def behavior(self):
+    def behavior(self) -> str:
         """get the currently selected behavior"""
         return self._controls.current_behavior
 
     @property
-    def classifier_type(self):
+    def classifier_type(self) -> ClassifierType:
         """get the current classifier type"""
         return self._classifier.classifier_type
 
     @property
-    def window_size(self):
+    def window_size(self) -> int:
         """get current window size"""
         return self._window_size
 
     @property
-    def uses_balance(self):
+    def uses_balance(self) -> bool:
         """return true if the controls widget is set to use balanced labels, false otherwise"""
         return self._controls.use_balance_labels
 
     @property
-    def uses_symmetric(self):
+    def uses_symmetric(self) -> bool:
         """return true if the controls widget is set to use symmetric behavior, false otherwise"""
         return self._controls.use_symmetric
 
     @property
-    def all_kfold(self):
+    def all_kfold(self) -> bool:
         """return true if all kfold is selected in the controls widget, false otherwise"""
         return self._controls.all_kfold
 
     @property
-    def classify_button_enabled(self):
+    def classify_button_enabled(self) -> bool:
         """return true if the classify button is currently enabled, false otherwise"""
         return self._controls.classify_button_enabled
 
     @property
-    def behaviors(self):
+    def behaviors(self) -> list[str]:
         """return the behaviors from the controls widget"""
         return self._controls.behaviors
 
@@ -217,7 +220,7 @@ class CentralWidget(QtWidgets.QWidget):
                 # if the player is set to show nothing, clear the labels
                 self._player_widget.set_labels(None)
 
-    def set_project(self, project):
+    def set_project(self, project: Project) -> None:
         """set the currently opened project"""
         self._project = project
 
@@ -231,7 +234,7 @@ class CentralWidget(QtWidgets.QWidget):
         self._controls.update_project_settings(project.settings)
         self._search_bar_widget.update_project(project)
 
-    def load_video(self, path):
+    def load_video(self, path: Path) -> None:
         """load a new video file into self._player_widget
 
         Args:
@@ -288,10 +291,10 @@ class CentralWidget(QtWidgets.QWidget):
             self._player_widget.reset()
             raise e
 
-    def keyPressEvent(self, event):
+    def keyPressEvent(self, event) -> None:
         """handle key press events"""
 
-        def begin_select_mode():
+        def begin_select_mode() -> None:
             if (
                 not self._controls.select_button_is_checked
                 and self._controls.select_button_enabled
@@ -341,53 +344,53 @@ class CentralWidget(QtWidgets.QWidget):
             # show closest with no argument toggles the setting
             self._player_widget.show_closest()
 
-    def show_track(self, show: bool):
+    def show_track(self, show: bool) -> None:
         """set the show track property of the player widget"""
         self._player_widget.show_track(show)
 
-    def overlay_pose(self, checked: bool):
+    def overlay_pose(self, checked: bool) -> None:
         """set the overlay pose property of the player widget"""
         self._player_widget.overlay_pose(checked)
 
-    def overlay_landmarks(self, checked: bool):
+    def overlay_landmarks(self, checked: bool) -> None:
         """set the overlay landmarks property of the player widget"""
         self._player_widget.overlay_landmarks(checked)
 
-    def overlay_segmentation(self, checked: bool):
+    def overlay_segmentation(self, checked: bool) -> None:
         """set the overlay segmentation property of the player widget"""
         self._player_widget.overlay_segmentation(checked)
 
-    def remove_behavior(self, behavior: str):
+    def remove_behavior(self, behavior: str) -> None:
         """remove a behavior from the list of behaviors"""
         self._controls.remove_behavior(behavior)
 
     @property
-    def controls(self):
+    def controls(self) -> MainControlWidget:
         """return the controls widget"""
         return self._controls
 
     @property
-    def timeline_view_mode(self):
+    def timeline_view_mode(self) -> StackedTimelineWidget.ViewMode:
         """return the timeline view mode"""
         return self._stacked_timeline.view_mode
 
     @timeline_view_mode.setter
-    def timeline_view_mode(self, view_mode: StackedTimelineWidget.ViewMode):
+    def timeline_view_mode(self, view_mode: StackedTimelineWidget.ViewMode) -> None:
         """set the timeline view mode"""
         self._stacked_timeline.view_mode = view_mode
         self._update_select_button_state()
 
     @property
-    def timeline_identity_mode(self):
+    def timeline_identity_mode(self) -> StackedTimelineWidget.IdentityMode:
         """return the timeline identity mode"""
         return self._stacked_timeline.identity_mode
 
     @timeline_identity_mode.setter
-    def timeline_identity_mode(self, identity_mode: StackedTimelineWidget.IdentityMode):
+    def timeline_identity_mode(self, identity_mode: StackedTimelineWidget.IdentityMode) -> None:
         """set the timeline view mode"""
         self._stacked_timeline.identity_mode = identity_mode
 
-    def _change_behavior(self, new_behavior):
+    def _change_behavior(self) -> None:
         """make UI changes to reflect the currently selected behavior"""
         if self._project is None:
             return
@@ -414,7 +417,7 @@ class CentralWidget(QtWidgets.QWidget):
 
         self._project.settings_manager.save_project_file({"selected_behavior": self.behavior})
 
-    def _start_selection(self, pressed):
+    def _start_selection(self, pressed: bool) -> None:
         """Handle a click on "select" button.
 
         If button was previously "unchecked" then enter "select mode". If the button was in the checked state,
@@ -429,7 +432,7 @@ class CentralWidget(QtWidgets.QWidget):
             self._controls.disable_label_buttons()
             self._stacked_timeline.clear_selection()
 
-    def select_all(self):
+    def select_all(self) -> None:
         """Select all frames in the current video for the current identity and behavior."""
         if not self._controls.select_button_is_checked and self._controls.select_button_enabled:
             self._controls.toggle_select_button()
@@ -443,7 +446,7 @@ class CentralWidget(QtWidgets.QWidget):
                 self._stacked_timeline.start_selection(self._selection_start, self._selection_end)
 
     @property
-    def _curr_selection_end(self):
+    def _curr_selection_end(self) -> int:
         """Get the end of the current selection.
 
         If no selection end is set, return the current frame index.
@@ -454,19 +457,19 @@ class CentralWidget(QtWidgets.QWidget):
             else self._player_widget.current_frame()
         )
 
-    def _label_behavior(self):
+    def _label_behavior(self) -> None:
         """Apply behavior label to currently selected range of frames"""
         start, end = sorted([self._selection_start, self._curr_selection_end])
         self._get_label_track().label_behavior(start, end)
         self._label_button_common()
 
-    def _label_not_behavior(self):
+    def _label_not_behavior(self) -> None:
         """apply _not_ behavior label to currently selected range of frames"""
         start, end = sorted([self._selection_start, self._curr_selection_end])
         self._get_label_track().label_not_behavior(start, end)
         self._label_button_common()
 
-    def _clear_behavior_label(self):
+    def _clear_behavior_label(self) -> None:
         """clear all behavior/not behavior labels from current selection"""
         label_range = sorted([self._selection_start, self._curr_selection_end])
         self._get_label_track().clear_labels(*label_range)
@@ -521,8 +524,8 @@ class CentralWidget(QtWidgets.QWidget):
 
         self._set_prediction_vis()
 
-    def _get_label_list(self):
-        """get a list of np.ndarray containing labels, one for each identity"""
+    def _get_label_list(self) -> list[TrackLabels]:
+        """get a list of TrackLabels, one for each identity"""
         behavior = self._controls.current_behavior
         identity = self._controls.current_identity_index
         if identity != -1 and behavior != "" and self._labels is not None:
@@ -552,11 +555,11 @@ class CentralWidget(QtWidgets.QWidget):
             and classifier_settings.get("symmetric_behavior", None) == self._controls.use_symmetric
         ):
             # if yes, we can enable the classify button
-            self._controls.classify_button_set_enabled(True)
+            self._controls.classify_button_enabled = True
         else:
             # if not, the classify button needs to be disabled until the
             # user retrains
-            self._controls.classify_button_set_enabled(False)
+            self._controls.classify_button_enabled = False
 
     def _train_button_clicked(self) -> None:
         """handle user click on "Train" button"""
@@ -572,6 +575,7 @@ class CentralWidget(QtWidgets.QWidget):
             parent=self,
         )
         self._training_thread.training_complete.connect(self._training_thread_complete)
+        self._training_thread.error_callback.connect(self._training_thread_error_callback)
         self._training_thread.update_progress.connect(self._update_training_progress)
         self._training_thread.current_status.connect(lambda m: self.status_message.emit(m, 0))
 
@@ -590,11 +594,43 @@ class CentralWidget(QtWidgets.QWidget):
 
     def _training_thread_complete(self) -> None:
         """enable classify button once the training is complete"""
-        self._progress_dialog.close()
-        self._progress_dialog.deleteLater()
-        self._progress_dialog = None
+        self._cleanup_training_thread()
+        self._cleanup_progress_dialog()
         self.status_message.emit("Training Complete", 3000)
-        self._controls.classify_button_set_enabled(True)
+        self._controls.classify_button_enabled = True
+
+    def _training_thread_error_callback(self, error: Exception) -> None:
+        """handle an error in the training thread"""
+        self._cleanup_training_thread()
+        self._cleanup_progress_dialog()
+        self.status_message.emit("Training Failed", 3000)
+        self._controls.classify_button_enabled = False
+        QtWidgets.QMessageBox.critical(
+            self, "Error", f"An exception occurred during training:\n{error}"
+        )
+
+    def _classify_thread_error_callback(self, error: Exception) -> None:
+        """handle an error in the classification thread"""
+        self._cleanup_training_thread()
+        self._cleanup_progress_dialog()
+        self.status_message.emit("Classification Failed", 3000)
+        self._controls.train_button_enabled = True
+        QtWidgets.QMessageBox.critical(
+            self, "Error", f"An exception occurred during classification:\n{error}"
+        )
+
+    def _cleanup_progress_dialog(self) -> None:
+        """clean up the progress dialog"""
+        if self._progress_dialog:
+            self._progress_dialog.close()
+            self._progress_dialog.deleteLater()
+            self._progress_dialog = None
+
+    def _cleanup_training_thread(self) -> None:
+        """clean up the training thread"""
+        if self._training_thread:
+            self._training_thread.deleteLater()
+            self._training_thread = None
 
     def _update_training_progress(self, step: int) -> None:
         """update progress bar with the number of completed tasks"""
@@ -613,7 +649,8 @@ class CentralWidget(QtWidgets.QWidget):
             self._loaded_video.name,
             parent=self,
         )
-        self._classify_thread.done.connect(self._classify_thread_complete)
+        self._classify_thread.classification_complete.connect(self._classify_thread_complete)
+        self._classify_thread.error_callback.connect(self._classify_thread_error_callback)
         self._classify_thread.update_progress.connect(self._update_classify_progress)
         self._classify_thread.current_status.connect(lambda m: self.status_message.emit(m, 0))
         self._progress_dialog = create_progress_dialog(
@@ -753,7 +790,7 @@ class CentralWidget(QtWidgets.QWidget):
         """handle classifier selection change"""
         if self._classifier.classifier_type != self._controls.classifier_type:
             # changing classifier type, disable until retrained
-            self._controls.classify_button_set_enabled(False)
+            self._controls.classify_button_enabled = False
             self._classifier.set_classifier(self._controls.classifier_type)
 
     def _pixmap_clicked(self, event: dict[str, int]) -> None:
@@ -850,7 +887,7 @@ class CentralWidget(QtWidgets.QWidget):
         if classifier_loaded:
             self._update_classifier_controls()
         else:
-            self._controls.classify_button_set_enabled(False)
+            self._controls.classify_button_enabled = False
 
     def _update_search_hit(self, search_hit: SearchHit | None) -> None:
         """Handle updates when the current search hit changes."""

--- a/src/jabs/ui/central_widget.py
+++ b/src/jabs/ui/central_widget.py
@@ -1,4 +1,5 @@
 import sys
+import traceback
 from pathlib import Path
 
 import numpy as np
@@ -601,6 +602,7 @@ class CentralWidget(QtWidgets.QWidget):
 
     def _training_thread_error_callback(self, error: Exception) -> None:
         """handle an error in the training thread"""
+        self._print_exception(error)
         self._cleanup_training_thread()
         self._cleanup_progress_dialog()
         self.status_message.emit("Training Failed", 3000)
@@ -611,6 +613,7 @@ class CentralWidget(QtWidgets.QWidget):
 
     def _classify_thread_error_callback(self, error: Exception) -> None:
         """handle an error in the classification thread"""
+        self._print_exception(error)
         self._cleanup_training_thread()
         self._cleanup_progress_dialog()
         self.status_message.emit("Classification Failed", 3000)
@@ -618,6 +621,18 @@ class CentralWidget(QtWidgets.QWidget):
         QtWidgets.QMessageBox.critical(
             self, "Error", f"An exception occurred during classification:\n{error}"
         )
+
+    @staticmethod
+    def _print_exception(e: Exception) -> None:
+        """Print a formatted traceback for the given exception to the terminal.
+
+        This method outputs the full stack trace and exception details to help with debugging.
+        It can be extended in the future to support additional logging or error handling mechanisms.
+
+        Args:
+            e (Exception): The exception instance to print.
+        """
+        traceback.print_exception(e)
 
     def _cleanup_progress_dialog(self) -> None:
         """clean up the progress dialog"""

--- a/src/jabs/ui/classification_thread.py
+++ b/src/jabs/ui/classification_thread.py
@@ -1,17 +1,27 @@
 import numpy as np
 import pandas as pd
-from PySide6 import QtCore
+from PySide6.QtCore import QThread, Signal, SignalInstance
 
 from jabs.feature_extraction import DEFAULT_WINDOW_SIZE, IdentityFeatures
 from jabs.video_reader.utilities import get_fps
 
 
-class ClassifyThread(QtCore.QThread):
+class ClassifyThread(QThread):
     """thread to run the classification to keep the main GUI thread responsive"""
 
-    done = QtCore.Signal(dict)
-    update_progress = QtCore.Signal(int)
-    current_status = QtCore.Signal(str)
+    # signal so that the main GUI thread can be notified when classification is complete
+    classification_complete: SignalInstance = Signal(dict)
+
+    # allow the thread to send a status string to the main GUI thread so that
+    # we can update a status bar if we want
+    current_status: SignalInstance = Signal(str)
+
+    # signal to inform the main GUI thread of the number of tasks completed
+    # so that it can update a progress bar
+    update_progress: SignalInstance = Signal(int)
+
+    # inform the main GUI thread if there was an error during training
+    error_callback: SignalInstance = Signal(Exception)
 
     def __init__(self, classifier, project, behavior, current_video, parent=None):
         super().__init__(parent=parent)
@@ -32,88 +42,89 @@ class ClassifyThread(QtCore.QThread):
         probabilities = {}
         frame_indexes = {}
 
-        project_settings = self._project.settings_manager.get_behavior(self._behavior)
+        try:
+            project_settings = self._project.settings_manager.get_behavior(self._behavior)
 
-        # iterate over each video in the project
-        for video in self._project.video_manager.videos:
-            video_path = self._project.video_manager.video_path(video)
+            # iterate over each video in the project
+            for video in self._project.video_manager.videos:
+                video_path = self._project.video_manager.video_path(video)
 
-            # load the poses for this video
-            pose_est = self._project.load_pose_est(video_path)
-            # fps used to scale some features from per pixel time unit to
-            # per second
-            fps = get_fps(str(video_path))
+                # load the poses for this video
+                pose_est = self._project.load_pose_est(video_path)
+                # fps used to scale some features from per pixel time unit to
+                # per second
+                fps = get_fps(str(video_path))
 
-            # make predictions for each identity in this video
-            predictions[video] = {}
-            probabilities[video] = {}
-            frame_indexes[video] = {}
+                # make predictions for each identity in this video
+                predictions[video] = {}
+                probabilities[video] = {}
+                frame_indexes[video] = {}
 
-            for identity in pose_est.identities:
-                self.current_status.emit(f"Classifying {video},  Identity {identity}")
+                for identity in pose_est.identities:
+                    self.current_status.emit(f"Classifying {video},  Identity {identity}")
 
-                # get the features for this identity
-                features = IdentityFeatures(
-                    video,
-                    identity,
-                    self._project.feature_dir,
-                    pose_est,
-                    fps=fps,
-                    op_settings=project_settings,
-                )
-                feature_values = features.get_features(
-                    project_settings.get("window_size", DEFAULT_WINDOW_SIZE)
-                )
-
-                # reformat the data in a single 2D numpy array to pass
-                # to the classifier
-                per_frame_features = pd.DataFrame(
-                    IdentityFeatures.merge_per_frame_features(
-                        feature_values["per_frame"]
+                    # get the features for this identity
+                    features = IdentityFeatures(
+                        video,
+                        identity,
+                        self._project.feature_dir,
+                        pose_est,
+                        fps=fps,
+                        op_settings=project_settings,
                     )
-                )
-                window_features = pd.DataFrame(
-                    IdentityFeatures.merge_window_features(feature_values["window"])
-                )
-                data = self._classifier.combine_data(
-                    per_frame_features, window_features
-                )
+                    feature_values = features.get_features(
+                        project_settings.get("window_size", DEFAULT_WINDOW_SIZE)
+                    )
 
-                if data.shape[0] > 0:
-                    # make predictions
-                    predictions[video][identity] = self._classifier.predict(data)
+                    # reformat the data in a single 2D numpy array to pass
+                    # to the classifier
+                    per_frame_features = pd.DataFrame(
+                        IdentityFeatures.merge_per_frame_features(feature_values["per_frame"])
+                    )
+                    window_features = pd.DataFrame(
+                        IdentityFeatures.merge_window_features(feature_values["window"])
+                    )
+                    data = self._classifier.combine_data(per_frame_features, window_features)
 
-                    # also get the probabilities
-                    prob = self._classifier.predict_proba(data)
-                    # Save the probability for the predicted class only.
-                    # The following code uses some
-                    # numpy magic to use the _predictions array as column indexes
-                    # for each row of the 'prob' array we just computed.
-                    probabilities[video][identity] = prob[
-                        np.arange(len(prob)), predictions[video][identity]
-                    ]
+                    if data.shape[0] > 0:
+                        # make predictions
+                        predictions[video][identity] = self._classifier.predict(data)
 
-                    # save the indexes for the predicted frames
-                    frame_indexes[video][identity] = feature_values["frame_indexes"]
-                else:
-                    predictions[video][identity] = np.array(0)
-                    probabilities[video][identity] = np.array(0)
-                    frame_indexes[video][identity] = np.array(0)
-                self._tasks_complete += 1
-                self.update_progress.emit(self._tasks_complete)
+                        # also get the probabilities
+                        prob = self._classifier.predict_proba(data)
+                        # Save the probability for the predicted class only.
+                        # The following code uses some
+                        # numpy magic to use the _predictions array as column indexes
+                        # for each row of the 'prob' array we just computed.
+                        probabilities[video][identity] = prob[
+                            np.arange(len(prob)), predictions[video][identity]
+                        ]
 
-        # save predictions
-        self.current_status.emit("Saving Predictions")
-        self._project.save_predictions(
-            predictions, probabilities, frame_indexes, self._behavior, self._classifier
-        )
+                        # save the indexes for the predicted frames
+                        frame_indexes[video][identity] = feature_values["frame_indexes"]
+                    else:
+                        predictions[video][identity] = np.array(0)
+                        probabilities[video][identity] = np.array(0)
+                        frame_indexes[video][identity] = np.array(0)
+                    self._tasks_complete += 1
+                    self.update_progress.emit(self._tasks_complete)
 
-        self._tasks_complete += 1
-        self.update_progress.emit(self._tasks_complete)
-        self.done.emit(
-            {
-                "predictions": predictions[self._current_video],
-                "probabilities": probabilities[self._current_video],
-                "frame_indexes": frame_indexes[self._current_video],
-            }
-        )
+            # save predictions
+            self.current_status.emit("Saving Predictions")
+            self._project.save_predictions(
+                predictions, probabilities, frame_indexes, self._behavior, self._classifier
+            )
+
+            self._tasks_complete += 1
+            self.update_progress.emit(self._tasks_complete)
+            self.classification_complete.emit(
+                {
+                    "predictions": predictions[self._current_video],
+                    "probabilities": probabilities[self._current_video],
+                    "frame_indexes": frame_indexes[self._current_video],
+                }
+            )
+        except Exception as e:
+            # if there was an exception, we'll emit the Exception as a signal so that
+            # the main GUI thread can handle it
+            self.error_callback.emit(e)

--- a/src/jabs/ui/main_control_widget.py
+++ b/src/jabs/ui/main_control_widget.py
@@ -297,15 +297,20 @@ class MainControlWidget(QtWidgets.QWidget):
         """return true if the train button is enabled"""
         return self._train_button.isEnabled()
 
-    @property
-    def classify_button_enabled(self):
-        """set the classify button to enabled or disabled"""
-        return self._classify_button.isEnabled()
-
     @train_button_enabled.setter
     def train_button_enabled(self, enabled: bool):
         """set the train button to enabled or disabled"""
         self._train_button.setEnabled(enabled)
+
+    @property
+    def classify_button_enabled(self):
+        """is classify button enabled?"""
+        return self._classify_button.isEnabled()
+
+    @classify_button_enabled.setter
+    def classify_button_enabled(self, enabled: bool):
+        """set the classify button to enabled or disabled"""
+        self._classify_button.setEnabled(enabled)
 
     @property
     def classifier_type(self):
@@ -396,10 +401,6 @@ class MainControlWidget(QtWidgets.QWidget):
             bout_behavior_project,
             bout_not_behavior_project,
         )
-
-    def classify_button_set_enabled(self, enabled: bool):
-        """set the classify button to enabled or disabled"""
-        self._classify_button.setEnabled(enabled)
 
     @property
     def select_button_enabled(self) -> bool:

--- a/src/jabs/ui/main_window.py
+++ b/src/jabs/ui/main_window.py
@@ -508,7 +508,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # open the behavior search dialog
         dialog = BehaviorSearchDialog(self._project, self)
-        if dialog.exec_() == QtWidgets.QDialog.Accepted:
+        if dialog.exec_() == QtWidgets.QDialog.DialogCode.Accepted:
             search_query = dialog.behavior_search_query
             self._central_widget.update_behavior_search_query(search_query)
 
@@ -596,6 +596,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def _project_load_error_callback(self, error: Exception):
         """Callback function to be called when the project fails to load."""
+        self._project_loader_thread.deleteLater()
         self._project_loader_thread = None
         self._progress_dialog.close()
         self._progress_dialog.deleteLater()

--- a/src/jabs/ui/training_thread.py
+++ b/src/jabs/ui/training_thread.py
@@ -1,25 +1,28 @@
 import numpy as np
-from PySide6 import QtCore
+from PySide6.QtCore import QThread, Signal, SignalInstance
 from tabulate import tabulate
 
 from jabs.types import ProjectDistanceUnit
 from jabs.utils import FINAL_TRAIN_SEED
 
 
-class TrainingThread(QtCore.QThread):
+class TrainingThread(QThread):
     """Thread used to run the training to keep the Qt main GUI thread responsive."""
 
     # signal so that the main GUI thread can be notified when the training is
     # complete
-    training_complete = QtCore.Signal()
+    training_complete: SignalInstance = Signal()
 
     # allow the thread to send a status string to the main GUI thread so that
     # we can update a status bar if we want
-    current_status = QtCore.Signal(str)
+    current_status: SignalInstance = Signal(str)
 
-    # allow the thread to send a status string to the main GUI thread so that
-    # we can update a status bar if we want
-    update_progress = QtCore.Signal(int)
+    # signal to inform the main GUI thread of the number of tasks completed
+    # so that it can update a progress bar
+    update_progress: SignalInstance = Signal(int)
+
+    # inform the main GUI thread if there was an error during training
+    error_callback: SignalInstance = Signal(Exception)
 
     def __init__(self, project, classifier, behavior, k=1, parent=None):
         super().__init__(parent=parent)
@@ -42,150 +45,145 @@ class TrainingThread(QtCore.QThread):
             self._tasks_complete += 1
             self.update_progress.emit(self._tasks_complete)
 
-        self.current_status.emit("Extracting Features")
-        features, group_mapping = self._project.get_labeled_features(
-            self._behavior, id_processed
-        )
-
-        self.current_status.emit("Generating train/test splits")
-        data_generator = self._classifier.leave_one_group_out(
-            features["per_frame"],
-            features["window"],
-            features["labels"],
-            features["groups"],
-        )
-
-        table_rows = []
-        accuracies = []
-        fbeta_behavior = []
-        fbeta_notbehavior = []
-
-        # Figure out the cross validation count if all were requested
-        if self._k == np.inf:
-            self._k = self._classifier.get_leave_one_group_out_max(
-                features["labels"], features["groups"]
+        try:
+            self.current_status.emit("Extracting Features")
+            features, group_mapping = self._project.get_labeled_features(
+                self._behavior, id_processed
             )
 
-        if self._k > 0:
-            for i, data in enumerate(data_generator):
-                if i + 1 > self._k:
-                    break
-                self.current_status.emit(
-                    f"cross validation iteration {i + 1} of {self._k}"
+            self.current_status.emit("Generating train/test splits")
+            data_generator = self._classifier.leave_one_group_out(
+                features["per_frame"],
+                features["window"],
+                features["labels"],
+                features["groups"],
+            )
+
+            table_rows = []
+            accuracies = []
+            fbeta_behavior = []
+            fbeta_notbehavior = []
+
+            # Figure out the cross validation count if all were requested
+            if self._k == np.inf:
+                self._k = self._classifier.get_leave_one_group_out_max(
+                    features["labels"], features["groups"]
                 )
 
-                test_info = group_mapping[data["test_group"]]
+            if self._k > 0:
+                for i, data in enumerate(data_generator):
+                    if i + 1 > self._k:
+                        break
+                    self.current_status.emit(f"cross validation iteration {i + 1} of {self._k}")
 
-                # train classifier, and then use it to classify our test data
-                self._classifier.behavior_name = self._behavior
-                self._classifier.set_project_settings(self._project)
-                self._classifier.train(data)
-                predictions = self._classifier.predict(data["test_data"])
+                    test_info = group_mapping[data["test_group"]]
 
-                # calculate some performance metrics using the classifications
-                accuracy = self._classifier.accuracy_score(
-                    data["test_labels"], predictions
-                )
-                pr = self._classifier.precision_recall_score(
-                    data["test_labels"], predictions
-                )
-                confusion = self._classifier.confusion_matrix(
-                    data["test_labels"], predictions
+                    # train classifier, and then use it to classify our test data
+                    self._classifier.behavior_name = self._behavior
+                    self._classifier.set_project_settings(self._project)
+                    self._classifier.train(data)
+                    predictions = self._classifier.predict(data["test_data"])
+
+                    # calculate some performance metrics using the classifications
+                    accuracy = self._classifier.accuracy_score(data["test_labels"], predictions)
+                    pr = self._classifier.precision_recall_score(data["test_labels"], predictions)
+                    confusion = self._classifier.confusion_matrix(data["test_labels"], predictions)
+
+                    table_rows.append(
+                        [
+                            accuracy,
+                            pr[0][0],
+                            pr[0][1],
+                            pr[1][0],
+                            pr[1][1],
+                            pr[2][0],
+                            pr[2][1],
+                            f"{test_info['video']} [{test_info['identity']}]",
+                        ]
+                    )
+                    accuracies.append(accuracy)
+                    fbeta_behavior.append(pr[2][1])
+                    fbeta_notbehavior.append(pr[2][0])
+
+                    # print performance metrics and feature importance to console
+                    print("-" * 70)
+                    print(f"training iteration {i + 1}")
+                    print("TEST DATA:")
+                    print(f"\tVideo: {test_info['video']}")
+                    print(f"\tIdentity: {test_info['identity']}")
+                    print(f"ACCURACY: {accuracy * 100:.2f}%")
+                    print("PRECISION RECALL:")
+                    print(f"              {'not behavior':12}  behavior")
+                    print(f"  precision   {pr[0][0]:<12.8}  {pr[0][1]:<.8}")
+                    print(f"  recall      {pr[1][0]:<12.8}  {pr[1][1]:<.8}")
+                    print(f"  fbeta score {pr[2][0]:<12.8}  {pr[2][1]:<.8}")
+                    print(f"  support     {pr[3][0]:<12}  {pr[3][1]}")
+                    print("CONFUSION MATRIX:")
+                    print(f"{confusion}")
+                    print("-" * 70)
+                    print("Top 10 features by importance:")
+                    self._classifier.print_feature_importance(data["feature_names"], 10)
+
+                    # let the parent thread know that we've finished this iteration
+                    self._tasks_complete += 1
+                    self.update_progress.emit(self._tasks_complete)
+
+                print("\n" + "=" * 70)
+                print("SUMMARY\n")
+                print(
+                    tabulate(
+                        table_rows,
+                        showindex="always",
+                        headers=[
+                            "accuracy",
+                            "precision\n(not behavior)",
+                            "precision\n(behavior)",
+                            "recall\n(not behavior)",
+                            "recall\n(behavior)",
+                            "f beta score\n(not behavior)",
+                            "f beta score\n(behavior)",
+                            "test - leave one out:\n(video [identity])",
+                        ],
+                    )
                 )
 
-                table_rows.append(
-                    [
-                        accuracy,
-                        pr[0][0],
-                        pr[0][1],
-                        pr[1][0],
-                        pr[1][1],
-                        pr[2][0],
-                        pr[2][1],
-                        f"{test_info['video']} [{test_info['identity']}]",
-                    ]
+                print(f"\nmean accuracy: {np.mean(accuracies):.5}")
+                print(f"std accuracy: {np.std(accuracies):.5}")
+                print(f"mean fbeta score (behavior): {np.mean(fbeta_behavior):.5}")
+                print(f"std fbeta score (behavior): {np.std(fbeta_behavior):.05}")
+                print(f"mean fbeta score (not behavior): {np.mean(fbeta_notbehavior):.5}")
+                print(f"std fbeta score (not behavior): {np.std(fbeta_notbehavior):.05}")
+                print(f"\nClassifier: {self._classifier.classifier_name}")
+                print(f"Behavior: {self._behavior}")
+                # TODO: move settings print to a common project function
+                # this will reduce repeated formatting across this and classify.py
+                unit = (
+                    "cm"
+                    if self._project.feature_manager.distance_unit == ProjectDistanceUnit.CM
+                    else "pixel"
                 )
-                accuracies.append(accuracy)
-                fbeta_behavior.append(pr[2][1])
-                fbeta_notbehavior.append(pr[2][0])
-
-                # print performance metrics and feature importance to console
+                print(f"Feature Distance Unit: {unit}")
                 print("-" * 70)
-                print(f"training iteration {i + 1}")
-                print("TEST DATA:")
-                print(f"\tVideo: {test_info['video']}")
-                print(f"\tIdentity: {test_info['identity']}")
-                print(f"ACCURACY: {accuracy * 100:.2f}%")
-                print("PRECISION RECALL:")
-                print(f"              {'not behavior':12}  behavior")
-                print(f"  precision   {pr[0][0]:<12.8}  {pr[0][1]:<.8}")
-                print(f"  recall      {pr[1][0]:<12.8}  {pr[1][1]:<.8}")
-                print(f"  fbeta score {pr[2][0]:<12.8}  {pr[2][1]:<.8}")
-                print(f"  support     {pr[3][0]:<12}  {pr[3][1]}")
-                print("CONFUSION MATRIX:")
-                print(f"{confusion}")
-                print("-" * 70)
-                print("Top 10 features by importance:")
-                self._classifier.print_feature_importance(data["feature_names"], 10)
 
-                # let the parent thread know that we've finished this iteration
-                self._tasks_complete += 1
-                self.update_progress.emit(self._tasks_complete)
-
-            print("\n" + "=" * 70)
-            print("SUMMARY\n")
-            print(
-                tabulate(
-                    table_rows,
-                    showindex="always",
-                    headers=[
-                        "accuracy",
-                        "precision\n(not behavior)",
-                        "precision\n(behavior)",
-                        "recall\n(not behavior)",
-                        "recall\n(behavior)",
-                        "f beta score\n(not behavior)",
-                        "f beta score\n(behavior)",
-                        "test - leave one out:\n(video [identity])",
-                    ],
-                )
+            # retrain with all training data and fixed random seed before saving:
+            self.current_status.emit("Training and saving final classifier")
+            full_dataset = self._classifier.combine_data(features["per_frame"], features["window"])
+            self._classifier.train(
+                {
+                    "training_data": full_dataset,
+                    "training_labels": features["labels"],
+                    "feature_names": full_dataset.columns.to_list(),
+                },
+                random_seed=FINAL_TRAIN_SEED,
             )
 
-            print(f"\nmean accuracy: {np.mean(accuracies):.5}")
-            print(f"std accuracy: {np.std(accuracies):.5}")
-            print(f"mean fbeta score (behavior): {np.mean(fbeta_behavior):.5}")
-            print(f"std fbeta score (behavior): {np.std(fbeta_behavior):.05}")
-            print(f"mean fbeta score (not behavior): {np.mean(fbeta_notbehavior):.5}")
-            print(f"std fbeta score (not behavior): {np.std(fbeta_notbehavior):.05}")
-            print(f"\nClassifier: {self._classifier.classifier_name}")
-            print(f"Behavior: {self._behavior}")
-            # TODO: move settings print to a common project function
-            # this will reduce repeated formatting across this and classify.py
-            unit = (
-                "cm"
-                if self._project.feature_manager.distance_unit == ProjectDistanceUnit.CM
-                else "pixel"
-            )
-            print(f"Feature Distance Unit: {unit}")
-            print("-" * 70)
+            self._project.save_classifier(self._classifier, self._behavior)
+            self._tasks_complete += 1
+            self.update_progress.emit(self._tasks_complete)
 
-        # retrain with all training data and fixed random seed before saving:
-        self.current_status.emit("Training and saving final classifier")
-        full_dataset = self._classifier.combine_data(
-            features["per_frame"], features["window"]
-        )
-        self._classifier.train(
-            {
-                "training_data": full_dataset,
-                "training_labels": features["labels"],
-                "feature_names": full_dataset.columns.to_list(),
-            },
-            random_seed=FINAL_TRAIN_SEED,
-        )
-
-        self._project.save_classifier(self._classifier, self._behavior)
-        self._tasks_complete += 1
-        self.update_progress.emit(self._tasks_complete)
-
-        self.current_status.emit("Training Complete")
-        self.training_complete.emit()
+            self.current_status.emit("Training Complete")
+            self.training_complete.emit()
+        except Exception as e:
+            # if there was an exception, we'll emit the Exception as a signal so that
+            # the main GUI thread can handle it
+            self.error_callback.emit(e)


### PR DESCRIPTION
previously, if an exception were raised during training or classification, the GUI would get stuck with the progress dialog open. The only remedy was to force quit the application. This was also confusing to users, because unless they looked in the terminal and saw the exception stack trace, they had no indication something was wrong other than the progress bar not moving for a long period of time. 

This change dismisses the progress bar and displays an alert dialog with a message about the exception that occurred. Also the stack trace is printed to the terminal to aid with debugging. In the future we could have CentralWidget treat different types of exceptions differently -- for example if there is a problem with data we could give the user a different error message (and not print the stack trace) vs if an unhandled exception is raised due to a bug in the code (need stack trace for debugging). 

Fixes #72 