### PR TITLE
Cleanup `src.jabs` style imports in tests. 

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,0 @@
-"""this exists for pytest to be able to import from src.jabs"""

--- a/tests/feature_modules/test_corner_features.py
+++ b/tests/feature_modules/test_corner_features.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-import src.jabs.feature_extraction.landmark_features.corner as corner_module
+import jabs.feature_extraction.landmark_features.corner as corner_module
 from tests.feature_modules.base import TestFeatureBase
 
 

--- a/tests/feature_modules/test_food_hopper.py
+++ b/tests/feature_modules/test_food_hopper.py
@@ -1,9 +1,9 @@
 import cv2
 import numpy as np
 
-from src.jabs.pose_estimation import PoseEstimation
-from src.jabs.feature_extraction.landmark_features.food_hopper import FoodHopper
-from src.jabs.feature_extraction.landmark_features.food_hopper import _EXCLUDED_POINTS
+from jabs.pose_estimation import PoseEstimation
+from jabs.feature_extraction.landmark_features.food_hopper import FoodHopper
+from jabs.feature_extraction.landmark_features.food_hopper import _EXCLUDED_POINTS
 from tests.feature_modules.base import TestFeatureBase
 
 

--- a/tests/feature_modules/test_lixit_distance.py
+++ b/tests/feature_modules/test_lixit_distance.py
@@ -3,7 +3,7 @@ import unittest
 
 import numpy as np
 
-import src.jabs.feature_extraction.landmark_features.lixit as lixit
+import jabs.feature_extraction.landmark_features.lixit as lixit
 from tests.feature_modules.base import TestFeatureBase
 
 

--- a/tests/feature_tests/seg_test_utils.py
+++ b/tests/feature_tests/seg_test_utils.py
@@ -10,8 +10,8 @@ import tempfile
 import shutil
 import gzip
 
-from src.jabs.feature_extraction.segmentation_features import SegmentationFeatureGroup
-import src.jabs.pose_estimation as pose_est
+from jabs.feature_extraction.segmentation_features import SegmentationFeatureGroup
+import jabs.pose_estimation as pose_est
 
 
 class SegDataBaseClass(object):

--- a/tests/feature_tests/test_hu_moments.py
+++ b/tests/feature_tests/test_hu_moments.py
@@ -2,7 +2,7 @@ import unittest
 
 # project imports
 from .seg_test_utils import SegDataBaseClass as SBC
-from src.jabs.feature_extraction.segmentation_features import HuMoments
+from jabs.feature_extraction.segmentation_features import HuMoments
 
 
 class Test(SBC, unittest.TestCase):

--- a/tests/feature_tests/test_temporal_features.py.disabled
+++ b/tests/feature_tests/test_temporal_features.py.disabled
@@ -3,7 +3,7 @@ import unittest
 import pandas as pd
 
 # project imports
-from src.jabs.feature_extraction import colnames
+from jabs.feature_extraction import colnames
 
 class TestTemporalFeatures(unittest.TestCase):
 

--- a/tests/project/test_prediction_manager.py
+++ b/tests/project/test_prediction_manager.py
@@ -2,7 +2,7 @@ import pytest
 import h5py
 import numpy as np
 from pathlib import Path
-from src.jabs.project.prediction_manager import PredictionManager
+from jabs.project.prediction_manager import PredictionManager
 
 
 class MockProjectPaths:

--- a/tests/project/test_project_merge.py
+++ b/tests/project/test_project_merge.py
@@ -64,7 +64,7 @@ def mock_projects_with_labels(tmp_path):
     src.load_pose_est.side_effect = lambda p: pose_obj("hash1")
 
     patcher = patch(
-        "src.jabs.project.project_merge.get_pose_path", side_effect=lambda p: p.with_suffix(".h5")
+        "jabs.project.project_merge.get_pose_path", side_effect=lambda p: p.with_suffix(".h5")
     )
     patcher.start()
 

--- a/tests/project/test_project_path.py
+++ b/tests/project/test_project_path.py
@@ -1,6 +1,6 @@
 import pytest
 from pathlib import Path
-from src.jabs.project.project_paths import ProjectPaths
+from jabs.project.project_paths import ProjectPaths
 
 
 @pytest.fixture

--- a/tests/project/test_project_util.py
+++ b/tests/project/test_project_util.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from src.jabs.project.project_utils import to_safe_name
+from jabs.project.project_utils import to_safe_name
 
 
 def test_to_safe_name():

--- a/tests/test_pose_file.py
+++ b/tests/test_pose_file.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import numpy as np
 
-import src.jabs.pose_estimation
+import jabs.pose_estimation
 
 _TEST_FILES = [
     "sample_pose_est_v3.h5.gz",
@@ -57,15 +57,15 @@ class TestOpenPose(unittest.TestCase):
                 with open(cls._tmpdir_path / f.replace(".h5.gz", ".h5"), "wb") as f_out:
                     shutil.copyfileobj(f_in, f_out)
 
-        cls._pose_est_v3 = src.jabs.pose_estimation.open_pose_file(
+        cls._pose_est_v3 = jabs.pose_estimation.open_pose_file(
             cls._tmpdir_path / "sample_pose_est_v3.h5"
         )
 
-        cls._pose_est_v4 = src.jabs.pose_estimation.open_pose_file(
+        cls._pose_est_v4 = jabs.pose_estimation.open_pose_file(
             cls._tmpdir_path / "sample_pose_est_v4.h5"
         )
 
-        cls._pose_est_v5 = src.jabs.pose_estimation.open_pose_file(
+        cls._pose_est_v5 = jabs.pose_estimation.open_pose_file(
             cls._tmpdir_path / "sample_pose_est_v5.h5"
         )
 
@@ -76,21 +76,21 @@ class TestOpenPose(unittest.TestCase):
     def test_open_pose_est_v3(self) -> None:
         """test that open_pose_file can open a V3 pose file"""
         self.assertIsInstance(
-            self._pose_est_v3, src.jabs.pose_estimation.PoseEstimationV3
+            self._pose_est_v3, jabs.pose_estimation.PoseEstimationV3
         )
         self.assertEqual(self._pose_est_v3.format_major_version, 3)
 
     def test_open_pose_est_v4(self) -> None:
         """test that open_pose_file can open a V4 pose file"""
         self.assertIsInstance(
-            self._pose_est_v4, src.jabs.pose_estimation.PoseEstimationV4
+            self._pose_est_v4, jabs.pose_estimation.PoseEstimationV4
         )
         self.assertEqual(self._pose_est_v4.format_major_version, 4)
 
     def test_open_pose_est_v5(self) -> None:
         """test that open_pose_file can open a V5 pose file"""
         self.assertIsInstance(
-            self._pose_est_v5, src.jabs.pose_estimation.PoseEstimationV5
+            self._pose_est_v5, jabs.pose_estimation.PoseEstimationV5
         )
         self.assertEqual(self._pose_est_v5.format_major_version, 5)
 
@@ -151,13 +151,13 @@ class TestOpenPose(unittest.TestCase):
             # this will be uncached, so it will read raw data from the pose file
             # and manipulate it to generate data in the form we need, and then
             # will write it back out to the cache directory
-            pose_v4 = src.jabs.pose_estimation.open_pose_file(
+            pose_v4 = jabs.pose_estimation.open_pose_file(
                 self._tmpdir_path / "sample_pose_est_v4.h5", cache_dir=cache_dir_path
             )
 
             # open it again, this time it should be read from the cached
             # file
-            pose_v4_from_cache = src.jabs.pose_estimation.open_pose_file(
+            pose_v4_from_cache = jabs.pose_estimation.open_pose_file(
                 self._tmpdir_path / "sample_pose_est_v4.h5", cache_dir=cache_dir_path
             )
 

--- a/tests/test_social_features/test_signal_processing.py
+++ b/tests/test_social_features/test_signal_processing.py
@@ -8,11 +8,11 @@ import tempfile
 from pathlib import Path
 from time import time
 
-import src.jabs.pose_estimation
+import jabs.pose_estimation
 
 # Bring in base features of interest.
-from src.jabs.feature_extraction.segmentation_features import moments
-from src.jabs.feature_extraction.base_features import point_speeds
+from jabs.feature_extraction.segmentation_features import moments
+from jabs.feature_extraction.base_features import point_speeds
 
 
 # test command: python -m unittest tests.test_social_features.test_fft
@@ -58,7 +58,7 @@ class TestSignalProcessing(unittest.TestCase):
                 shutil.copyfileobj(f_in, f_out)
 
         if os.path.isfile(pose_path):
-            cls._pose_est_v6 = src.jabs.pose_estimation.open_pose_file(pose_path)
+            cls._pose_est_v6 = jabs.pose_estimation.open_pose_file(pose_path)
             cls._poses = cls._pose_est_v6
 
             with h5py.File(pose_path, "r") as f:

--- a/tests/test_track_labels.py
+++ b/tests/test_track_labels.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from src.jabs.project.track_labels import TrackLabels
+from jabs.project.track_labels import TrackLabels
 
 
 class TestTrackLabels(unittest.TestCase):


### PR DESCRIPTION
This PR removes the `src.jabs` style imports from the tests.

It **does not** apply ruff formatting or linting, as it does not appear that linting/formatting had previously been applied to the tests directory. 