### PR TITLE
Applying simple formatting and linting rules to tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the JABS project."""

--- a/tests/feature_modules/__init__.py
+++ b/tests/feature_modules/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the JABS feature modules."""

--- a/tests/feature_modules/base.py
+++ b/tests/feature_modules/base.py
@@ -10,20 +10,22 @@ import jabs.pose_estimation
 
 
 class TestFeatureBase(unittest.TestCase):
+    """Base class for feature module tests."""
+
     _tmpdir = None
     _test_file = Path(__file__).parent.parent / "data" / "sample_pose_est_v5.h5.gz"
 
     @classmethod
     def setUpClass(cls) -> None:
+        """Setup temporary directory and copy pose file to it."""
         cls._tmpdir = tempfile.TemporaryDirectory()
         cls._tmpdir_path = Path(cls._tmpdir.name)
 
         pose_path = cls._tmpdir_path / "sample_pose_est_v5.h5"
 
         # decompress pose file into tempdir
-        with gzip.open(cls._test_file, "rb") as f_in:
-            with open(pose_path, "wb") as f_out:
-                shutil.copyfileobj(f_in, f_out)
+        with gzip.open(cls._test_file, "rb") as f_in, open(pose_path, "wb") as f_out:
+            shutil.copyfileobj(f_in, f_out)
 
         cls._pose_est_v5 = jabs.pose_estimation.open_pose_file(
             cls._tmpdir_path / "sample_pose_est_v5.h5"
@@ -31,9 +33,7 @@ class TestFeatureBase(unittest.TestCase):
 
         # V5 pose file in the data directory does not currently have "lixit"
         # as one of its static objects, so we'll manually add it
-        cls._pose_est_v5.static_objects["lixit"] = np.asarray(
-            [[62, 166]], dtype=np.uint16
-        )
+        cls._pose_est_v5.static_objects["lixit"] = np.asarray([[62, 166]], dtype=np.uint16)
 
         # V5 pose file also doesn't have the food hopper static object
         cls._pose_est_v5.static_objects["food_hopper"] = np.asarray(
@@ -42,4 +42,5 @@ class TestFeatureBase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls) -> None:
+        """Cleanup temporary directory."""
         cls._tmpdir.cleanup()

--- a/tests/feature_modules/test_lixit_distance.py
+++ b/tests/feature_modules/test_lixit_distance.py
@@ -28,9 +28,7 @@ class TestCornerFeatures(TestFeatureBase):
             # check dimensions of window feature values
             dist_window_values = self.lixit_distance.window(i, 5, distances)
             for op in dist_window_values:
-                self.assertEqual(
-                    dist_window_values[op].shape, (self._pose_est_v5.num_frames,)
-                )
+                self.assertEqual(dist_window_values[op].shape, (self._pose_est_v5.num_frames,))
 
     @unittest.skip("")
     def test_distances_greater_equal_zero(self):

--- a/tests/feature_tests/seg_test_utils.py
+++ b/tests/feature_tests/seg_test_utils.py
@@ -3,18 +3,16 @@ This file contains the base class SegTest.  This class can be inherited by tests
 data in the pose file (v6+).
 """
 
-import h5py
-import os
-from pathlib import Path
-import tempfile
-import shutil
 import gzip
+import shutil
+import tempfile
+from pathlib import Path
 
-from jabs.feature_extraction.segmentation_features import SegmentationFeatureGroup
 import jabs.pose_estimation as pose_est
+from jabs.feature_extraction.segmentation_features import SegmentationFeatureGroup
 
 
-class SegDataBaseClass(object):
+class SegDataBaseClass:
     """Common setup and teardown for segmentation tests."""
 
     pixel_scale = 1.0
@@ -24,13 +22,12 @@ class SegDataBaseClass(object):
 
     @classmethod
     def setUpClass(cls) -> None:
+        """Setup temporary directory and copy pose file to it."""
         cls._tmpdir = tempfile.TemporaryDirectory()
         cls._tmpdir_path = Path(cls._tmpdir.name)
 
         with gzip.open(cls.dataPath / cls.dataFileName, "rb") as f_in:
-            with open(
-                cls._tmpdir_path / cls.dataFileName.replace(".h5.gz", ".h5"), "wb"
-            ) as f_out:
+            with open(cls._tmpdir_path / cls.dataFileName.replace(".h5.gz", ".h5"), "wb") as f_out:
                 shutil.copyfileobj(f_in, f_out)
 
         cls._pose_est_v6 = pose_est.open_pose_file(
@@ -42,6 +39,7 @@ class SegDataBaseClass(object):
 
     @classmethod
     def tearDown(cls):
+        """Cleanup temporary directory."""
         if cls._tmpdir:
             cls._tmpdir.cleanup()
 

--- a/tests/feature_tests/test_hu_moments.py
+++ b/tests/feature_tests/test_hu_moments.py
@@ -2,7 +2,6 @@ import unittest
 
 # project imports
 from .seg_test_utils import SegDataBaseClass as SBC
-from jabs.feature_extraction.segmentation_features import HuMoments
 
 
 class Test(SBC, unittest.TestCase):
@@ -10,7 +9,6 @@ class Test(SBC, unittest.TestCase):
 
     def testHuMomentFeatureName(self) -> None:
         """Test HuMoment class."""
-
         # test that data was read and setup correctly
         huMomentsFeature = self.feature_mods["hu_moments"]
 

--- a/tests/project/__init__.py
+++ b/tests/project/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the project module."""

--- a/tests/project/test_prediction_manager.py
+++ b/tests/project/test_prediction_manager.py
@@ -1,7 +1,7 @@
-import pytest
 import h5py
 import numpy as np
-from pathlib import Path
+import pytest
+
 from jabs.project.prediction_manager import PredictionManager
 
 
@@ -84,9 +84,7 @@ def test_load_predictions(prediction_manager, mock_project):
         prediction_group = h5.create_group("predictions")
         behavior_group = prediction_group.create_group(behavior)
         behavior_group.create_dataset("predicted_class", data=[[1, 0, -1], [0, 1, -1]])
-        behavior_group.create_dataset(
-            "probabilities", data=[[0.9, 0.8, -1], [0.7, 0.6, -1]]
-        )
+        behavior_group.create_dataset("probabilities", data=[[0.9, 0.8, -1], [0.7, 0.6, -1]])
 
     predictions, probabilities, frame_indexes = prediction_manager.load_predictions(
         video, behavior

--- a/tests/project/test_project_path.py
+++ b/tests/project/test_project_path.py
@@ -1,5 +1,5 @@
 import pytest
-from pathlib import Path
+
 from jabs.project.project_paths import ProjectPaths
 
 

--- a/tests/test_base_features/test_segmentation.py
+++ b/tests/test_base_features/test_segmentation.py
@@ -1,16 +1,14 @@
 import unittest
+from pathlib import Path
+
 import h5py
 import numpy as np
-
-from pathlib import Path
 
 # TODO: this unit test should be removed or fixed. This shouldn't have been commited in it's current state
 #  it references a file that doesn't exist in the repository, and it has significant amounts of unreachable code
 
 
-def ugly_segmentation_sort(
-    seg_data: np.ndarray, longterm_seg_id: np.ndarray
-) -> np.ndarray:
+def ugly_segmentation_sort(seg_data: np.ndarray, longterm_seg_id: np.ndarray) -> np.ndarray:
     """
     This method attempts to sort the segmentation data according to the longterm segmentation id.
     This code is highly inefficient and ugly should be replaced with a vectorized expression.
@@ -40,9 +38,7 @@ class TestPoseMatchSegmentation(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        dataPath = (
-            Path(__file__).parent.parent.parent / "data" / "B6J_MDB0054_pose_est_v6.h5"
-        )
+        dataPath = Path(__file__).parent.parent.parent / "data" / "B6J_MDB0054_pose_est_v6.h5"
 
         with h5py.File(dataPath, "r") as f:
             print(f["poseest"].keys())
@@ -93,9 +89,7 @@ class TestPoseMatchSegmentation(unittest.TestCase):
         # Attempt 2
         # ugly, but should work
         if False:
-            seg_data_tmp = np.zeros_like(
-                self.seg_data
-            )  # np.full_like(self.seg_data, -1)
+            seg_data_tmp = np.zeros_like(self.seg_data)  # np.full_like(self.seg_data, -1)
 
             for frame in range(self.seg_data.shape[0]):
                 map = self.longterm_seg_sorting[frame]
@@ -112,9 +106,7 @@ class TestPoseMatchSegmentation(unittest.TestCase):
         # Attempt 3, put into a function.
         if True:
             frame = 5
-            sorted_seg_dat = ugly_segmentation_sort(
-                self.seg_data, self.longterm_seg_sorting
-            )
+            sorted_seg_dat = ugly_segmentation_sort(self.seg_data, self.longterm_seg_sorting)
             print("SEG ID:")
             print(self.longterm_seg_sorting[frame])
             print("RAW:")

--- a/tests/test_track_labels.py
+++ b/tests/test_track_labels.py
@@ -54,7 +54,6 @@ class TestTrackLabels(unittest.TestCase):
 
     def test_downsample_basic(self):
         """testing downsampling of label array"""
-
         # downsample into an array of length 3
         # will result in three bins of uniform value
         # 0-24 will be unlabeled
@@ -80,7 +79,6 @@ class TestTrackLabels(unittest.TestCase):
         test that a bin containing mix of Label.NONE and Label.BEHAVIOR results
         in a value of Label.BEHAVIOR in downsampled array
         """
-
         labels = TrackLabels(10)
 
         # label position 0, 1, 2
@@ -99,7 +97,6 @@ class TestTrackLabels(unittest.TestCase):
         test that a bin containing mix of Label.BEHAVIOR and Label.NOT_BEHAVIOR
         results in a special value (Label.MIX)
         """
-
         labels = TrackLabels(10)
 
         # label position 0, 1,
@@ -119,7 +116,6 @@ class TestTrackLabels(unittest.TestCase):
         test that we can downsample to a size that doesn't evenly divide
         the label array
         """
-
         labels = TrackLabels(100)
         ds = TrackLabels.downsample(labels.get_labels(), 33)
 
@@ -140,7 +136,7 @@ class TestTrackLabels(unittest.TestCase):
             {"start": 300, "end": 325, "present": True},
         ]
 
-        for exported, expected in zip(labels.get_blocks(), expected_blocks):
+        for exported, expected in zip(labels.get_blocks(), expected_blocks, strict=False):
             self.assertDictEqual(exported, expected)
 
     def test_export_behavior_block_slice(self):
@@ -151,7 +147,9 @@ class TestTrackLabels(unittest.TestCase):
 
         expected_blocks = [{"start": 0, "end": 25, "present": True}]
 
-        for exported, expected in zip(labels.get_slice_blocks(0, 25), expected_blocks):
+        for exported, expected in zip(
+            labels.get_slice_blocks(0, 25), expected_blocks, strict=False
+        ):
             self.assertDictEqual(exported, expected)
 
     def test_labeling_single_frame(self):
@@ -167,9 +165,7 @@ class TestTrackLabels(unittest.TestCase):
         # make sure the block is exported properly
         exported_blocks = labels.get_blocks()
         self.assertEqual(len(exported_blocks), 1)
-        self.assertDictEqual(
-            {"start": 25, "end": 25, "present": True}, exported_blocks[0]
-        )
+        self.assertDictEqual({"start": 25, "end": 25, "present": True}, exported_blocks[0])
 
     def test_label_with_mask(self):
         """test labeling with a mask"""


### PR DESCRIPTION
This PR applied automated and straight-forward manual fixes for linting and formatting rules on the tests directory. It does not get all of the linting rules to pass on the directory. 