### PR TITLE
fix previous and next video keyboard control when some video filenames are filtered

### DIFF
--- a/src/jabs/ui/video_list_widget.py
+++ b/src/jabs/ui/video_list_widget.py
@@ -171,24 +171,35 @@ class VideoListDockWidget(QtWidgets.QDockWidget):
                 item.setText(video)
 
     def select_previous_video(self) -> None:
-        """Select the previous video in the list, if possible.
+        """Select the previous visible video in the list, if possible.
 
-        Does nothing if already at the start or the list is empty.
-        """
-        if self._file_list.count() == 0:
-            return
-        current_row = self._file_list.currentRow()
-        if current_row > 0:
-            self._file_list.setCurrentRow(current_row - 1)
-
-    def select_next_video(self) -> None:
-        """Select the next video in the list, if possible.
-
-        Does nothing if already at the end or the list is empty.
+        Skips over hidden items to find the last visible item before
+        the current selection.
         """
         count = self._file_list.count()
         if count == 0:
             return
         current_row = self._file_list.currentRow()
-        if 0 <= current_row < count - 1:
-            self._file_list.setCurrentRow(current_row + 1)
+        # Search backwards for the previous visible item
+        for i in range(current_row - 1, -1, -1):
+            item = self._file_list.item(i)
+            if not item.isHidden():
+                self._file_list.setCurrentRow(i)
+                break
+
+    def select_next_video(self) -> None:
+        """Select the next visible video in the list, if possible.
+
+        Skips over hidden items to find the next visible item after
+        the current selection.
+        """
+        count = self._file_list.count()
+        if count == 0:
+            return
+        current_row = self._file_list.currentRow()
+        # Search forwards for the next visible item
+        for i in range(current_row + 1, count):
+            item = self._file_list.item(i)
+            if not item.isHidden():
+                self._file_list.setCurrentRow(i)
+                break


### PR DESCRIPTION
currentRow() and setCurrentRow() in a QListWidget operate on all items, not just visible ones. 

This resulted in a bug when using the previous and next video keyboard shortcuts while a filter is applied to the video list.

This change searches forward or backwards from the current video to find the next or previous visible video to account for filtering 