### PR TITLE
implement timeline annotation search

### DIFF
--- a/src/jabs/behavior_search/__init__.py
+++ b/src/jabs/behavior_search/__init__.py
@@ -6,5 +6,6 @@ from .behavior_search_util import (
     PredictionBehaviorSearchQuery,
     PredictionSearchKind,
     SearchHit,
+    TimelineAnnotationSearchQuery,
     search_behaviors,
 )

--- a/src/jabs/ui/central_widget.py
+++ b/src/jabs/ui/central_widget.py
@@ -982,22 +982,20 @@ class CentralWidget(QtWidgets.QWidget):
             self._player_widget.seek_to_frame(search_hit.start_frame)
 
             # set the current identity based on the search hit
-            try:
-                selected_id = int(search_hit.identity)
-            except ValueError:
-                selected_id = None
+            selected_id = search_hit.identity
+            if selected_id is not None:
+                try:
+                    selected_id = int(selected_id)
+                except ValueError:
+                    selected_id = None
 
             num_identities = self._pose_est.num_identities
             if selected_id is not None and selected_id < num_identities:
                 self._controls.set_identity_index(selected_id)
-            else:
-                print(f"Invalid identity for search hit: {search_hit.identity}")
 
             # update the behavior in the controls to match the search hit
             if search_hit.behavior is not None:
                 self._controls.set_behavior(search_hit.behavior)
-            else:
-                print("Search hit has no behavior, using current behavior.")
 
             self.search_hit_loaded.emit(search_hit)
 

--- a/src/jabs/ui/search_bar_widget.py
+++ b/src/jabs/ui/search_bar_widget.py
@@ -6,6 +6,7 @@ from jabs.behavior_search import (
     PredictionBehaviorSearchQuery,
     PredictionSearchKind,
     SearchHit,
+    TimelineAnnotationSearchQuery,
     search_behaviors,
 )
 from jabs.project import Project
@@ -129,6 +130,7 @@ class SearchBarWidget(QtWidgets.QWidget):
             self.setVisible(True)
             self.text_label.setText(_describe_query(search_query))
             self._search_results = search_behaviors(self._project, search_query)
+            print(f"Search results: {len(self._search_results)} hits found.")
 
         self._update_result_count_label()
         self.search_results_changed.emit(self._search_results)
@@ -335,11 +337,31 @@ def _describe_query(query: BehaviorSearchQuery) -> str:
                         parts.append(f"behavior prob. < {lt}")
 
             if max_frames is not None and min_frames is not None:
-                parts.append(f"with {min_frames} to {max_frames} contiguous frames")
+                parts.append(f"having {min_frames} to {max_frames} contiguous frames")
             elif min_frames is not None and min_frames > 1:
-                parts.append(f"with at least {min_frames} contiguous frames")
+                parts.append(f"having at least {min_frames} contiguous frames")
             elif max_frames is not None and max_frames > 1:
-                parts.append(f"with at most {max_frames} contiguous frames")
+                parts.append(f"having at most {max_frames} contiguous frames")
+
+            return " ".join(parts)
+
+        case TimelineAnnotationSearchQuery(
+            tag=tag,
+            min_contiguous_frames=min_frames,
+            max_contiguous_frames=max_frames,
+        ):
+            parts = []
+            if tag is None:
+                parts.append("All timeline annotations")
+            else:
+                parts.append(f"Timeline annotations with tag '{tag}'")
+
+            if max_frames is not None and min_frames is not None:
+                parts.append(f"having {min_frames} to {max_frames} contiguous frames")
+            elif min_frames is not None and min_frames > 1:
+                parts.append(f"having at least {min_frames} contiguous frames")
+            elif max_frames is not None and max_frames > 1:
+                parts.append(f"having at most {max_frames} contiguous frames")
 
             return " ".join(parts)
         case _:

--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/label_overview_util.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/label_overview_util.py
@@ -1,17 +1,19 @@
+from random import Random
+
 from PySide6.QtCore import QPoint, Qt
 from PySide6.QtGui import QBrush, QPen, QPolygon
 
 from ...colors import SEARCH_HIT_COLOR
 
 
-def diamond_at(x, y, w, h):
+def diamond_at(x: float, y: float, w: float, h: float) -> QPolygon:
     """Create a diamond shape polygon centered at (x, y) with width w and height h.
 
     Args:
-        x (int): The x-coordinate of the center.
-        y (int): The y-coordinate of the center.
-        w (int): The width of the diamond.
-        h (int): The height of the diamond.
+        x (float): The x-coordinate of the center.
+        y (float): The y-coordinate of the center.
+        w (float): The width of the diamond.
+        h (float): The height of the diamond.
 
     Returns:
         QPolygon: A polygon representing the diamond shape.
@@ -42,15 +44,35 @@ def render_search_hits(
     """
     qp.setPen(QPen(SEARCH_HIT_COLOR, 1, Qt.PenStyle.SolidLine))
     qp.setBrush(QBrush(SEARCH_HIT_COLOR, Qt.BrushStyle.SolidPattern))
-    center_y = bar_height // 2
-    diamond_w = bar_height // 8
-    diamond_h = bar_height // 8
+    diamond_w = bar_height / 8
+    diamond_h = bar_height / 8
 
-    for hit in search_results:
+    rand = Random(str(search_results[0].start_frame) if search_results else "42")
+
+    y_min_dist_edge = diamond_h
+    y_min_neighbor_sep = diamond_h
+
+    prev_y_pos = 0
+    for i, hit in enumerate(search_results):
         rel_start_frame = hit.start_frame - start
         rel_end_frame = hit.end_frame - start + 1
         bounded_rel_start = max(0, rel_start_frame)
         bounded_rel_end = min(window_frames_total, rel_end_frame)
+
+        # Randomly select a y position but take care not to have y overlap with the
+        # previous hit. This will give an ability to distinguish between hits that
+        # overlap in time.
+        if i == 0:
+            y_pos = rand.random() * (bar_height - y_min_dist_edge * 2) + y_min_dist_edge
+        else:
+            y_pos = (
+                rand.random() * (bar_height - y_min_dist_edge * 2 - y_min_neighbor_sep * 2)
+                + y_min_dist_edge
+            )
+            if y_pos > prev_y_pos - y_min_neighbor_sep:
+                y_pos += y_min_neighbor_sep * 2
+
+        prev_y_pos = y_pos
 
         if bounded_rel_start > rel_end_frame or bounded_rel_end < rel_start_frame:
             # skip search hits that are completely out of bounds
@@ -58,10 +80,10 @@ def render_search_hits(
 
         start_pos = offset + (bounded_rel_start * frame_width)
         end_pos = offset + (bounded_rel_end * frame_width)
-        qp.drawLine(start_pos, center_y, end_pos, center_y)
+        qp.drawLine(start_pos, y_pos, end_pos, y_pos)
 
         if bounded_rel_start == rel_start_frame:
-            qp.drawPolygon(diamond_at(start_pos, center_y, diamond_w, diamond_h))
+            qp.drawPolygon(diamond_at(start_pos, y_pos, diamond_w, diamond_h))
 
         if bounded_rel_end == rel_end_frame:
-            qp.drawPolygon(diamond_at(end_pos, center_y, diamond_w, diamond_h))
+            qp.drawPolygon(diamond_at(end_pos, y_pos, diamond_w, diamond_h))

--- a/src/jabs/ui/stacked_timeline_widget/stacked_timeline_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/stacked_timeline_widget.py
@@ -9,6 +9,7 @@ from jabs.behavior_search import (
     LabelBehaviorSearchQuery,
     PredictionBehaviorSearchQuery,
     SearchHit,
+    TimelineAnnotationSearchQuery,
 )
 from jabs.project import TrackLabels
 
@@ -400,9 +401,9 @@ class StackedTimelineWidget(QWidget):
         for i, label_overview_widget in enumerate(self._label_overview_widgets):
             curr_search_results: list[SearchHit] = []
             match behavior_search_query:
-                case LabelBehaviorSearchQuery():
+                case LabelBehaviorSearchQuery() | TimelineAnnotationSearchQuery():
                     for hit in search_results:
-                        if hit.identity == str(i):
+                        if hit.identity is None or hit.identity == str(i):
                             curr_search_results.append(hit)
 
             label_overview_widget.set_search_results(curr_search_results)
@@ -410,9 +411,9 @@ class StackedTimelineWidget(QWidget):
         for i, prediction_overview_widget in enumerate(self._prediction_overview_widgets):
             curr_search_results: list[SearchHit] = []
             match behavior_search_query:
-                case PredictionBehaviorSearchQuery():
+                case PredictionBehaviorSearchQuery() | TimelineAnnotationSearchQuery():
                     for hit in search_results:
-                        if hit.identity == str(i):
+                        if hit.identity is None or hit.identity == str(i):
                             curr_search_results.append(hit)
 
             prediction_overview_widget.set_search_results(curr_search_results)


### PR DESCRIPTION
Implement timeline annotation search with ability to specify a contiguous frame count range. Also randomized y axis placement of search results on timeline to avoid confusion if search hits overlap in time. Loading available tag strings is done in a background thread for the search dialog to avoid blocking the UI.