### PR TITLE
implement dialog to show timeline annotation details

### DIFF
--- a/src/jabs/ui/player_widget/overlays/annotation_info_dialog.py
+++ b/src/jabs/ui/player_widget/overlays/annotation_info_dialog.py
@@ -1,0 +1,27 @@
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QDialog, QFormLayout, QLabel, QPushButton, QVBoxLayout
+
+
+class AnnotationInfoDialog(QDialog):
+    """Dialog to display detailed information about an annotation."""
+
+    def __init__(self, annotation_data: dict, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Annotation Details")
+        layout = QVBoxLayout(self)
+
+        tag_label = QLabel(f"<b>{annotation_data.get('tag', '')}</b>")
+        tag_label.setAlignment(Qt.AlignmentFlag.AlignHCenter)
+        layout.addWidget(tag_label)
+
+        form = QFormLayout()
+        form.addRow("Start Frame:", QLabel(str(annotation_data.get("start", ""))))
+        form.addRow("End Frame:", QLabel(str(annotation_data.get("end", ""))))
+        desc_label = QLabel(annotation_data.get("description", ""))
+        desc_label.setWordWrap(True)
+        form.addRow("Description:", desc_label)
+        layout.addLayout(form)
+
+        close_btn = QPushButton("Close")
+        close_btn.clicked.connect(self.accept)
+        layout.addWidget(close_btn)

--- a/src/jabs/ui/player_widget/overlays/annotation_overlay.py
+++ b/src/jabs/ui/player_widget/overlays/annotation_overlay.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 
 from PySide6 import QtCore, QtGui
 
+from .annotation_info_dialog import AnnotationInfoDialog
 from .overlay import Overlay
 
 if TYPE_CHECKING:
@@ -135,7 +136,10 @@ class AnnotationOverlay(Overlay):
                 # Draw all stacked rectangles
                 for x, y, rect_width, rect_height, annotation, text, color_str in rects:
                     rect = QtCore.QRectF(x, y, rect_width, rect_height)
-                    self._rects_with_data.append((rect, annotation.data))
+                    data = annotation.data.copy()
+                    data["start"] = annotation.begin
+                    data["end"] = annotation.end
+                    self._rects_with_data.append((rect, data))
                     fill_color = QtGui.QColor(color_str)
                     if not fill_color.isValid():
                         fill_color = QtGui.QColor(220, 220, 220)
@@ -172,7 +176,10 @@ class AnnotationOverlay(Overlay):
             y = self.parent.scaled_pix_y + self._MARGIN_Y + i * (rect_height + self._SPACING)
 
             rect = QtCore.QRectF(x, y, rect_width, rect_height)
-            self._rects_with_data.append((rect, annotation.data))
+            data = annotation.data.copy()
+            data["start"] = annotation.begin
+            data["end"] = annotation.end
+            self._rects_with_data.append((rect, data))
             fill_color = QtGui.QColor(color_str)
             if not fill_color.isValid():
                 fill_color = QtGui.QColor(220, 220, 220)
@@ -199,7 +206,7 @@ class AnnotationOverlay(Overlay):
         pos = event.position() if hasattr(event, "position") else event.pos()
         for rect, annotation in self._rects_with_data:
             if rect.contains(pos):
-                # TODO: display annotations details in a dialog or tooltip
-                print(f"Clicked on annotation: {annotation['tag']}")
+                dialog = AnnotationInfoDialog(annotation, self.parent)
+                dialog.exec()
                 return True
         return False


### PR DESCRIPTION
implements the on click event for timeline annotations
uses a new dialog to show details about the annotation

<img width="886" height="526" alt="image" src="https://github.com/user-attachments/assets/a092c0d3-3f3c-4c5f-bbf6-5b62af015b0f" />
