### PR TITLE
make behavior when opening project from command line more reliable on macOS

### DIFF
--- a/src/jabs/scripts/gui_entrypoint.py
+++ b/src/jabs/scripts/gui_entrypoint.py
@@ -29,6 +29,10 @@ def main():
         sys.exit(1)
 
     if args.project_dir is not None:
+        # this force the GUI to process events before opening the project
+        # this is necessary to avoid a race condition where the main window
+        # is not fully initialized before trying to open the project
+        QtWidgets.QApplication.processEvents()
         try:
             main_window.open_project(args.project_dir)
         except Exception as e:

--- a/src/jabs/scripts/gui_entrypoint.py
+++ b/src/jabs/scripts/gui_entrypoint.py
@@ -29,7 +29,7 @@ def main():
         sys.exit(1)
 
     if args.project_dir is not None:
-        # this force the GUI to process events before opening the project
+        # this forces the GUI to process events before opening the project
         # this is necessary to avoid a race condition where the main window
         # is not fully initialized before trying to open the project
         QtWidgets.QApplication.processEvents()


### PR DESCRIPTION
jabs lets you open a project directly from the command line:

`jabs <path to project dir>`

on macOS, sometimes the JABS window does not take focus when it is launched this way which also sometimes results in the menu bar not being updated with the JABS menu unless you minimize and restore JABS

This change makes sure the main window has a chance to process events before trying to open the project, which helps ensure it is fully initialized before opening the project. 