### PR TITLE
adds field for filtering the list of videos using a partial string match

### DIFF
--- a/src/jabs/ui/video_list_widget.py
+++ b/src/jabs/ui/video_list_widget.py
@@ -111,7 +111,7 @@ class VideoListDockWidget(QtWidgets.QDockWidget):
         """Filter the video list based on the text entered in the filter box."""
         for i in range(self._file_list.count()):
             item = self._file_list.item(i)
-            item.setHidden(text.lower() not in item.text().lower())
+            item.setHidden(text.strip().lower() not in item.text().lower())
 
     def set_project(self, project):
         """Update the video list with the active project's videos and select first video in list."""


### PR DESCRIPTION
lets user filter the list of videos in a project by a simple string partial match

e.g. if a user types "foo" in the search box, all video names that contain the substring "foo" will be shown in the video list

This comparison is case insensitive 

filtering the video list does not change the selected video, even if the selected video is now hidden in the list.  The user needs to click on a new video in the filtered results to change the loaded video. 


Also, makes selected video more obvious

