### PR TITLE
Add timeline annotation editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.pyc
 
+# pyinstaller
 dist
+build
 
 .idea
 .vscode

--- a/src/jabs/pose_estimation/pose_est.py
+++ b/src/jabs/pose_estimation/pose_est.py
@@ -364,3 +364,16 @@ class PoseEstimation(ABC):
     def external_identities(self) -> list[int] | None:
         """get the jabs identity to external identity mapping"""
         return self._external_identities
+
+    def identity_index_to_display(self, identity_index: int) -> str:
+        """Convert an identity index to a display string.
+
+        Args:
+            identity_index (int): The identity index to convert.
+
+        Returns:
+            str: The display string for the identity.
+        """
+        if self.external_identities and 0 <= identity_index < len(self.external_identities):
+            return str(self.external_identities[identity_index])
+        return str(identity_index)

--- a/src/jabs/project/__init__.py
+++ b/src/jabs/project/__init__.py
@@ -4,11 +4,13 @@ from .export_training import export_training_data
 from .project import Project
 from .project_pruning import get_videos_to_prune
 from .read_training import load_training_data
+from .timeline_annotations import TimelineAnnotations
 from .track_labels import TrackLabels
 from .video_labels import VideoLabels
 
 __all__ = [
     "Project",
+    "TimelineAnnotations",
     "TrackLabels",
     "VideoLabels",
     "export_training_data",

--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -384,7 +384,7 @@ class Project:
                     archived_labels[video][behavior][ident] = annotations["labels"][ident].pop(
                         behavior
                     )
-            self.save_annotations(VideoLabels.load(annotations), pose)
+            self.save_annotations(VideoLabels.load(annotations, pose), pose)
 
         # write the archived labels out
         ts = datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/src/jabs/project/timeline_annotations.py
+++ b/src/jabs/project/timeline_annotations.py
@@ -101,10 +101,13 @@ class TimelineAnnotations:
             # Create a data dict for the interval.
             # Note: description and identity are optional fields
             identity_index = annotation.get("identity")
-            if pose and identity_index is not None:
-                display_identity = pose.identity_index_to_display(identity_index)
+            if identity_index is not None:
+                if pose:
+                    display_identity = pose.identity_index_to_display(identity_index)
+                else:
+                    display_identity = str(identity_index)
             else:
-                display_identity = str(identity_index)
+                display_identity = None
             data = {
                 "tag": tag,
                 "color": color,

--- a/src/jabs/project/timeline_annotations.py
+++ b/src/jabs/project/timeline_annotations.py
@@ -67,6 +67,9 @@ class TimelineAnnotations:
 
         Returns:
             TimelineAnnotations: An instance loaded with the provided data.
+
+        Note: loading currently skips invalid entries with a warning printed to stderr. Consider
+        raising an exception for stricter handling in the future.
         """
         annotations = cls()
 
@@ -85,7 +88,7 @@ class TimelineAnnotations:
                 continue
 
             # validate the tag format:
-            if 1 > len(tag) > MAX_TAG_LEN:
+            if len(tag) < 1 or len(tag) > MAX_TAG_LEN:
                 print(
                     f"Annotation tag must be 1 to {MAX_TAG_LEN} characters in length, skipping annotation: \n\t{annotation}",
                     file=sys.stderr,

--- a/src/jabs/project/timeline_annotations.py
+++ b/src/jabs/project/timeline_annotations.py
@@ -152,18 +152,6 @@ class TimelineAnnotations:
             annotations.append(annotation_data)
         return annotations
 
-    def _intervaltree_candidates(self, start: int, end: int) -> list[Interval]:
-        """Retrieve candidate intervals in the interval tree overlapping the given start and end.
-
-        Args:
-            start (int): The start frame of the interval.
-            end (int): The end frame of the interval (inclusive).
-
-        Returns:
-            list[Interval]: A list of candidate Interval objects overlapping the given range.
-        """
-        return list(self._tree[start : end + 1])
-
     @staticmethod
     def _interval_matches(
         interval: Interval, *, start: int, end: int, tag: str, identity_index: int | None
@@ -199,7 +187,7 @@ class TimelineAnnotations:
         Returns:
             list[Interval]: A list of matching Interval objects.
         """
-        candidates = self._intervaltree_candidates(start, end)
+        candidates = self._tree[start : end + 1]
         return [
             interval
             for interval in candidates

--- a/src/jabs/project/timeline_annotations.py
+++ b/src/jabs/project/timeline_annotations.py
@@ -34,11 +34,7 @@ class TimelineAnnotations:
         display_identity: str | None = None
 
     def __init__(self) -> None:
-        """Initialize a TimelineAnnotations instance with an empty IntervalTree.
-
-        Args:
-            tree (IntervalTree): The interval tree containing annotation intervals.
-        """
+        """Initialize a TimelineAnnotations instance with an empty IntervalTree."""
         self._tree: IntervalTree = IntervalTree()
 
     def add_annotation(self, annotation: Annotation) -> None:

--- a/src/jabs/project/timeline_annotations.py
+++ b/src/jabs/project/timeline_annotations.py
@@ -1,0 +1,272 @@
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+from intervaltree import Interval, IntervalTree
+
+from jabs.pose_estimation import PoseEstimation
+
+MAX_TAG_LEN = 32
+
+
+class TimelineAnnotations:
+    """A stand-alone helper class for managing timeline annotations stored in an IntervalTree.
+
+    This class provides methods to load, serialize, query, and manipulate annotations
+    represented as intervals within an IntervalTree. Annotations typically represent
+    labeled segments on a timeline, each with start and end frames, tags, rendering color,
+    and optional identity indices.
+
+    Attributes:
+        _tree (IntervalTree): The underlying interval tree storing annotation intervals.
+    """
+
+    @dataclass
+    class Annotation:
+        """Dataclass to define an Annotation to be stored in the IntervalTree."""
+
+        start: int
+        end: int
+        tag: str
+        color: str
+        description: str | None = None
+        identity_index: int | None = None
+        display_identity: str | None = None
+
+    def __init__(self) -> None:
+        """Initialize a TimelineAnnotations instance with an empty IntervalTree.
+
+        Args:
+            tree (IntervalTree): The interval tree containing annotation intervals.
+        """
+        self._tree: IntervalTree = IntervalTree()
+
+    def add_annotation(self, annotation: Annotation) -> None:
+        """Add a new timeline annotation to the interval tree.
+
+        Args:
+            annotation (Annotation): The annotation to add.
+        """
+        self._tree[annotation.start : annotation.end + 1] = {
+            "tag": annotation.tag,
+            "color": annotation.color,
+            "description": annotation.description,
+            "identity": annotation.identity_index,
+            "display_identity": annotation.display_identity,
+        }
+
+    @classmethod
+    def load(
+        cls, data: list[dict[str, Any]], pose: PoseEstimation | None = None
+    ) -> "TimelineAnnotations":
+        """Load a TimelineAnnotations instance from a JSON-compatible dictionary.
+
+        Args:
+            data (dict): The dictionary containing serialized timeline annotations.
+            pose (PoseEstimation | None): Optional PoseEstimation instance for identity mapping.
+
+        Returns:
+            TimelineAnnotations: An instance loaded with the provided data.
+        """
+        annotations = cls()
+
+        for annotation in data:
+            try:
+                start = annotation["start"]
+                end = annotation["end"]
+                tag = annotation["tag"]
+                color = annotation["color"]
+            except KeyError:
+                print(
+                    "Missing required annotation fields, loading skipped for annotation:",
+                    annotation,
+                    file=sys.stderr,
+                )
+                continue
+
+            # validate the tag format:
+            if 1 > len(tag) > MAX_TAG_LEN:
+                print(
+                    f"Annotation tag must be 1 to {MAX_TAG_LEN} characters in length, skipping annotation: \n\t{annotation}",
+                    file=sys.stderr,
+                )
+                continue
+            # only allow alphanumeric characters, underscores, and hyphens
+            if not all(c.isalnum() or c in "_-" for c in tag):
+                print(
+                    f"Annotation tag can only contain alphanumeric characters, underscores, and hyphens. Skipping annotation: \n\t{annotation}",
+                    file=sys.stderr,
+                )
+                continue
+
+            # Create a data dict for the interval.
+            # Note: description and identity are optional fields
+            identity_index = annotation.get("identity")
+            if pose and identity_index is not None:
+                display_identity = pose.identity_index_to_display(identity_index)
+            else:
+                display_identity = str(identity_index)
+            data = {
+                "tag": tag,
+                "color": color,
+                "description": annotation.get("description"),
+                "identity": identity_index,
+                "display_identity": display_identity,
+            }
+
+            # Add the annotation to the IntervalTree.
+            # The start and end contained in the JSON file are inclusive, so we add 1 to end.
+            annotations._tree[start : end + 1] = data
+        return annotations
+
+    def serialize(self) -> list[dict]:
+        """Convert the internal IntervalTree to a JSON-serializable list of dictionaries.
+
+        Returns:
+            list[dict]: A list containing a dictionary representation for each timeline annotation,
+             suitable for JSON serialization.
+        """
+        annotations = []
+        for element in self._tree:
+            try:
+                annotation_data = {
+                    "start": element.begin,
+                    "end": element.end - 1,  # convert to inclusive
+                    "tag": element.data["tag"],
+                    "color": element.data["color"],
+                }
+            except KeyError as e:
+                print(f"Missing required annotation data: {e}")
+                continue
+
+            # optional fields
+            description = element.data.get("description")
+            if description is not None:
+                annotation_data["description"] = description
+            identity = element.data.get("identity")
+            if identity is not None:
+                annotation_data["identity"] = identity
+
+            annotations.append(annotation_data)
+        return annotations
+
+    def _intervaltree_candidates(self, start: int, end: int) -> list[Interval]:
+        """Retrieve candidate intervals in the interval tree overlapping the given start and end.
+
+        Args:
+            start (int): The start frame of the interval.
+            end (int): The end frame of the interval (inclusive).
+
+        Returns:
+            list[Interval]: A list of candidate Interval objects overlapping the given range.
+        """
+        return list(self._tree[start : end + 1])
+
+    @staticmethod
+    def _interval_matches(
+        interval: Interval, *, start: int, end: int, tag: str, identity_index: int | None
+    ) -> bool:
+        """Determine if an interval matches the given annotation parameters.
+
+        Args:
+            interval (Interval): The interval to check.
+            start (int): The expected start frame.
+            end (int): The expected end frame (inclusive).
+            tag (str): The annotation tag to match (case-insensitive).
+            identity_index (int | None): The identity index to match, or None.
+
+        Returns:
+            bool: True if the interval matches all parameters, False otherwise.
+        """
+        if interval.begin != start or (interval.end - 1) != end:
+            return False
+        data = interval.data or {}
+        return data["tag"].lower() == tag.lower() and data.get("identity") == identity_index
+
+    def find_matching_intervals(
+        self, *, start: int, end: int, tag: str, identity_index: int | None
+    ) -> list[Interval]:
+        """Find all intervals matching the specified annotation parameters.
+
+        Args:
+            start (int): The start frame of the annotation.
+            end (int): The end frame of the annotation (inclusive).
+            tag (str): The annotation tag to match (case-insensitive).
+            identity_index (int | None): The identity index to match, or None.
+
+        Returns:
+            list[Interval]: A list of matching Interval objects.
+        """
+        candidates = self._intervaltree_candidates(start, end)
+        return [
+            interval
+            for interval in candidates
+            if self._interval_matches(
+                interval, start=start, end=end, tag=tag, identity_index=identity_index
+            )
+        ]
+
+    def annotation_exists(
+        self, *, start: int, end: int, tag: str, identity_index: int | None
+    ) -> bool:
+        """Check if an annotation with the given parameters exists in the interval tree.
+
+        Args:
+            start (int): The start frame of the annotation.
+            end (int): The end frame of the annotation (inclusive).
+            tag (str): The annotation tag to match (case-insensitive).
+            identity_index (int | None): The identity index to match, or None.
+
+        Returns:
+            bool: True if such an annotation exists, False otherwise.
+        """
+        return bool(
+            self.find_matching_intervals(
+                start=start, end=end, tag=tag, identity_index=identity_index
+            )
+        )
+
+    def remove_annotation_by_key(
+        self, *, start: int, end: int, tag: str, identity_index: int | None
+    ) -> int:
+        """Remove all annotations matching the specified parameters from the interval tree.
+
+        Args:
+            start (int): The start frame of the annotation.
+            end (int): The end frame of the annotation (inclusive).
+            tag (str): The annotation tag to match (case-insensitive).
+            identity_index (int | None): The identity index to match, or None.
+
+        Returns:
+            int: The number of annotations removed.
+
+        Note: this implementation removes all matching annotations -- however in practice
+        it should match 0 or 1 since we check for key collision at insertion time.
+        """
+        intervals = self.find_matching_intervals(
+            start=start, end=end, tag=tag, identity_index=identity_index
+        )
+        for interval in intervals:
+            self._tree.remove(interval)
+        return len(intervals)
+
+    def __len__(self) -> int:
+        """Return the number of annotations stored in the interval tree.
+
+        Returns:
+            int: The number of annotations in the tree.
+        """
+        return len(self._tree)
+
+    def __getitem__(self, key):
+        """Provide array-like access to annotations.
+
+        Supports slicing and indexing by delegating to the internal IntervalTree's __getitem__.
+
+        Args:
+            key (int, slice, or interval specifier): The key to index or slice the annotations.
+
+        Returns:
+            set[Interval]: The intervals corresponding to the key.
+        """
+        return self._tree[key]

--- a/src/jabs/project/timeline_annotations.py
+++ b/src/jabs/project/timeline_annotations.py
@@ -1,10 +1,9 @@
 import sys
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
 from intervaltree import Interval, IntervalTree
-
-from jabs.pose_estimation import PoseEstimation
 
 MAX_TAG_LEN = 32
 
@@ -53,13 +52,13 @@ class TimelineAnnotations:
 
     @classmethod
     def load(
-        cls, data: list[dict[str, Any]], pose: PoseEstimation | None = None
+        cls, data: list[dict[str, Any]], id_index_to_display: Callable[[int], str] | None = None
     ) -> "TimelineAnnotations":
         """Load a TimelineAnnotations instance from a JSON-compatible dictionary.
 
         Args:
             data (dict): The dictionary containing serialized timeline annotations.
-            pose (PoseEstimation | None): Optional PoseEstimation instance for identity mapping.
+            id_index_to_display (Callable[[int], str] | None): Optional function to map identity index to a display string.
 
         Returns:
             TimelineAnnotations: An instance loaded with the provided data.
@@ -102,8 +101,8 @@ class TimelineAnnotations:
             # Note: description and identity are optional fields
             identity_index = annotation.get("identity")
             if identity_index is not None:
-                if pose:
-                    display_identity = pose.identity_index_to_display(identity_index)
+                if id_index_to_display:
+                    display_identity = id_index_to_display(identity_index)
                 else:
                     display_identity = str(identity_index)
             else:

--- a/src/jabs/project/video_labels.py
+++ b/src/jabs/project/video_labels.py
@@ -219,7 +219,9 @@ class VideoLabels:
 
         # load non-behavior annotations if they exist
         if "annotations" in video_label_dict:
-            labels._annotations = TimelineAnnotations.load(video_label_dict["annotations"], pose)
+            labels._annotations = TimelineAnnotations.load(
+                video_label_dict["annotations"], pose.identity_index_to_display
+            )
 
         return labels
 

--- a/src/jabs/project/video_labels.py
+++ b/src/jabs/project/video_labels.py
@@ -301,7 +301,7 @@ class VideoLabels:
                 if pose and identity_index is not None:
                     display_identity = pose.identity_index_to_display(identity_index)
                 else:
-                    display_identity = None
+                    display_identity = str(identity_index)
                 data = {
                     "tag": tag,
                     "color": color,

--- a/src/jabs/project/video_labels.py
+++ b/src/jabs/project/video_labels.py
@@ -9,9 +9,6 @@ if TYPE_CHECKING:
     from .project_merge import MergeStrategy
 
 
-MAX_TAG_LEN = 32
-
-
 class VideoLabels:
     """Stores and manages frame-level behavior labels for each identity in a video.
 

--- a/src/jabs/project/video_manager.py
+++ b/src/jabs/project/video_manager.py
@@ -89,8 +89,9 @@ class VideoManager:
 
         path = self._paths.annotations_dir / Path(video_filename).with_suffix(".json")
 
-        # if annotations already exist for this video file in the project open
+        # if annotations already exist for this video file in the project open them
         if path.exists():
+            # VideoLabels.load can use pose to convert identity index to the display identity
             pose = open_pose_file(
                 get_pose_path(self.video_path(video_filename)), self._paths.cache_dir
             )

--- a/src/jabs/project/video_manager.py
+++ b/src/jabs/project/video_manager.py
@@ -80,7 +80,6 @@ class VideoManager:
 
         Args:
             video_name: filename of the video: string or pathlib.Path
-            pose_est: PoseEstimation object used to initialize the VideoLabels
 
         Returns:
             initialized VideoLabels object if annotations exist, otherwise None
@@ -92,8 +91,11 @@ class VideoManager:
 
         # if annotations already exist for this video file in the project open
         if path.exists():
+            pose = open_pose_file(
+                get_pose_path(self.video_path(video_filename)), self._paths.cache_dir
+            )
             with path.open() as f:
-                return VideoLabels.load(json.load(f))
+                return VideoLabels.load(json.load(f), pose)
         else:
             return None
 

--- a/src/jabs/resources/docs/user_guide/user_guide.md
+++ b/src/jabs/resources/docs/user_guide/user_guide.md
@@ -455,10 +455,12 @@ unselect the frames and leave select mode without making a change to the labels.
 
 ### Applying Labels
 
-The "Label Behavior Button" will mark all of the frames in the current selection
-as showing the behavior. The "Label Not Behavior" button will mark all of the
-frames in the current selection as not showing the behavior. Finally, the "Clear
-Labels" button will remove all labels from the currently selected frames.
+The label **Behavior** button will mark the selected interval of frames as showing
+the current behavior. The label **Not Behavior** button will mark all the
+frames in selected interval as not showing the behavior. The **New Timeline Annotation**
+button will open the Timeline Annotation Editor dialog to create a new timeline 
+annotation for the selected interval. Finally, the "Clear Labels" button will remove
+all labels from the currently selected frames.
 
 ### Keyboard Shortcuts
 

--- a/src/jabs/resources/docs/user_guide/user_guide.md
+++ b/src/jabs/resources/docs/user_guide/user_guide.md
@@ -18,7 +18,7 @@ estimation files. The first time a project directory is opened in JABS, it will
 create a subdirectory called "jabs", which contains various files created by
 JABS to save project state, including labels and current predictions.
 
-### Example JABS project directory listing:
+### Example JABS Project Directory listing:
 
 ```text
 VIDEO_1.avi
@@ -38,9 +38,9 @@ VIDEO_7_pose_est_v3.h5
 jabs/
 ```
 
-## Initializing A JABS Project Directory
+## Initializing a JABS Project Directory
 
-The first time you open a project directory in with JABS it will create the 
+The first time you open a project directory with JABS it will create the 
 "jabs" subdirectory. Features will be computed the first time the "Train" button
 is clicked. This can be very time-consuming depending on the number and length
 of videos in the project directory.
@@ -50,11 +50,11 @@ directory before it is opened in the JABS GUI. This script checks to make sure
 that a pose file exists for each video in the directory, and that the pose file
 and video have the same number of frames. Then, after these basic checks, the
 script will compute features for all the videos in the project. Since
-`jabs-int` can compute features for multiple videos in parallel, it
+`jabs-init` can compute features for multiple videos in parallel, it
 is significantly faster than doing so through the GUI during the training
 process.
 
-### jabs-init usage:
+### jabs-init Usage:
 
 ```text
 usage: jabs-init [-h] [-f] [-p PROCESSES] [-w WINDOW_SIZE] [--force-pixel-distances] [--metadata METADATA]
@@ -81,7 +81,7 @@ options:
                         Skip feature calculation and only initialize/validate the project
 ```
 
-### example jabs-init command
+### Example jabs-init Command
 
 The following command runs the `jabs-init` script to compute features
 using window sizes of 2, 5, and 10. The script will use up to 8 processes for
@@ -323,16 +323,16 @@ tool (`jabs-classify`).
 - **Sliding Window Indicator:** highlights the section of the global views that
   correspond to the frames displayed in the "sliding window" views.
 
-By default, the Timeline shows manual labels and predicted behaviors for the currently 
+By default, the Timeline shows manual labels and predicted behaviors for the current 
 subject animal. The Timeline can be toggled to show all subjects by selecting 
 View->Timeline->All Animals in the menu bar. The Timeline can also be toggled to show only
 manual labels, only predicted labels. If "All Animals" is selected, the Timeline will show
 which set of labels and predictions belong to the subject animal by drawing a colored box 
-them. 
+around them. 
 
 **Timeline Menu**
 
-<img src="imgs/timeline_menu.png" alt="JABS Timeline" alt="Timeline visualization options" />
+<img src="imgs/timeline_menu.png" alt="Timeline visualization options" />
 
 <br />
 **Example Timeline with "Labels & Predictions" and "All Animals" selected**
@@ -457,12 +457,68 @@ unselect the frames and leave select mode without making a change to the labels.
 
 The label **Behavior** button will mark the selected interval of frames as showing
 the current behavior. The label **Not Behavior** button will mark all the
-frames in selected interval as not showing the behavior. The **New Timeline Annotation**
+frames in the selected interval as not showing the behavior. The **New Timeline Annotation**
 button will open the Timeline Annotation Editor dialog to create a new timeline 
 annotation for the selected interval. Finally, the "Clear Labels" button will remove
 all labels from the currently selected frames.
 
-### Keyboard Shortcuts
+### Timeline Annotations
+
+Timeline annotations mark frame intervals that are not tied to a behavior label. They are never
+used for training and can apply to the entire video or to a specific animal (via an identity).
+Each annotation includes a short tag, an optional description, and a display color. Tags appear
+as overlays in the video and can be searched (with search hits highlighted in the label timeline),
+making it easy to flag edge cases, highlight areas of disagreement for review, or note uncertainty
+and poor pose quality.
+
+#### Where They’re Stored
+Each video’s annotations are saved to `jabs/annotations/<video_name>.json` inside the project directory.
+
+Example annotation file (other top-level fields omitted for clarity):
+```json
+{
+  "annotations": [
+    {
+      "start": 100,
+      "end": 200,
+      "tag": "identity",
+      "identity": 0,
+      "color": "#ff0000",
+      "description": "identity is wrong"
+    },
+    {
+      "start": 150,
+      "end": 250,
+      "tag": "obstructed",
+      "identity": null,
+      "color": "#0000ff",
+      "description": "view is obstructed"
+    }
+  ]
+}
+```
+
+##### Fields
+- start (int): first frame index (inclusive).
+- end (int): last frame index (inclusive).
+- tag (str): short label for quick identification (see Tag rules).
+- identity (int | null): optional animal identity; if omitted or null, the annotation applies to the whole video.
+- color (str): display color, e.g. `#RRGGBB` or an SVG color name.
+- description (str, optional): free-text notes.
+
+##### Tag Rules
+- Characters: letters, digits, underscores `_`, and hyphens `-`; **no whitespace**.
+- Length: 1–32 characters.
+- Matching/filtering is case-insensitive; display preserves your original casing.
+
+##### How They’re Displayed
+- Tag Overlay: the tag appears as a badge in the video.
+- If identity is set, the tag follows that animal.
+- If the pose file includes external identity mapping, the JABS identity is converted to the external ID for display.
+- If pose is missing, the tag snaps to the upper-left corner and is prefixed with the identity (e.g., 1234: tag).
+- Clicking a tag opens details.
+
+### Labeling Using Keyboard Shortcuts
 
 Using the keyboard controls can be the fastest way to label.
 
@@ -472,7 +528,7 @@ The arrow keys can be used for stepping through video. The up arrow skips ahead
 10 frames, and the down arrow skips back 10 frames. The right arrow advances one
 frame, and the left arrow goes back one frame.
 
-#### Labeling  Controls
+#### Labeling Controls
 
 The z, x, and c keys can be used to apply labels.
 

--- a/src/jabs/ui/annotation_edit_dialog.py
+++ b/src/jabs/ui/annotation_edit_dialog.py
@@ -161,7 +161,7 @@ class AnnotationEditDialog(QDialog):
         self._update_color_display()
         form.addRow("Color:", color_row)
 
-        # Description (wider)
+        # Description
         self._description_edit = QLineEdit()
         self._description_edit.setPlaceholderText("Optional description…")
         self._description_edit.setSizePolicy(
@@ -173,7 +173,7 @@ class AnnotationEditDialog(QDialog):
             self._description_edit.setText(description)
         form.addRow("Description:", self._description_edit)
 
-        # Applies-to (stacked vertically in a single form row)
+        # annotation scope (identity vs entire video)
         self._identity_radio = QRadioButton("Selected identity")
         self._video_radio = QRadioButton("Entire video")
         # Default selection is identity, but allow override via parameter

--- a/src/jabs/ui/annotation_edit_dialog.py
+++ b/src/jabs/ui/annotation_edit_dialog.py
@@ -198,12 +198,9 @@ class AnnotationEditDialog(QDialog):
         if edit_mode:
             self._identity_radio.setEnabled(False)
             self._video_radio.setEnabled(False)
-            self._identity_radio.setToolTip(
-                "Scope cannot be changed when editing an existing annotation."
-            )
-            self._video_radio.setToolTip(
-                "Scope cannot be changed when editing an existing annotation."
-            )
+            tooltip = "Scope cannot be changed when editing an existing annotation."
+            self._identity_radio.setToolTip(tooltip)
+            self._video_radio.setToolTip(tooltip)
 
         # Collapsible Help panel (hidden by default)
         toggle_button = QToolButton()

--- a/src/jabs/ui/annotation_edit_dialog.py
+++ b/src/jabs/ui/annotation_edit_dialog.py
@@ -19,7 +19,7 @@ from PySide6.QtWidgets import (
 )
 from qt_material_icons import MaterialIcon
 
-from jabs.project import timeline_annotations, video_labels
+from jabs.project import timeline_annotations
 
 DEFAULT_ANNOTATION_COLOR = "#6495ED"  # cornflower blue
 
@@ -133,9 +133,9 @@ class AnnotationEditDialog(QDialog):
 
         # Tag
         self._tag_edit = QLineEdit()
-        self._tag_edit.setMaxLength(video_labels.MAX_TAG_LEN)
+        self._tag_edit.setMaxLength(timeline_annotations.MAX_TAG_LEN)
         char_width = self._tag_edit.fontMetrics().averageCharWidth()
-        self._tag_edit.setMinimumWidth(char_width * (video_labels.MAX_TAG_LEN + 2))
+        self._tag_edit.setMinimumWidth(char_width * (timeline_annotations.MAX_TAG_LEN + 2))
         self._tag_edit.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         self._tag_edit.textChanged.connect(self._update_tag_label_style)
         form.addRow("Tag:", self._tag_edit)
@@ -352,7 +352,7 @@ class AnnotationEditDialog(QDialog):
         Returns:
             True if valid, False otherwise
         """
-        return 0 < len(tag) <= video_labels.MAX_TAG_LEN and all(
+        return 0 < len(tag) <= timeline_annotations.MAX_TAG_LEN and all(
             c.isalnum() or c in "_-" for c in tag
         )
 
@@ -365,7 +365,9 @@ class AnnotationEditDialog(QDialog):
         invalid = not self._is_tag_valid(tag)
         self._tag_edit.setStyleSheet("" if not invalid else "color: red;")
         self._tag_edit.setToolTip(
-            "" if not invalid else f"Alphanumeric, -, _ only; length ≤ {video_labels.MAX_TAG_LEN}"
+            ""
+            if not invalid
+            else f"Alphanumeric, -, _ only; length ≤ {timeline_annotations.MAX_TAG_LEN}"
         )
 
     def _update_ok_button_state(self) -> None:

--- a/src/jabs/ui/annotation_edit_dialog.py
+++ b/src/jabs/ui/annotation_edit_dialog.py
@@ -19,7 +19,7 @@ from PySide6.QtWidgets import (
 )
 from qt_material_icons import MaterialIcon
 
-from jabs.project import video_labels
+from jabs.project import timeline_annotations, video_labels
 
 DEFAULT_ANNOTATION_COLOR = "#6495ED"  # cornflower blue
 
@@ -31,7 +31,7 @@ end frame, a short tag, an optional animal identity, a display color, and an opt
 <br><br>
 <b>Tag requirements</b><br>
   • Alphanumeric only, may include <code>-</code> and <code>_</code>.<br>
-  • Length ≤ {video_labels.MAX_TAG_LEN} characters.<br>
+  • Length ≤ {timeline_annotations.MAX_TAG_LEN} characters.<br>
   • No whitespace or special characters allowed.<br>
   • Tags are case-preserving for display but are case insensitive for matching and search.<br><br> 
 <b>Color</b><br>

--- a/src/jabs/ui/annotation_edit_dialog.py
+++ b/src/jabs/ui/annotation_edit_dialog.py
@@ -1,0 +1,355 @@
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import (
+    QButtonGroup,
+    QColorDialog,
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QRadioButton,
+    QSizePolicy,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
+from qt_material_icons import MaterialIcon
+
+from jabs.project import video_labels
+
+DEFAULT_ANNOTATION_COLOR = "#6495ED"  # cornflower blue
+
+HELP_TEXT = f"""
+        <b>Tag requirements</b><br>
+        • Alphanumeric only, may include <code>-</code> and <code>_</code>.<br>
+        • Length ≤ {video_labels.MAX_TAG_LEN} characters.<br>
+        • No whitespace or special characters allowed.<br><br>
+        <b>Color</b><br>
+        • Use the picker to choose a color. This color is used for the annotation overlay in the video player.<br><br>
+        <b>Annotation scope</b><br>
+        • <i>Selected identity</i>: Annotation applies to the currently selected identity in the main window.<br>
+        • <i>Entire video</i>: Annotation applies to the video and not a specific animal identity.
+    """
+
+EDIT_HELP_TEXT = """
+        <b>Editing an existing annotation</b><br>
+        • You may update the <i>tag</i>, <i>color</i>, and <i>description</i> fields.<br>
+        • The start and end frames of the interval cannot be modified.<br>
+        • The scope (selected identity vs entire video) cannot be modified.<br>
+        • To change the interval or scope, please delete this annotation and create a new one.<br><br>
+    """
+
+
+class AnnotationEditDialog(QDialog):
+    """Dialog to add a new annotation or edit an existing one.
+
+    Args:
+        start: Start frame of the annotation interval.
+        end: End frame of the annotation interval.
+        parent: Parent widget.
+        tag: Initial tag value (for editing existing annotation).
+        color: Initial color value (for editing existing annotation).
+        description: Initial description value (for editing existing annotation).
+        applies_to_identity: Scope value (for editing existing annotation).
+        identity_index: Index of the identity this annotation applies to (if any).
+        display_identity: Display name of the identity (if any).
+        edit_mode: If True, the dialog is in edit mode (editing existing annotation).
+    Emits:
+        annotation_deleted: Emitted when an annotation is deleted, with payload containing
+            start, end, tag, and identity_index.
+
+    In edit_mode, you can change tag/color/description or delete. Interval and scope are currently locked
+    to the initial values.
+    Uniqueness key elsewhere is (start, end, tag, identity_index).
+    """
+
+    annotation_deleted = Signal(object)
+
+    def __init__(
+        self,
+        start: int,
+        end: int,
+        parent=None,
+        *,
+        tag: str | None = None,
+        color: str | QColor | None = None,
+        description: str | None = None,
+        applies_to_identity: bool | None = None,
+        identity_index: int | None = None,
+        display_identity: str | None = None,
+        edit_mode: bool = False,
+    ):
+        super().__init__(parent)
+        self.setWindowTitle("Edit Annotation" if edit_mode else "Add Annotation")
+        self._start = start
+        self._end = end
+        self._identity_index = identity_index
+        self._initial_tag = tag
+
+        if edit_mode and None in (tag, color, applies_to_identity):
+            raise ValueError("In edit mode, tag, color, and applies_to_identity must be provided.")
+
+        # root layout
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(14, 14, 14, 14)
+        layout.setSpacing(16)
+
+        # form area
+        form = QFormLayout()
+        form.setLabelAlignment(Qt.AlignmentFlag.AlignRight)
+        form.setFormAlignment(Qt.AlignmentFlag.AlignTop)
+        form.setHorizontalSpacing(12)
+        form.setVerticalSpacing(10)
+        form.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow)
+        layout.addLayout(form)
+
+        # Start / End (read-only display on one row each)
+        self._start_label = QLabel(str(start))
+        self._end_label = QLabel(str(end))
+        form.addRow("Start:", self._start_label)
+        form.addRow("End:", self._end_label)
+
+        # Optional identity display
+        self._identity_name_label = None
+        if display_identity:
+            self._identity_name_label = QLabel(display_identity)
+            self._identity_name_label.setTextInteractionFlags(
+                Qt.TextInteractionFlag.TextSelectableByMouse
+            )
+            form.addRow("Identity:", self._identity_name_label)
+
+        # Tag
+        self._tag_edit = QLineEdit()
+        self._tag_edit.setMaxLength(video_labels.MAX_TAG_LEN)
+        char_width = self._tag_edit.fontMetrics().averageCharWidth()
+        self._tag_edit.setMinimumWidth(char_width * 35)
+        self._tag_edit.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self._tag_edit.textChanged.connect(self._update_tag_label_style)
+        form.addRow("Tag:", self._tag_edit)
+        if tag is not None:
+            self._tag_edit.setText(tag)
+
+        # Color (swatch + hex label + pick button)
+        self._color = QColor(color) if color is not None else QColor(DEFAULT_ANNOTATION_COLOR)
+        color_row = QWidget()
+        color_layout = QHBoxLayout(color_row)
+        color_layout.setContentsMargins(0, 0, 0, 0)
+        color_layout.setSpacing(8)
+
+        self._color_swatch = QFrame()
+        self._color_swatch.setFixedSize(20, 20)
+        self._color_swatch.setFrameShape(QFrame.Shape.Box)
+        self._color_swatch.setLineWidth(1)
+
+        self._color_label = QLabel()
+        self._color_label.setMinimumWidth(80)
+
+        self._pick_color_btn = QPushButton("Pick…")
+        self._pick_color_btn.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self._pick_color_btn.clicked.connect(self._pick_color)
+
+        color_layout.addWidget(self._color_swatch)
+        color_layout.addWidget(self._color_label)
+        color_layout.addWidget(self._pick_color_btn)
+        color_layout.addStretch(1)
+
+        self._update_color_display()
+        form.addRow("Color:", color_row)
+
+        # Description (wider)
+        self._description_edit = QLineEdit()
+        self._description_edit.setPlaceholderText("Optional description…")
+        self._description_edit.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
+        )
+        char_width = self._description_edit.fontMetrics().averageCharWidth()
+        self._description_edit.setMinimumWidth(char_width * 80)
+        if description is not None:
+            self._description_edit.setText(description)
+        form.addRow("Description:", self._description_edit)
+
+        # Applies-to (stacked vertically in a single form row)
+        self._identity_radio = QRadioButton("Selected identity")
+        self._video_radio = QRadioButton("Entire video")
+        # Default selection is identity, but allow override via parameter
+        if applies_to_identity is None:
+            self._identity_radio.setChecked(True)
+        else:
+            self._identity_radio.setChecked(bool(applies_to_identity))
+            self._video_radio.setChecked(not bool(applies_to_identity))
+        radio_group = QButtonGroup(self)
+        radio_group.addButton(self._identity_radio)
+        radio_group.addButton(self._video_radio)
+
+        applies_widget = QWidget()
+        applies_vlayout = QVBoxLayout(applies_widget)
+        applies_vlayout.setContentsMargins(0, 0, 0, 0)
+        applies_vlayout.setSpacing(6)
+        applies_vlayout.addWidget(self._identity_radio)
+        applies_vlayout.addWidget(self._video_radio)
+        form.addRow("Annotation scope:", applies_widget)
+
+        # In edit mode, the scope (identity vs entire video) cannot be changed
+        if edit_mode:
+            self._identity_radio.setEnabled(False)
+            self._video_radio.setEnabled(False)
+            self._identity_radio.setToolTip(
+                "Scope cannot be changed when editing an existing annotation."
+            )
+            self._video_radio.setToolTip(
+                "Scope cannot be changed when editing an existing annotation."
+            )
+
+        # Collapsible Help panel (hidden by default)
+        toggle_button = QToolButton()
+        toggle_button.setText("Show help")
+        toggle_button.setCheckable(True)
+        toggle_button.setArrowType(Qt.ArrowType.RightArrow)
+        toggle_button.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
+        layout.addWidget(toggle_button)
+
+        details_panel = QWidget()
+        details_layout = QVBoxLayout(details_panel)
+        details_layout.setContentsMargins(8, 8, 8, 8)
+        details_layout.setSpacing(6)
+
+        details_label = QLabel()
+        details_label.setTextFormat(Qt.TextFormat.RichText)
+        details_label.setWordWrap(True)
+        details_label.setTextInteractionFlags(Qt.TextInteractionFlag.TextBrowserInteraction)
+        details_label.setText(
+            f"""
+                {HELP_TEXT}
+                {"<br><br>" + EDIT_HELP_TEXT if edit_mode else ""}
+            """
+        )
+        details_label.setOpenExternalLinks(True)
+        details_layout.addWidget(details_label)
+
+        details_panel.setVisible(False)
+        layout.addWidget(details_panel)
+
+        def _toggle_details(checked: bool) -> None:
+            """Show or hide the details panel and update button text/arrow."""
+            details_panel.setVisible(checked)
+            toggle_button.setText("Hide help" if checked else "Show help")
+            toggle_button.setArrowType(
+                Qt.ArrowType.DownArrow if checked else Qt.ArrowType.RightArrow
+            )
+            # Recompute layout so the dialog shrinks/expands to content
+            details_panel.updateGeometry()
+            self.layout().activate()
+            self.adjustSize()
+
+        toggle_button.toggled.connect(_toggle_details)
+
+        #  Dialog buttons
+        button_row = QHBoxLayout()
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        self._ok_button = buttons.button(QDialogButtonBox.StandardButton.Ok)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+
+        if edit_mode or any(v is not None for v in (tag, color, description, applies_to_identity)):
+            delete_button = QToolButton()
+            delete_button.setToolTip("Delete this annotation")
+            delete_button.setIcon(MaterialIcon("delete"))
+            delete_button.clicked.connect(self._confirm_delete)
+            button_row.addWidget(delete_button)
+
+        button_row.addStretch(1)
+        button_row.addWidget(buttons)
+
+        layout.addLayout(button_row)
+
+        # Validator wiring
+        self._tag_edit.textChanged.connect(self._update_ok_button_state)
+        self._update_ok_button_state()
+
+    def get_annotation(self) -> dict:
+        """Return the annotation data as a dictionary."""
+        return {
+            "tag": self._tag_edit.text(),
+            "color": self._color.name(QColor.NameFormat.HexRgb),
+            "description": self._description_edit.text() or None,
+            "applies_to_identity": self._identity_radio.isChecked(),
+        }
+
+    def _update_color_display(self) -> None:
+        """Update the color swatch and label to reflect the current color."""
+        name = self._color.name(QColor.NameFormat.HexRgb) if self._color.isValid() else "(none)"
+        self._color_label.setText(name)
+        self._color_swatch.setStyleSheet(f"background-color: {name};")
+
+    def _pick_color(self) -> None:
+        """Open color picker dialog and update color."""
+        chosen = QColorDialog.getColor(self._color, self, "Choose Annotation Color")
+        if chosen.isValid():
+            self._color = chosen
+            self._update_color_display()
+            self._update_ok_button_state()
+
+    def _confirm_delete(self) -> None:
+        """Confirm deletion; on Yes, emit signal and close dialog.
+
+        Parent code should connect to `annotation_deleted` and remove the interval(s)
+        from the appropriate IntervalTree in the VideoLabels object.
+        """
+        reply = QMessageBox.question(
+            self,
+            "Delete annotation?",
+            "Are you sure you want to delete this annotation? This cannot be undone.",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if reply == QMessageBox.StandardButton.Yes:
+            payload = {
+                "start": self._start,
+                "end": self._end,
+                "tag": self._initial_tag,
+                "identity_index": self._identity_index,
+            }
+            self.annotation_deleted.emit(payload)
+            # Close the dialog after emitting
+            self.reject()
+
+    @staticmethod
+    def _is_tag_valid(tag: str) -> bool:
+        """Check if a tag is valid according to the rules
+
+        Args:
+            tag: the tag string to validate
+        Returns:
+            True if valid, False otherwise
+        """
+        return 0 < len(tag) <= video_labels.MAX_TAG_LEN and all(
+            c.isalnum() or c in "_-" for c in tag
+        )
+
+    def _update_tag_label_style(self, tag: str) -> None:
+        """Update the tag label style based on validity.
+
+        Args:
+            tag: the current tag text
+        """
+        invalid = not self._is_tag_valid(tag)
+        self._tag_edit.setStyleSheet("" if not invalid else "color: red;")
+        self._update_ok_button_state()
+
+    def _update_ok_button_state(self) -> None:
+        """Enable or disable the OK button based on form validity."""
+        if not hasattr(self, "_ok_button"):
+            return  # may be called before button is set up
+
+        tag_valid = self._is_tag_valid(self._tag_edit.text())
+        color_valid = (
+            self._color.isValid() if hasattr(self, "_color") else False
+        )  # color may not be set yet
+        self._ok_button.setEnabled(tag_valid and color_valid)

--- a/src/jabs/ui/annotation_edit_dialog.py
+++ b/src/jabs/ui/annotation_edit_dialog.py
@@ -54,7 +54,7 @@ class AnnotationEditDialog(QDialog):
         tag: Initial tag value (for editing existing annotation).
         color: Initial color value (for editing existing annotation).
         description: Initial description value (for editing existing annotation).
-        applies_to_identity: Scope value (for editing existing annotation).
+        identity_scoped: Scope value (for editing existing annotation).
         identity_index: Index of the identity this annotation applies to (if any).
         display_identity: Display name of the identity (if any).
         edit_mode: If True, the dialog is in edit mode (editing existing annotation).
@@ -81,7 +81,7 @@ class AnnotationEditDialog(QDialog):
         tag: str | None = None,
         color: str | QColor | None = None,
         description: str | None = None,
-        applies_to_identity: bool | None = None,
+        identity_scoped: bool | None = None,
         identity_index: int | None = None,
         display_identity: str | None = None,
         edit_mode: bool = False,
@@ -93,8 +93,8 @@ class AnnotationEditDialog(QDialog):
         self._identity_index = identity_index
         self._initial_tag_value = tag
 
-        if edit_mode and None in (tag, color, applies_to_identity):
-            raise ValueError("In edit mode, tag, color, and applies_to_identity must be provided.")
+        if edit_mode and None in (tag, color, identity_scoped):
+            raise ValueError("In edit mode, tag, color, and identity_scoped must be provided.")
 
         # root layout
         layout = QVBoxLayout(self)
@@ -177,11 +177,11 @@ class AnnotationEditDialog(QDialog):
         self._identity_radio = QRadioButton("Selected identity")
         self._video_radio = QRadioButton("Entire video")
         # Default selection is identity, but allow override via parameter
-        if applies_to_identity is None:
+        if identity_scoped is None:
             self._identity_radio.setChecked(True)
         else:
-            self._identity_radio.setChecked(bool(applies_to_identity))
-            self._video_radio.setChecked(not bool(applies_to_identity))
+            self._identity_radio.setChecked(bool(identity_scoped))
+            self._video_radio.setChecked(not bool(identity_scoped))
         radio_group = QButtonGroup(self)
         radio_group.addButton(self._identity_radio)
         radio_group.addButton(self._video_radio)
@@ -287,7 +287,7 @@ class AnnotationEditDialog(QDialog):
             "tag": self._tag_edit.text(),
             "color": self._color.name(QColor.NameFormat.HexRgb),
             "description": self._description_edit.text() or None,
-            "applies_to_identity": self._identity_radio.isChecked(),
+            "identity_scoped": self._identity_radio.isChecked(),
         }
 
     def _update_color_display(self) -> None:

--- a/src/jabs/ui/annotation_edit_dialog.py
+++ b/src/jabs/ui/annotation_edit_dialog.py
@@ -235,7 +235,7 @@ class AnnotationEditDialog(QDialog):
         details_panel.setVisible(False)
         layout.addWidget(details_panel)
 
-        def _toggle_details(checked: bool) -> None:
+        def _toggle_help(checked: bool) -> None:
             """Show or hide the details panel and update button text/arrow."""
             details_panel.setVisible(checked)
             toggle_button.setText("Hide help" if checked else "Show help")
@@ -247,7 +247,7 @@ class AnnotationEditDialog(QDialog):
             self.layout().activate()
             self.adjustSize()
 
-        toggle_button.toggled.connect(_toggle_details)
+        toggle_button.toggled.connect(_toggle_help)
 
         #  Dialog buttons
         button_row = QHBoxLayout()

--- a/src/jabs/ui/annotation_edit_dialog.py
+++ b/src/jabs/ui/annotation_edit_dialog.py
@@ -24,24 +24,30 @@ from jabs.project import video_labels
 DEFAULT_ANNOTATION_COLOR = "#6495ED"  # cornflower blue
 
 HELP_TEXT = f"""
-        <b>Tag requirements</b><br>
-        • Alphanumeric only, may include <code>-</code> and <code>_</code>.<br>
-        • Length ≤ {video_labels.MAX_TAG_LEN} characters.<br>
-        • No whitespace or special characters allowed.<br><br>
-        <b>Color</b><br>
-        • Use the picker to choose a color. This color is used for the annotation overlay in the video player.<br><br>
-        <b>Annotation scope</b><br>
-        • <i>Selected identity</i>: Annotation applies to the currently selected identity in the main window.<br>
-        • <i>Entire video</i>: Annotation applies to the video and not a specific animal identity.
-    """
+<b>What are Timeline Annotations?</b><br>
+Timeline Annotations are user-defined labels for specific frame intervals in a video. They are not used for model
+training; they help flag edge cases, disagreements, or notes for review. Each annotation includes a start and
+end frame, a short tag, an optional animal identity, a display color, and an optional free-text description.
+<br><br>
+<b>Tag requirements</b><br>
+  • Alphanumeric only, may include <code>-</code> and <code>_</code>.<br>
+  • Length ≤ {video_labels.MAX_TAG_LEN} characters.<br>
+  • No whitespace or special characters allowed.<br>
+  • Tags are case-preserving for display but are case insensitive for matching and search.<br><br> 
+<b>Color</b><br>
+  • Use the picker to choose a color. This color is used for the annotation overlay in the video player.<br><br>
+<b>Annotation scope</b><br>
+  • <i>Selected identity</i>: Annotation applies to the currently selected identity in the main window.<br>
+  • <i>Entire video</i>: Annotation applies to the video and not a specific animal identity.
+"""
 
 EDIT_HELP_TEXT = """
-        <b>Editing an existing annotation</b><br>
-        • You may update the <i>tag</i>, <i>color</i>, and <i>description</i> fields.<br>
-        • The start and end frames of the interval cannot be modified.<br>
-        • The scope (selected identity vs entire video) cannot be modified.<br>
-        • To change the interval or scope, please delete this annotation and create a new one.<br><br>
-    """
+<b>Editing an existing annotation</b><br>
+  • You may update the <i>tag</i>, <i>color</i>, and <i>description</i> fields.<br>
+  • The start and end frames of the interval cannot be modified.<br>
+  • The scope (selected identity vs entire video) cannot be modified.<br>
+  • To change the interval or scope, please delete this annotation and create a new one.<br><br>
+"""
 
 
 class AnnotationEditDialog(QDialog):
@@ -219,12 +225,10 @@ class AnnotationEditDialog(QDialog):
         details_label.setTextFormat(Qt.TextFormat.RichText)
         details_label.setWordWrap(True)
         details_label.setTextInteractionFlags(Qt.TextInteractionFlag.TextBrowserInteraction)
-        details_label.setText(
-            f"""
-                {HELP_TEXT}
-                {"<br><br>" + EDIT_HELP_TEXT if edit_mode else ""}
-            """
-        )
+        details_label.setText(f"""
+            {HELP_TEXT}
+            {"<br><br>" + EDIT_HELP_TEXT if edit_mode else ""}
+        """)
         details_label.setOpenExternalLinks(True)
         details_layout.addWidget(details_label)
 

--- a/src/jabs/ui/annotation_edit_dialog.py
+++ b/src/jabs/ui/annotation_edit_dialog.py
@@ -135,7 +135,7 @@ class AnnotationEditDialog(QDialog):
         self._tag_edit = QLineEdit()
         self._tag_edit.setMaxLength(video_labels.MAX_TAG_LEN)
         char_width = self._tag_edit.fontMetrics().averageCharWidth()
-        self._tag_edit.setMinimumWidth(char_width * 35)
+        self._tag_edit.setMinimumWidth(char_width * (video_labels.MAX_TAG_LEN + 2))
         self._tag_edit.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         self._tag_edit.textChanged.connect(self._update_tag_label_style)
         form.addRow("Tag:", self._tag_edit)

--- a/src/jabs/ui/annotation_edit_dialog.py
+++ b/src/jabs/ui/annotation_edit_dialog.py
@@ -179,7 +179,7 @@ class AnnotationEditDialog(QDialog):
             self._description_edit.setText(description)
         form.addRow("Description:", self._description_edit)
 
-        # annotation scope (identity vs entire video)
+        # annotation scope (identity vs video)
         self._identity_radio = QRadioButton("Selected identity")
         self._video_radio = QRadioButton("Video")
         # Default selection is identity, but allow override via parameter
@@ -200,7 +200,7 @@ class AnnotationEditDialog(QDialog):
         applies_vlayout.addWidget(self._video_radio)
         form.addRow("Annotation scope:", applies_widget)
 
-        # In edit mode, the scope (identity vs entire video) cannot be changed
+        # In edit mode, the scope (identity vs video) cannot be changed
         if edit_mode:
             self._identity_radio.setEnabled(False)
             self._video_radio.setEnabled(False)

--- a/src/jabs/ui/annotation_edit_dialog.py
+++ b/src/jabs/ui/annotation_edit_dialog.py
@@ -38,7 +38,7 @@ end frame, a short tag, an optional animal identity, a display color, and an opt
   • Use the picker to choose a color. This color is used for the annotation overlay in the video player.<br><br>
 <b>Annotation scope</b><br>
   • <i>Selected identity</i>: Annotation applies to the currently selected identity in the main window.<br>
-  • <i>Entire video</i>: Annotation applies to the video and not a specific animal identity.
+  • <i>Video</i>: Annotation applies to the video and not a specific animal identity.
 """
 
 EDIT_HELP_TEXT = """
@@ -181,7 +181,7 @@ class AnnotationEditDialog(QDialog):
 
         # annotation scope (identity vs entire video)
         self._identity_radio = QRadioButton("Selected identity")
-        self._video_radio = QRadioButton("Entire video")
+        self._video_radio = QRadioButton("Video")
         # Default selection is identity, but allow override via parameter
         if identity_scoped is None:
             self._identity_radio.setChecked(True)

--- a/src/jabs/ui/annotation_edit_dialog.py
+++ b/src/jabs/ui/annotation_edit_dialog.py
@@ -341,7 +341,7 @@ class AnnotationEditDialog(QDialog):
 
     @staticmethod
     def _is_tag_valid(tag: str) -> bool:
-        """Check if a tag is valid according to the rules
+        """Check if a tag is valid
 
         Args:
             tag: the tag string to validate

--- a/src/jabs/ui/central_widget.py
+++ b/src/jabs/ui/central_widget.py
@@ -1172,10 +1172,10 @@ class CentralWidget(QtWidgets.QWidget):
         )
         if dialog.exec() == QDialog.DialogCode.Accepted:
             result = dialog.get_annotation()
-            # result keys: tag, color, description, applies_to_identity
+            # result keys: tag, color, description, identity_scoped
             tag = result["tag"]
             identity_index = (
-                self._controls.current_identity_index if result["applies_to_identity"] else None
+                self._controls.current_identity_index if result["identity_scoped"] else None
             )
             display_identity = (
                 self._pose_est.identity_index_to_display(self._controls.current_identity_index)
@@ -1229,7 +1229,7 @@ class CentralWidget(QtWidgets.QWidget):
 
         # insert the updated annotation back
         new_tag = updated["tag"]
-        identity = identity if updated["applies_to_identity"] else None
+        identity = identity if updated["identity_scoped"] else None
         display_identity = (
             self._pose_est.identity_index_to_display(identity) if identity is not None else None
         )

--- a/src/jabs/ui/central_widget.py
+++ b/src/jabs/ui/central_widget.py
@@ -1297,6 +1297,7 @@ class CentralWidget(QtWidgets.QWidget):
 
         Uniqueness key: (start, end, tag, identity_index)
         where `end` in our UI is inclusive, but `interval.end` is exclusive.
+        Tag matching is case-insensitive.
 
         Args:
             interval (Interval): The interval to check.
@@ -1311,7 +1312,7 @@ class CentralWidget(QtWidgets.QWidget):
         if interval.begin != start or (interval.end - 1) != end:
             return False
         data = interval.data or {}
-        return data.get("tag") == tag and data.get("identity") == identity_index
+        return data["tag"].lower() == tag.lower() and data.get("identity") == identity_index
 
     def _find_matching_intervals(
         self, *, start: int, end: int, tag: str, identity_index: int | None

--- a/src/jabs/ui/label_count_widget.py
+++ b/src/jabs/ui/label_count_widget.py
@@ -52,26 +52,14 @@ class FrameLabelCountWidget(QtWidgets.QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
 
         # add static labels to grid
-        layout.addWidget(
-            frame_header, 0, 0, 1, 3, alignment=Qt.AlignmentFlag.AlignCenter
-        )
-        layout.addWidget(
-            QtWidgets.QLabel("Subject"), 1, 1, alignment=Qt.AlignmentFlag.AlignRight
-        )
-        layout.addWidget(
-            QtWidgets.QLabel("Total"), 1, 2, alignment=Qt.AlignmentFlag.AlignRight
-        )
+        layout.addWidget(frame_header, 0, 0, 1, 3, alignment=Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(QtWidgets.QLabel("Subject"), 1, 1, alignment=Qt.AlignmentFlag.AlignRight)
+        layout.addWidget(QtWidgets.QLabel("Total"), 1, 2, alignment=Qt.AlignmentFlag.AlignRight)
         layout.addWidget(QtWidgets.QLabel("Behavior"), 2, 0)
         layout.addWidget(QtWidgets.QLabel("Not Behavior"), 3, 0)
-        layout.addWidget(
-            bout_header, 4, 0, 1, 3, alignment=Qt.AlignmentFlag.AlignCenter
-        )
-        layout.addWidget(
-            QtWidgets.QLabel("Subject"), 5, 1, alignment=Qt.AlignmentFlag.AlignRight
-        )
-        layout.addWidget(
-            QtWidgets.QLabel("Total"), 5, 2, alignment=Qt.AlignmentFlag.AlignRight
-        )
+        layout.addWidget(bout_header, 4, 0, 1, 3, alignment=Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(QtWidgets.QLabel("Subject"), 5, 1, alignment=Qt.AlignmentFlag.AlignRight)
+        layout.addWidget(QtWidgets.QLabel("Total"), 5, 2, alignment=Qt.AlignmentFlag.AlignRight)
         layout.addWidget(QtWidgets.QLabel("Behavior"), 6, 0)
         layout.addWidget(QtWidgets.QLabel("Not Behavior"), 7, 0)
 
@@ -159,21 +147,13 @@ class FrameLabelCountWidget(QtWidgets.QWidget):
               #bouts not behavior for project
         """
         self._frame_labels["behavior_current"].setText(f"{frame_behavior_current}")
-        self._frame_labels["not_behavior_current"].setText(
-            f"{frame_not_behavior_current}"
-        )
+        self._frame_labels["not_behavior_current"].setText(f"{frame_not_behavior_current}")
         self._frame_labels["behavior_project"].setText(f"{frame_behavior_project}")
-        self._frame_labels["not_behavior_project"].setText(
-            f"{frame_not_behavior_project}"
-        )
+        self._frame_labels["not_behavior_project"].setText(f"{frame_not_behavior_project}")
 
         self._bout_labels["behavior_current"].setText(f"{bout_behavior_current}")
-        self._bout_labels["not_behavior_current"].setText(
-            f"{bout_not_behavior_current}"
-        )
+        self._bout_labels["not_behavior_current"].setText(f"{bout_not_behavior_current}")
         self._bout_labels["behavior_project"].setText(f"{bout_behavior_project}")
-        self._bout_labels["not_behavior_project"].setText(
-            f"{bout_not_behavior_project}"
-        )
+        self._bout_labels["not_behavior_project"].setText(f"{bout_not_behavior_project}")
 
         self.update()

--- a/src/jabs/ui/main_control_widget.py
+++ b/src/jabs/ui/main_control_widget.py
@@ -227,8 +227,7 @@ class MainControlWidget(QtWidgets.QWidget):
                     }}
                 """)
 
-        self._timeline_annotation_button = QtWidgets.QPushButton("Timeline Annotation")
-        self._timeline_annotation_button.setToolTip("[a]")
+        self._timeline_annotation_button = QtWidgets.QPushButton("New Timeline Annotation")
         self._timeline_annotation_button.clicked.connect(self.timeline_annotation_button_clicked)
 
         self._clear_label_button = QtWidgets.QPushButton("Clear Label")

--- a/src/jabs/ui/main_control_widget.py
+++ b/src/jabs/ui/main_control_widget.py
@@ -61,6 +61,7 @@ class MainControlWidget(QtWidgets.QWidget):
     label_behavior_clicked = QtCore.Signal()
     label_not_behavior_clicked = QtCore.Signal()
     clear_label_clicked = QtCore.Signal()
+    timeline_annotation_button_clicked = QtCore.Signal()
     start_selection = QtCore.Signal(bool)
     identity_changed = QtCore.Signal()
     train_clicked = QtCore.Signal()
@@ -77,7 +78,7 @@ class MainControlWidget(QtWidgets.QWidget):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # initial behavior labels to list in the drop down selection
+        # initial behavior labels to list in the drop-down selection
         self._behaviors = []
 
         # behavior selection form components
@@ -185,23 +186,25 @@ class MainControlWidget(QtWidgets.QWidget):
         self._label_behavior_button = QtWidgets.QPushButton()
         self._label_behavior_button.setToolTip("[z]")
         self._label_behavior_button.clicked.connect(self.label_behavior_clicked)
-        self._label_behavior_button.setStyleSheet(f"""
-                    QPushButton {{
-                        background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
-                                           stop: 0 rgba{BEHAVIOR_BUTTON_COLOR_BRIGHT.getRgb()},
-                                           stop: 1.0 rgba{BEHAVIOR_COLOR.getRgb()});
-                        border-radius: 4px;
-                        padding: 2px;
-                        color: white;
-                    }}
-                    QPushButton:pressed {{
-                        background-color: rgba{BEHAVIOR_BUTTON_COLOR_BRIGHT.getRgb()};
-                    }}
-                    QPushButton:disabled {{
-                        background-color: rgba{BEHAVIOR_BUTTON_DISABLED_COLOR.getRgb()};
-                        color: grey;
-                    }}
-                """)
+        self._label_behavior_button.setStyleSheet(
+            f"""
+                QPushButton {{
+                    background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
+                                       stop: 0 rgba{BEHAVIOR_BUTTON_COLOR_BRIGHT.getRgb()},
+                                       stop: 1.0 rgba{BEHAVIOR_COLOR.getRgb()});
+                    border-radius: 4px;
+                    padding: 2px;
+                    color: white;
+                }}
+                QPushButton:pressed {{
+                    background-color: rgba{BEHAVIOR_BUTTON_COLOR_BRIGHT.getRgb()};
+                }}
+                QPushButton:disabled {{
+                    background-color: rgba{BEHAVIOR_BUTTON_DISABLED_COLOR.getRgb()};
+                    color: grey;
+                }}
+            """
+        )
 
         self._label_not_behavior_button = QtWidgets.QPushButton()
         self._label_not_behavior_button.setToolTip("[c]")
@@ -224,6 +227,10 @@ class MainControlWidget(QtWidgets.QWidget):
                     }}
                 """)
 
+        self._timeline_annotation_button = QtWidgets.QPushButton("Timeline Annotation")
+        self._timeline_annotation_button.setToolTip("[a]")
+        self._timeline_annotation_button.clicked.connect(self.timeline_annotation_button_clicked)
+
         self._clear_label_button = QtWidgets.QPushButton("Clear Label")
         self._clear_label_button.setToolTip("[x]")
         self._clear_label_button.clicked.connect(self.clear_label_clicked)
@@ -239,8 +246,9 @@ class MainControlWidget(QtWidgets.QWidget):
 
         label_layout.addWidget(self._label_behavior_button, 0, 0, 1, 2)
         label_layout.addWidget(self._label_not_behavior_button, 1, 0, 1, 2)
-        label_layout.addWidget(self._clear_label_button, 2, 0)
-        label_layout.addWidget(self._select_button, 2, 1)
+        label_layout.addWidget(self._timeline_annotation_button, 2, 0, 1, 2)
+        label_layout.addWidget(self._clear_label_button, 3, 0)
+        label_layout.addWidget(self._select_button, 3, 1)
         label_layout.setContentsMargins(5, 5, 5, 5)
         label_group = QtWidgets.QGroupBox("Labeling")
         label_group.setLayout(label_layout)
@@ -358,12 +366,14 @@ class MainControlWidget(QtWidgets.QWidget):
         self._label_not_behavior_button.setEnabled(False)
         self._clear_label_button.setEnabled(False)
         self._select_button.setChecked(False)
+        self._timeline_annotation_button.setEnabled(False)
 
     def enable_label_buttons(self):
         """enable labeling buttons"""
         self._label_behavior_button.setEnabled(True)
         self._label_not_behavior_button.setEnabled(True)
         self._clear_label_button.setEnabled(True)
+        self._timeline_annotation_button.setEnabled(True)
 
     def set_use_balance_labels_checkbox_enabled(self, val: bool):
         """enable or disable the balance labels checkbox"""

--- a/src/jabs/ui/player_widget/overlays/annotation_info_dialog.py
+++ b/src/jabs/ui/player_widget/overlays/annotation_info_dialog.py
@@ -49,6 +49,9 @@ class AnnotationInfoDialog(QDialog):
         form.addRow("Start Frame:", QLabel(str(annotation_data.get("start", ""))))
         form.addRow("End Frame:", QLabel(str(annotation_data.get("end", ""))))
 
+        if annotation_data.get("display_identity") is not None:
+            form.addRow("Identity:", QLabel(str(annotation_data["display_identity"])))
+
         # color: show swatch with the annotation color
         color = annotation_data["color"]
         color_row_widget = QWidget()
@@ -116,6 +119,8 @@ class AnnotationInfoDialog(QDialog):
             "identity": data.get("identity"),  # None means applies to whole video
         }
 
+        identity_scoped = bool(data.get("identity_scoped"))
+
         def _on_deleted(payload: dict) -> None:
             central_widget.on_annotation_deleted(payload)
 
@@ -126,7 +131,7 @@ class AnnotationInfoDialog(QDialog):
                 tag=original_key["tag"],
                 color=data.get("color"),
                 description=data.get("description"),
-                identity_scoped=bool(data.get("identity_scoped", True)),
+                identity_scoped=identity_scoped,
                 identity_index=data.get("identity"),  # your existing param
                 display_identity=data.get("display_identity"),
                 edit_mode=True,

--- a/src/jabs/ui/player_widget/overlays/annotation_info_dialog.py
+++ b/src/jabs/ui/player_widget/overlays/annotation_info_dialog.py
@@ -1,5 +1,23 @@
-from PySide6.QtCore import Qt
-from PySide6.QtWidgets import QDialog, QFormLayout, QLabel, QPushButton, QVBoxLayout
+import traceback
+from typing import TYPE_CHECKING
+
+from PySide6.QtCore import Qt, QTimer
+from PySide6.QtWidgets import (
+    QDialog,
+    QFormLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QToolButton,
+    QVBoxLayout,
+)
+from qt_material_icons import MaterialIcon
+
+from jabs.ui.annotation_edit_dialog import AnnotationEditDialog
+from jabs.ui.util import find_central_widget
+
+if TYPE_CHECKING:
+    from jabs.ui.central_widget import CentralWidget
 
 
 class AnnotationInfoDialog(QDialog):
@@ -22,6 +40,70 @@ class AnnotationInfoDialog(QDialog):
         form.addRow("Description:", desc_label)
         layout.addLayout(form)
 
-        close_btn = QPushButton("Close")
-        close_btn.clicked.connect(self.accept)
-        layout.addWidget(close_btn)
+        # Action buttons row: Edit (pencil) and Close
+        button_row = QHBoxLayout()
+        edit_button = QToolButton()
+        edit_button.setIcon(MaterialIcon("edit"))
+        edit_button.setToolTip("Edit this annotation")
+        edit_button.setAutoRaise(True)
+        edit_button.clicked.connect(lambda: self._open_editor(annotation_data))
+
+        close_button = QPushButton("Close")
+        close_button.clicked.connect(self.accept)
+        close_button.setDefault(True)
+
+        button_row.addWidget(edit_button)
+        button_row.addStretch(1)
+        button_row.addWidget(close_button)
+        layout.addLayout(button_row)
+
+    def _open_editor(self, data: dict) -> None:
+        """Open the AnnotationDialog in editable mode with prefilled fields.
+
+        End this dialog's modal session first, then open the editor to avoid
+        re-entrant modal warnings on macOS.
+        """
+        parent = self.parent()
+        central_widget: CentralWidget | None = find_central_widget(self)
+
+        if central_widget is None:
+            raise RuntimeWarning("Error: Could not find central widget to handle annotation edit.")
+
+        # capture the original key so central widget can find/remove the old interval
+        original_key = {
+            "start": int(data.get("start", 0)),
+            "end": int(data.get("end", 0)),
+            "tag": data.get("tag"),
+            "identity": data.get("identity"),  # None means applies to whole video
+        }
+
+        def _on_deleted(payload: dict) -> None:
+            central_widget.on_annotation_deleted(payload)
+
+        def launch_editor():
+            dialog = AnnotationEditDialog(
+                start=original_key["start"],
+                end=original_key["end"],
+                tag=original_key["tag"],
+                color=data.get("color"),
+                description=data.get("description"),
+                applies_to_identity=bool(data.get("applies_to_identity", True)),
+                identity_index=data.get("identity"),  # your existing param
+                display_identity=data.get("display_identity"),
+                edit_mode=True,
+                parent=parent,
+            )
+            dialog.annotation_deleted.connect(_on_deleted)
+            try:
+                rc = dialog.exec()
+                if rc == QDialog.DialogCode.Accepted:
+                    updated = dialog.get_annotation()
+                    if central_widget:
+                        central_widget.on_annotation_edited(original_key, updated)
+            except Exception as e:
+                print(f"Error during edit flow: {e}")
+                traceback.print_exc()
+
+        # Close this dialog's modal session cleanly, then schedule the editor
+        self.accept()
+        QTimer.singleShot(0, launch_editor)

--- a/src/jabs/ui/player_widget/overlays/annotation_info_dialog.py
+++ b/src/jabs/ui/player_widget/overlays/annotation_info_dialog.py
@@ -126,7 +126,7 @@ class AnnotationInfoDialog(QDialog):
                 tag=original_key["tag"],
                 color=data.get("color"),
                 description=data.get("description"),
-                applies_to_identity=bool(data.get("applies_to_identity", True)),
+                identity_scoped=bool(data.get("identity_scoped", True)),
                 identity_index=data.get("identity"),  # your existing param
                 display_identity=data.get("display_identity"),
                 edit_mode=True,

--- a/src/jabs/ui/player_widget/overlays/annotation_info_dialog.py
+++ b/src/jabs/ui/player_widget/overlays/annotation_info_dialog.py
@@ -1,7 +1,7 @@
-import traceback
 from typing import TYPE_CHECKING
 
-from PySide6.QtCore import Qt, QTimer
+from PySide6.QtCore import QSize, Qt, QTimer
+from PySide6.QtGui import QColor, QPixmap
 from PySide6.QtWidgets import (
     QDialog,
     QFormLayout,
@@ -10,6 +10,7 @@ from PySide6.QtWidgets import (
     QPushButton,
     QToolButton,
     QVBoxLayout,
+    QWidget,
 )
 from qt_material_icons import MaterialIcon
 
@@ -19,33 +20,71 @@ from jabs.ui.util import find_central_widget
 if TYPE_CHECKING:
     from jabs.ui.central_widget import CentralWidget
 
+# Swatch size constant for color display
+SWATCH_SIZE = 20
+
 
 class AnnotationInfoDialog(QDialog):
-    """Dialog to display detailed information about an annotation."""
+    """Dialog to display detailed information about an annotation.
 
-    def __init__(self, annotation_data: dict, parent=None):
+    Args:
+        annotation_data (dict): Dictionary containing annotation details.
+        parent (QWidget | None): Parent widget for the dialog.
+    """
+
+    def __init__(self, annotation_data: dict, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setWindowTitle("Annotation Details")
+        self.setMinimumWidth(400)
         layout = QVBoxLayout(self)
 
         tag_label = QLabel(f"<b>{annotation_data.get('tag', '')}</b>")
         tag_label.setAlignment(Qt.AlignmentFlag.AlignHCenter)
+        tag_label.setStyleSheet("font-size: 16pt;")
         layout.addWidget(tag_label)
 
         form = QFormLayout()
+        form.setLabelAlignment(Qt.AlignmentFlag.AlignLeft)
+        form.setFormAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
         form.addRow("Start Frame:", QLabel(str(annotation_data.get("start", ""))))
         form.addRow("End Frame:", QLabel(str(annotation_data.get("end", ""))))
-        desc_label = QLabel(annotation_data.get("description", ""))
-        desc_label.setWordWrap(True)
-        form.addRow("Description:", desc_label)
+
+        # color: show swatch with the annotation color
+        color = annotation_data["color"]
+        color_row_widget = QWidget()
+        color_row_layout = QHBoxLayout(color_row_widget)
+        color_row_layout.setContentsMargins(0, 0, 0, 0)
+        color_swatch = QLabel()
+        pixmap = QPixmap(SWATCH_SIZE, SWATCH_SIZE)
+        pixmap.fill(QColor(color))
+        color_swatch.setPixmap(pixmap)
+        color_row_layout.addWidget(color_swatch)
+        color_row_layout.addStretch(1)
+        form.addRow("Color:", color_row_widget)
+
+        # description
+        description_label = QLabel(annotation_data.get("description", ""))
+        description_label.setWordWrap(True)
+        form.addRow("Description:", description_label)
         layout.addLayout(form)
 
-        # Action buttons row: Edit (pencil) and Close
+        # buttons
         button_row = QHBoxLayout()
+        button_row.setAlignment(Qt.AlignmentFlag.AlignLeft)
         edit_button = QToolButton()
         edit_button.setIcon(MaterialIcon("edit"))
+        edit_button.setIconSize(QSize(24, 24))
         edit_button.setToolTip("Edit this annotation")
-        edit_button.setAutoRaise(True)
+        edit_button.setStyleSheet("""
+                QToolButton {
+                    border-radius: 6px;
+                    background-color: transparent;
+                    padding: 4px;
+                }
+                QToolButton:hover {
+                    background-color: rgba(0,0,0,0.1);
+                }
+            """)
         edit_button.clicked.connect(lambda: self._open_editor(annotation_data))
 
         close_button = QPushButton("Close")
@@ -67,7 +106,7 @@ class AnnotationInfoDialog(QDialog):
         central_widget: CentralWidget | None = find_central_widget(self)
 
         if central_widget is None:
-            raise RuntimeWarning("Error: Could not find central widget to handle annotation edit.")
+            raise RuntimeError("Error: Could not find central widget to handle annotation edit.")
 
         # capture the original key so central widget can find/remove the old interval
         original_key = {
@@ -102,6 +141,8 @@ class AnnotationInfoDialog(QDialog):
                         central_widget.on_annotation_edited(original_key, updated)
             except Exception as e:
                 print(f"Error during edit flow: {e}")
+                import traceback
+
                 traceback.print_exc()
 
         # Close this dialog's modal session cleanly, then schedule the editor

--- a/src/jabs/ui/player_widget/overlays/annotation_info_dialog.py
+++ b/src/jabs/ui/player_widget/overlays/annotation_info_dialog.py
@@ -118,8 +118,7 @@ class AnnotationInfoDialog(QDialog):
             "tag": data.get("tag"),
             "identity": data.get("identity"),  # None means applies to whole video
         }
-
-        identity_scoped = bool(data.get("identity_scoped"))
+        identity_scoped = data.get("identity") is not None
 
         def _on_deleted(payload: dict) -> None:
             central_widget.on_annotation_deleted(payload)

--- a/src/jabs/ui/player_widget/overlays/annotation_overlay.py
+++ b/src/jabs/ui/player_widget/overlays/annotation_overlay.py
@@ -152,7 +152,7 @@ class AnnotationOverlay(Overlay):
                     rect = QtCore.QRectF(x, y, rect_width, rect_height)
                     data = annotation.data.copy()
                     data["start"] = annotation.begin
-                    data["end"] = annotation.end
+                    data["end"] = annotation.end - 1  # make end inclusive
                     self._rects_with_data.append((rect, data))
                     fill_color = QtGui.QColor(color_str)
                     if not fill_color.isValid():
@@ -192,7 +192,7 @@ class AnnotationOverlay(Overlay):
             rect = QtCore.QRectF(x, y, rect_width, rect_height)
             data = annotation.data.copy()
             data["start"] = annotation.begin
-            data["end"] = annotation.end
+            data["end"] = annotation.end - 1  # make end inclusive
             self._rects_with_data.append((rect, data))
             fill_color = QtGui.QColor(color_str)
             if not fill_color.isValid():

--- a/src/jabs/ui/player_widget/player_widget.py
+++ b/src/jabs/ui/player_widget/player_widget.py
@@ -264,7 +264,7 @@ class PlayerWidget(QtWidgets.QWidget):
         self._pose_est = pose_est
         self._identities = pose_est.identities
         self._frame_widget.set_pose(pose_est)
-        self._frame_widget.annotations = video_labels.interval_annotations
+        self._frame_widget.annotations = video_labels.timeline_annotations
 
         self._player_thread = PlayerThread(
             self._video_stream,

--- a/src/jabs/ui/stacked_timeline_widget/frame_labels_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/frame_labels_widget.py
@@ -98,9 +98,7 @@ class FrameLabelsWidget(QWidget):
                 label_text = f"{i}"
                 label_width = self._font_metrics.horizontalAdvance(label_text)
                 painter.setPen(QApplication.palette().text().color())
-                painter.drawText(
-                    offset - label_width / 2 + 1, self._font_height + 8, label_text
-                )
+                painter.drawText(offset - label_width / 2 + 1, self._font_height + 8, label_text)
 
     def set_current_frame(self, current_frame):
         """called to reposition the view around new current frame"""

--- a/src/jabs/ui/stacked_timeline_widget/stacked_timeline_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/stacked_timeline_widget.py
@@ -399,7 +399,7 @@ class StackedTimelineWidget(QWidget):
             widget.set_labels(predictions_list[i], probabilities_list[i])
 
     def set_search_results(
-        self, behavior_search_query: BehaviorSearchQuery, search_results: list[SearchHit]
+        self, behavior_search_query: BehaviorSearchQuery | None, search_results: list[SearchHit]
     ) -> None:
         """Set search results for timelines.
 

--- a/src/jabs/ui/util.py
+++ b/src/jabs/ui/util.py
@@ -22,7 +22,14 @@ def send_file_to_recycle_bin(file_path: Path) -> bool:
 
 
 def find_central_widget(widget: QWidget) -> QWidget | None:
-    """Traverse up the parent hierarchy to find the central widget of the main window."""
+    """Traverse up the parent hierarchy to find the central widget of the main window.
+
+    Args:
+        widget (QWidget): The starting widget to begin the search from.
+
+    Returns:
+        QWidget | None: The central widget if found, otherwise None.
+    """
     w = widget
     while w is not None:
         if isinstance(w, QMainWindow):

--- a/src/jabs/ui/util.py
+++ b/src/jabs/ui/util.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from PySide6.QtCore import QFile
+from PySide6.QtWidgets import QMainWindow, QWidget
 
 
 def send_file_to_recycle_bin(file_path: Path) -> bool:
@@ -18,3 +19,13 @@ def send_file_to_recycle_bin(file_path: Path) -> bool:
         return True  # Ignore missing files
     file = QFile(str(file_path))
     return file.moveToTrash()
+
+
+def find_central_widget(widget: QWidget) -> QWidget | None:
+    """Traverse up the parent hierarchy to find the central widget of the main window."""
+    w = widget
+    while w is not None:
+        if isinstance(w, QMainWindow):
+            return w.centralWidget()
+        w = w.parent()
+    return None

--- a/tests/timeline_annotations.py
+++ b/tests/timeline_annotations.py
@@ -4,12 +4,9 @@ from intervaltree import Interval
 from jabs.project.timeline_annotations import MAX_TAG_LEN, TimelineAnnotations
 
 
-class DummyPose:
-    """Dummy pose class with identity mapping function."""
-
-    def identity_index_to_display(self, idx):
-        """Dummy mapping function."""
-        return f"ID-{idx}"
+def identity_index_to_display(idx: int) -> str:
+    """Dummy mapping function."""
+    return f"ID-{idx}"
 
 
 def test_add_and_len_and_getitem():
@@ -106,7 +103,7 @@ def test_load_with_pose_mapping_and_optional_fields():
         {"start": 1, "end": 3, "tag": "tag1", "color": "#ff0000", "identity": 4},
         {"start": 10, "end": 10, "tag": "tag2", "color": "#00ff00", "description": "chair"},
     ]
-    rebuilt = TimelineAnnotations.load(data, pose=DummyPose())
+    rebuilt = TimelineAnnotations.load(data, id_index_to_display=identity_index_to_display)
     assert len(rebuilt) == 2
 
     # Check that identity/display_identity are stored

--- a/tests/timeline_annotations.py
+++ b/tests/timeline_annotations.py
@@ -1,0 +1,153 @@
+import pytest
+from intervaltree import Interval
+
+from jabs.project.timeline_annotations import MAX_TAG_LEN, TimelineAnnotations
+
+
+class DummyPose:
+    """Dummy pose class with identity mapping function."""
+
+    def identity_index_to_display(self, idx):
+        """Dummy mapping function."""
+        return f"ID-{idx}"
+
+
+def test_add_and_len_and_getitem():
+    """Basic add, len, getitem functionality."""
+    ta = TimelineAnnotations()
+    ta.add_annotation(
+        TimelineAnnotations.Annotation(
+            start=10,
+            end=20,
+            tag="foo",
+            color="#abcdef",
+            description="d1",
+            identity_index=1,
+            display_identity="ID-1",
+        )
+    )
+    ta.add_annotation(TimelineAnnotations.Annotation(start=30, end=40, tag="bar", color="#123456"))
+
+    # len should be number of intervals
+    assert len(ta) == 2
+
+    # getitem pass-through should return set of Interval
+    result = ta[10:21]  # inclusive input, tree stores [begin, end)
+    assert isinstance(result, set)
+    assert any(isinstance(iv, Interval) and iv.begin == 10 and iv.end == 21 for iv in result)
+
+
+def test_find_and_exists_and_remove():
+    """Test find, exists, and remove by exact key."""
+    ta = TimelineAnnotations()
+    # Add two overlapping intervals with different tags/identity
+    ta.add_annotation(
+        TimelineAnnotations.Annotation(
+            start=0, end=5, tag="eat", color="#000000", identity_index=None
+        )
+    )
+    ta.add_annotation(
+        TimelineAnnotations.Annotation(
+            start=0, end=5, tag="eat", color="#111111", identity_index=2
+        )
+    )
+
+    # find by exact key should return correct count
+    matches_none = ta.find_matching_intervals(start=0, end=5, tag="eat", identity_index=None)
+    matches_id2 = ta.find_matching_intervals(start=0, end=5, tag="eat", identity_index=2)
+    assert len(matches_none) == 1
+    assert len(matches_id2) == 1
+
+    # exists
+    assert ta.annotation_exists(start=0, end=5, tag="eat", identity_index=None)
+    assert ta.annotation_exists(start=0, end=5, tag="eat", identity_index=2)
+    assert not ta.annotation_exists(start=0, end=5, tag="drink", identity_index=None)
+
+    # remove by key should only remove that one
+    removed = ta.remove_annotation_by_key(start=0, end=5, tag="eat", identity_index=None)
+    assert removed == 1
+    assert len(ta) == 1
+    assert not ta.annotation_exists(start=0, end=5, tag="eat", identity_index=None)
+    assert ta.annotation_exists(start=0, end=5, tag="eat", identity_index=2)
+
+
+def test_serialize_roundtrip_basic():
+    """Test serialize and load roundtrip with basic required fields."""
+    ta = TimelineAnnotations()
+    ta.add_annotation(
+        TimelineAnnotations.Annotation(
+            start=5, end=7, tag="walk", color="#aaaaaa", description="desc"
+        )
+    )
+
+    data = ta.serialize()
+    # Expected one dict with inclusive end
+    assert isinstance(data, list)
+    assert len(data) == 1
+    entry = data[0]
+    assert entry["start"] == 5
+    assert entry["end"] == 7
+    assert entry["tag"] == "walk"
+    assert entry["color"] == "#aaaaaa"
+    assert entry["description"] == "desc"
+
+    # Now load from data should rebuild an equivalent tree
+    rebuilt = TimelineAnnotations.load(data)
+    assert len(rebuilt) == 1
+    # using same inclusive selection to hit the interval
+    assert rebuilt.annotation_exists(start=5, end=7, tag="walk", identity_index=None)
+
+
+def test_load_with_pose_mapping_and_optional_fields():
+    """Test load with optional fields and pose identity mapping."""
+    data = [
+        {"start": 1, "end": 3, "tag": "run", "color": "#ff0000", "identity": 4},
+        {"start": 10, "end": 10, "tag": "sit", "color": "#00ff00", "description": "chair"},
+    ]
+    rebuilt = TimelineAnnotations.load(data, pose=DummyPose())
+    assert len(rebuilt) == 2
+
+    # Check that identity/display_identity are stored
+    intervals = list(rebuilt._tree)
+    stored = [iv.data for iv in intervals]
+    run = next(x for x in stored if x["tag"] == "run")
+    sit = next(x for x in stored if x["tag"] == "sit")
+    assert run["identity"] == 4
+    assert run["display_identity"] == "ID-4"
+    assert "description" in sit and sit["description"] == "chair"
+
+
+def test_load_skips_invalid_entries():
+    """Test that load skips entries with missing required fields or invalid tags."""
+    # Missing required fields
+    data = [
+        {"start": 0, "end": 1, "color": "#fff"},  # missing tag
+        {"start": 0, "tag": "x", "color": "#fff"},  # missing end
+        {"end": 1, "tag": "x", "color": "#fff"},  # missing start
+    ]
+    rebuilt = TimelineAnnotations.load(data)
+    assert len(rebuilt) == 0
+
+    # Invalid tag characters should be skipped
+    data2 = [
+        {"start": 0, "end": 1, "tag": "bad tag!", "color": "#fff"},
+        {"start": 0, "end": 1, "tag": "good_tag-1", "color": "#fff"},
+    ]
+    rebuilt2 = TimelineAnnotations.load(data2)
+    assert len(rebuilt2) == 1
+    assert rebuilt2.annotation_exists(start=0, end=1, tag="good_tag-1", identity_index=None)
+
+
+@pytest.mark.parametrize(
+    "tag, ok",
+    [
+        ("a", True),
+        ("a" * MAX_TAG_LEN, True),
+        ("a" * (MAX_TAG_LEN + 1), False),
+    ],
+)
+def test_tag_length(tag, ok):
+    """Test that tags exceeding max length are skipped."""
+    data = [{"start": 0, "end": 0, "tag": tag, "color": "#000"}]
+    rebuilt = TimelineAnnotations.load(data)
+    assert len(rebuilt) == 1 if ok else len(rebuilt) == 0

--- a/tests/timeline_annotations.py
+++ b/tests/timeline_annotations.py
@@ -32,7 +32,9 @@ def test_add_and_len_and_getitem():
     assert len(ta) == 2
 
     # getitem pass-through should return set of Interval
-    result = ta[10:21]  # inclusive input, tree stores [begin, end)
+    result = ta[
+        10:21
+    ]  # Annotation class is inclusive of end, but IntervalTree is exclusive so add 1
     assert isinstance(result, set)
     assert any(isinstance(iv, Interval) and iv.begin == 10 and iv.end == 21 for iv in result)
 

--- a/tests/timeline_annotations.py
+++ b/tests/timeline_annotations.py
@@ -45,32 +45,32 @@ def test_find_and_exists_and_remove():
     # Add two overlapping intervals with different tags/identity
     ta.add_annotation(
         TimelineAnnotations.Annotation(
-            start=0, end=5, tag="eat", color="#000000", identity_index=None
+            start=0, end=5, tag="tag1", color="#000000", identity_index=None
         )
     )
     ta.add_annotation(
         TimelineAnnotations.Annotation(
-            start=0, end=5, tag="eat", color="#111111", identity_index=2
+            start=0, end=5, tag="tag1", color="#111111", identity_index=2
         )
     )
 
     # find by exact key should return correct count
-    matches_none = ta.find_matching_intervals(start=0, end=5, tag="eat", identity_index=None)
-    matches_id2 = ta.find_matching_intervals(start=0, end=5, tag="eat", identity_index=2)
+    matches_none = ta.find_matching_intervals(start=0, end=5, tag="tag1", identity_index=None)
+    matches_id2 = ta.find_matching_intervals(start=0, end=5, tag="tag1", identity_index=2)
     assert len(matches_none) == 1
     assert len(matches_id2) == 1
 
     # exists
-    assert ta.annotation_exists(start=0, end=5, tag="eat", identity_index=None)
-    assert ta.annotation_exists(start=0, end=5, tag="eat", identity_index=2)
-    assert not ta.annotation_exists(start=0, end=5, tag="drink", identity_index=None)
+    assert ta.annotation_exists(start=0, end=5, tag="tag1", identity_index=None)
+    assert ta.annotation_exists(start=0, end=5, tag="tag1", identity_index=2)
+    assert not ta.annotation_exists(start=0, end=5, tag="tag2", identity_index=None)
 
     # remove by key should only remove that one
-    removed = ta.remove_annotation_by_key(start=0, end=5, tag="eat", identity_index=None)
+    removed = ta.remove_annotation_by_key(start=0, end=5, tag="tag1", identity_index=None)
     assert removed == 1
     assert len(ta) == 1
-    assert not ta.annotation_exists(start=0, end=5, tag="eat", identity_index=None)
-    assert ta.annotation_exists(start=0, end=5, tag="eat", identity_index=2)
+    assert not ta.annotation_exists(start=0, end=5, tag="tag1", identity_index=None)
+    assert ta.annotation_exists(start=0, end=5, tag="tag1", identity_index=2)
 
 
 def test_serialize_roundtrip_basic():
@@ -78,7 +78,7 @@ def test_serialize_roundtrip_basic():
     ta = TimelineAnnotations()
     ta.add_annotation(
         TimelineAnnotations.Annotation(
-            start=5, end=7, tag="walk", color="#aaaaaa", description="desc"
+            start=5, end=7, tag="tag1", color="#aaaaaa", description="desc"
         )
     )
 
@@ -89,7 +89,7 @@ def test_serialize_roundtrip_basic():
     entry = data[0]
     assert entry["start"] == 5
     assert entry["end"] == 7
-    assert entry["tag"] == "walk"
+    assert entry["tag"] == "tag1"
     assert entry["color"] == "#aaaaaa"
     assert entry["description"] == "desc"
 
@@ -97,14 +97,14 @@ def test_serialize_roundtrip_basic():
     rebuilt = TimelineAnnotations.load(data)
     assert len(rebuilt) == 1
     # using same inclusive selection to hit the interval
-    assert rebuilt.annotation_exists(start=5, end=7, tag="walk", identity_index=None)
+    assert rebuilt.annotation_exists(start=5, end=7, tag="tag1", identity_index=None)
 
 
 def test_load_with_pose_mapping_and_optional_fields():
     """Test load with optional fields and pose identity mapping."""
     data = [
-        {"start": 1, "end": 3, "tag": "run", "color": "#ff0000", "identity": 4},
-        {"start": 10, "end": 10, "tag": "sit", "color": "#00ff00", "description": "chair"},
+        {"start": 1, "end": 3, "tag": "tag1", "color": "#ff0000", "identity": 4},
+        {"start": 10, "end": 10, "tag": "tag2", "color": "#00ff00", "description": "chair"},
     ]
     rebuilt = TimelineAnnotations.load(data, pose=DummyPose())
     assert len(rebuilt) == 2
@@ -112,8 +112,8 @@ def test_load_with_pose_mapping_and_optional_fields():
     # Check that identity/display_identity are stored
     intervals = list(rebuilt._tree)
     stored = [iv.data for iv in intervals]
-    run = next(x for x in stored if x["tag"] == "run")
-    sit = next(x for x in stored if x["tag"] == "sit")
+    run = next(x for x in stored if x["tag"] == "tag1")
+    sit = next(x for x in stored if x["tag"] == "tag2")
     assert run["identity"] == 4
     assert run["display_identity"] == "ID-4"
     assert "description" in sit and sit["description"] == "chair"


### PR DESCRIPTION
Implements KLAUS-184

This PR adds the ability to create new Timeline Annotations through the JABS GUI as well as edit or delete existing Timeline Annotations.

A new button is added to the "Labeling" button group in the MainControlWidget:

<img width="318" height="209" alt="image" src="https://github.com/user-attachments/assets/7f429318-da25-4ba2-9d57-5a7c111dac46" />



This button becomes active when JABS is in "Select Mode" and one or more frames are selected

<img width="853" height="209" alt="image" src="https://github.com/user-attachments/assets/35c7191a-c45c-4f58-8ceb-4993d069e591" />



Clicking it will open the Timeline Annotation Editor:

<img width="895" height="428" alt="image" src="https://github.com/user-attachments/assets/578674b7-c8b7-4fcd-b931-ba82e152a2bf" />

Entering a valid tag is required for the "OK" button to become active. If the user enters invalid text for the tag, for example special characters, the text color will change red to indicate the value is not valid.
Clicking the color swatch will let the user pick a different color for the annotation. This is the background color used to draw the overlay in the video player for the annotation. 
The Description field is optional, and contains longer free form text. The annotation's scope can either be the "Selected Identity" or the "Video".

The combination of (tag, start, end, identity) is used to uniquely identify a tag.  If a user tries to save an annotation that match an existing annotation, then a message dialog will inform them it is a duplicate and it won't be saved. Note: tag matching is case-insensitive (but case-preserving for display).  

Clicking the > Show Help button will expand the dialog to show help text:

<img width="895" height="703" alt="image" src="https://github.com/user-attachments/assets/89748c37-6531-468b-963d-a2472bf74c7a" />



After clicking OK, the annotation is saved and will appear in the video player overlay:

<img width="761" height="670" alt="image" src="https://github.com/user-attachments/assets/3834f101-49b9-47ef-abd4-d1cc03191949" />



Clicking an annotation in the video player will open the Annotation Info dialog:

<img width="761" height="670" alt="image" src="https://github.com/user-attachments/assets/401e4a67-4098-425a-a60f-1d0bbdc51901" />



There is a pencil icon in the lower left of the Annotation Info dialog. Clicking that will open the annotation in the editor dialog

<img width="825" height="429" alt="image" src="https://github.com/user-attachments/assets/c50b6634-f869-42a2-a1ea-f4a076918f55" />



Currently, when editing an existing annotation only the Tag, color, and description can be changed. At this time it is not possible to change the identity or scope of the annotation. 

There is a trash can icon.  Clicking this will prompt the user to ask if they want to delete the annotation:
<img width="825" height="429" alt="image" src="https://github.com/user-attachments/assets/c834aa5c-c814-43c1-8ea5-c89c1333d988" />



 