### PR TITLE
revert name change of window op for circular features

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jabs-behavior-classifier"
-version = "0.34.0"
+version = "0.34.1"
 license = "Proprietary"
 repository = "https://github.com/KumarLabJax/JABS-behavior-classifier"
 description = ""

--- a/src/jabs/feature_extraction/base_features/angles.py
+++ b/src/jabs/feature_extraction/base_features/angles.py
@@ -16,8 +16,8 @@ class Angles(Feature):
 
     # need to override to set the correct range for circular operations
     _circular_window_operations: typing.ClassVar[dict[str, typing.Callable]] = {
-        "circmean": lambda x: stats.circmean(x, low=0, high=360, nan_policy="omit"),
-        "circstd": lambda x: stats.circstd(x, low=0, high=360, nan_policy="omit"),
+        "mean": lambda x: stats.circmean(x, low=0, high=360, nan_policy="omit"),
+        "std": lambda x: stats.circstd(x, low=0, high=360, nan_policy="omit"),
     }
 
     def __init__(self, poses: PoseEstimation, pixel_scale: float):

--- a/src/jabs/feature_extraction/feature_base_class.py
+++ b/src/jabs/feature_extraction/feature_base_class.py
@@ -54,8 +54,8 @@ class Feature(abc.ABC):
     # most angles are bearings in the range [-180, 180)
     # if an angle feature is in a different range, the subclass needs to override this
     _circular_window_operations: typing.ClassVar[dict[str, typing.Callable]] = {
-        "circmean": lambda x: stats.circmean(x, low=-180, high=180, nan_policy="omit"),
-        "circstd": lambda x: stats.circstd(x, low=-180, high=180, nan_policy="omit"),
+        "mean": lambda x: stats.circmean(x, low=-180, high=180, nan_policy="omit"),
+        "std": lambda x: stats.circstd(x, low=-180, high=180, nan_policy="omit"),
     }
 
     def __init__(self, poses: PoseEstimation, pixel_scale: float):

--- a/src/jabs/feature_extraction/features.py
+++ b/src/jabs/feature_extraction/features.py
@@ -16,7 +16,7 @@ from .landmark_features import LandmarkFeatureGroup
 from .segmentation_features import SegmentationFeatureGroup
 from .social_features import SocialFeatureGroup
 
-FEATURE_VERSION = 14
+FEATURE_VERSION = 15
 
 _FEATURE_MODULES = [BaseFeatureGroup, SocialFeatureGroup, SegmentationFeatureGroup]
 

--- a/tests/feature_modules/test_corner_features.py
+++ b/tests/feature_modules/test_corner_features.py
@@ -39,23 +39,9 @@ class TestCornerFeatures(TestFeatureBase):
 
             bearing_window_values = bearing_to_corner.window(i, 5, bearing_per_frame)
             for op in bearing_window_values:
-                if op.startswith("circ"):
-                    # circular operations
+                for feature in bearing_window_values[op]:
                     self.assertEqual(
-                        bearing_window_values[op]["bearing to corner"].shape,
-                        (self._pose_est_v5.num_frames,),
-                    )
-                    self.assertEqual(
-                        bearing_window_values[op]["bearing to center"].shape,
-                        (self._pose_est_v5.num_frames,),
-                    )
-                else:
-                    self.assertEqual(
-                        bearing_window_values[op]["bearing to corner sine"].shape,
-                        (self._pose_est_v5.num_frames,),
-                    )
-                    self.assertEqual(
-                        bearing_window_values[op]["bearing to center cosine"].shape,
+                        bearing_window_values[op][feature].shape,
                         (self._pose_est_v5.num_frames,),
                     )
 


### PR DESCRIPTION
reverts name change of window operations for circular features to restore backwards compatibility with previously exported training data