### PR TITLE
Fix feature file

### DIFF
--- a/src/jabs/feature_extraction/base_features/angles.py
+++ b/src/jabs/feature_extraction/base_features/angles.py
@@ -17,7 +17,7 @@ class Angles(Feature):
     # need to override to set the correct range for circular operations
     _circular_window_operations: typing.ClassVar[dict[str, typing.Callable]] = {
         "mean": lambda x: stats.circmean(x, low=0, high=360, nan_policy="omit"),
-        "std": lambda x: stats.circstd(x, low=0, high=360, nan_policy="omit"),
+        "std_dev": lambda x: stats.circstd(x, low=0, high=360, nan_policy="omit"),
     }
 
     def __init__(self, poses: PoseEstimation, pixel_scale: float):

--- a/src/jabs/feature_extraction/feature_base_class.py
+++ b/src/jabs/feature_extraction/feature_base_class.py
@@ -55,7 +55,7 @@ class Feature(abc.ABC):
     # if an angle feature is in a different range, the subclass needs to override this
     _circular_window_operations: typing.ClassVar[dict[str, typing.Callable]] = {
         "mean": lambda x: stats.circmean(x, low=-180, high=180, nan_policy="omit"),
-        "std": lambda x: stats.circstd(x, low=-180, high=180, nan_policy="omit"),
+        "std_dev": lambda x: stats.circstd(x, low=-180, high=180, nan_policy="omit"),
     }
 
     def __init__(self, poses: PoseEstimation, pixel_scale: float):

--- a/src/jabs/feature_extraction/feature_base_class.py
+++ b/src/jabs/feature_extraction/feature_base_class.py
@@ -150,7 +150,6 @@ class Feature(abc.ABC):
                 if k.endswith(" sine") or k.endswith(" cosine")
             }
             circular = {k: v for k, v in per_frame_features.items() if k not in non_circular}
-
             circular_features = self._window_circular(identity, window_size, circular)
         else:
             # feature does not use circular window operations, so we can compute standard window features on all values
@@ -159,7 +158,15 @@ class Feature(abc.ABC):
         # standard method for computing window features on non-circular values
         non_circular_features = self._window_standard(identity, window_size, non_circular)
 
-        return circular_features | non_circular_features
+        merged = dict(non_circular_features)  # start with dict1's keys/values
+
+        for k, v in circular_features.items():
+            if k in merged:
+                merged[k] = {**merged[k], **v}  # merge the inner dicts
+            else:
+                merged[k] = v
+
+        return merged
 
     def _window_standard(self, identity: int, window_size: int, per_frame_values: dict) -> dict:
         """standard method for computing standard window feature values

--- a/src/jabs/feature_extraction/feature_base_class.py
+++ b/src/jabs/feature_extraction/feature_base_class.py
@@ -158,8 +158,8 @@ class Feature(abc.ABC):
         # standard method for computing window features on non-circular values
         non_circular_features = self._window_standard(identity, window_size, non_circular)
 
+        # non_circular_features and circular_features are both dicts of dicts, but they may have overlapping *top level* keys.
         merged = dict(non_circular_features)  # start with dict1's keys/values
-
         for k, v in circular_features.items():
             if k in merged:
                 merged[k] = {**merged[k], **v}  # merge the inner dicts

--- a/src/jabs/feature_extraction/features.py
+++ b/src/jabs/feature_extraction/features.py
@@ -16,7 +16,7 @@ from .landmark_features import LandmarkFeatureGroup
 from .segmentation_features import SegmentationFeatureGroup
 from .social_features import SocialFeatureGroup
 
-FEATURE_VERSION = 15
+FEATURE_VERSION = 16
 
 _FEATURE_MODULES = [BaseFeatureGroup, SocialFeatureGroup, SegmentationFeatureGroup]
 


### PR DESCRIPTION
renaming circular mean and std_dev from `circmean` and `circstd` back to `mean` and `std_dev` caused them to get overwritten by the non-circular mean and std_dev if a Feature class included both circular and non-circular per-frame features. 

This pull request fixes the merging of circular and non-circular window features computed by a Feature class. This assumes there can be a collision with the top-level key names. 

also, the circular standard deviation was improperly renamed in the last pull request. 