### PR TITLE
deal with more errors reading cached convex hulls

### DIFF
--- a/src/jabs/pose_estimation/pose_est.py
+++ b/src/jabs/pose_estimation/pose_est.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 
 import h5py
+import joblib
 import numpy as np
 from shapely.geometry import MultiPoint
 
@@ -255,8 +256,8 @@ class PoseEstimation(ABC):
 
                 try:
                     with path.open("rb") as f:
-                        convex_hulls = pickle.load(f)
-                except OSError:
+                        convex_hulls = joblib.load(f)
+                except (OSError, EOFError, pickle.UnpicklingError):
                     # we weren't able to read in the cached convex hulls,
                     # just ignore the exception and we'll generate them
                     pass
@@ -279,7 +280,7 @@ class PoseEstimation(ABC):
 
                 if path:
                     with path.open("wb") as f:
-                        pickle.dump(convex_hulls, f)
+                        joblib.dump(convex_hulls, f)
 
             self._convex_hull_cache[identity] = convex_hulls
             return convex_hulls

--- a/src/jabs/pose_estimation/pose_est.py
+++ b/src/jabs/pose_estimation/pose_est.py
@@ -1,5 +1,4 @@
 import enum
-import pickle
 from abc import ABC, abstractmethod
 from pathlib import Path
 
@@ -257,7 +256,7 @@ class PoseEstimation(ABC):
                 try:
                     with path.open("rb") as f:
                         convex_hulls = joblib.load(f)
-                except (OSError, EOFError, pickle.UnpicklingError):
+                except Exception:
                     # we weren't able to read in the cached convex hulls,
                     # just ignore the exception and we'll generate them
                     pass


### PR DESCRIPTION
handle more types of errors when trying to read cached convex hull arrays

also uses joblib for reading/writing pickle file (used elsewhere in JABS rather than the pickle module because it handles numpy arrays better. changing here just for consistency )