### PR TITLE
Rename behavior utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ After installation, the following commands are available in your environment:
 - `jabs-classify` — run a trained classifier  
 - `jabs-stats` — print accuracy statistics for a classifier  
 - `jabs-export-training` — export training data from an existing JABS project
+- `jabs-cli` - collection of smaller command line utilities
 
 You can view usage information for any command with:
 

--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -696,7 +696,6 @@ class Project:
         if old_path.exists():
             old_path.rename(new_path)
 
-        # rename labels in all videos
         for video in self._video_manager.videos:
             # Rename predictions dataset inside the per-video HDF5 file.
             pred_file = self._paths.prediction_dir / Path(video).with_suffix(".h5").name
@@ -709,14 +708,11 @@ class Project:
                             del grp[safe_new_name]
                         grp.move(safe_old_name, safe_new_name)
 
-            labels = self._video_manager.load_video_labels(video)
-
-            # if no labels for video skip it
-            if labels is None:
+            # rename labels inside annotation file
+            if (labels := self._video_manager.load_video_labels(video)) is None:
                 continue
-
-            pose = self.load_pose_est(self._video_manager.video_path(video))
             labels.rename_behavior(old_name, new_name)
+            pose = self.load_pose_est(self._video_manager.video_path(video))
             self.save_annotations(labels, pose)
 
         # update project settings

--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 
+import h5py
 import numpy as np
 import pandas as pd
 
@@ -156,6 +157,29 @@ class Project:
     def session_tracker(self) -> SessionTracker | None:
         """get the session tracker for this project"""
         return self._session_tracker
+
+    @staticmethod
+    def is_valid_project_directory(directory: Path) -> bool:
+        """Check if a directory is a valid JABS project directory.
+
+        Currently just checks for the existence of the jabs directory and project.json file. This can be
+        called before initializing a Project object, which will create these files if they do not exist which
+        might not be desired behavior for tools that expect to operate on an existing JABS project directory.
+
+        Args:
+            directory: Path to the directory to check.
+
+        Returns:
+            True if the directory is a valid JABS project directory, False otherwise.
+        """
+        try:
+            paths = ProjectPaths(directory)
+            if not paths.jabs_dir.exists() or not paths.project_file.exists():
+                return False
+        except (ValueError, FileNotFoundError):
+            return False
+
+        return True
 
     def load_pose_est(self, video_path: Path) -> PoseEstimation:
         """return a PoseEstimation object for a given video path
@@ -646,3 +670,54 @@ class Project:
                     }
 
         return counts
+
+    def rename_behavior(self, old_name: str, new_name: str) -> None:
+        """Rename a behavior throughout the project.
+
+        This updates the project settings, and renames any files associated with the behavior.
+        It also updates any labels for this behavior in all videos.
+
+        Args:
+            old_name (str): current behavior name
+            new_name (str): new behavior name
+
+        Returns:
+            None
+        """
+        if new_name in self._settings_manager.behavior_names:
+            raise ValueError(f"Behavior {new_name} already exists in project")
+
+        safe_old_name = to_safe_name(old_name)
+        safe_new_name = to_safe_name(new_name)
+
+        # rename pickled classifier
+        old_path = self._paths.classifier_dir / f"{safe_old_name}.pickle"
+        new_path = self._paths.classifier_dir / f"{safe_new_name}.pickle"
+        if old_path.exists():
+            old_path.rename(new_path)
+
+        # rename labels in all videos
+        for video in self._video_manager.videos:
+            # Rename predictions dataset inside the per-video HDF5 file.
+            pred_file = self._paths.prediction_dir / Path(video).with_suffix(".h5").name
+            if pred_file.exists():
+                with h5py.File(pred_file, "r+") as hf:
+                    if "predictions" in hf and safe_old_name in hf["predictions"]:
+                        grp = hf["predictions"]
+                        # If dataset already exists at the destination, remove it first
+                        if safe_new_name in grp:
+                            del grp[safe_new_name]
+                        grp.move(safe_old_name, safe_new_name)
+
+            labels = self._video_manager.load_video_labels(video)
+
+            # if no labels for video skip it
+            if labels is None:
+                continue
+
+            pose = self.load_pose_est(self._video_manager.video_path(video))
+            labels.rename_behavior(old_name, new_name)
+            self.save_annotations(labels, pose)
+
+        # update project settings
+        self._settings_manager.rename_behavior(old_name, new_name)

--- a/src/jabs/project/settings_manager.py
+++ b/src/jabs/project/settings_manager.py
@@ -180,3 +180,28 @@ class SettingsManager:
         current_version = self._project_info.get("version")
         if current_version != version_str():
             self.save_project_file({"version": version_str()})
+
+    def rename_behavior(self, old_name: str, new_name: str) -> None:
+        """Rename a behavior in the project settings.
+
+        Args:
+            old_name: Current name of the behavior to rename.
+            new_name: New name for the behavior.
+
+        Raises:
+            KeyError: If the old behavior name does not exist or
+                the new behavior name already exists.
+        """
+        if old_name not in self._project_info.get("behavior", {}):
+            raise KeyError(f"Behavior '{old_name}' not found in project.")
+
+        if new_name in self._project_info.get("behavior", {}):
+            raise KeyError(f"Behavior '{new_name}' already exists in project.")
+
+        self._project_info["behavior"][new_name] = self._project_info["behavior"].pop(old_name)
+
+        # if the old behavior was the selected behavior, update to new name
+        if self._project_info.get("selected_behavior") == old_name:
+            self._project_info["selected_behavior"] = new_name
+
+        self.save_project_file()

--- a/src/jabs/project/video_labels.py
+++ b/src/jabs/project/video_labels.py
@@ -242,3 +242,31 @@ class VideoLabels:
             for behavior, other_track_labels in behaviors.items():
                 track_labels = self.get_track_labels(identity, behavior)
                 track_labels.merge(other_track_labels, strategy)
+
+    def rename_behavior(self, old_name: str, new_name: str) -> None:
+        """Rename a behavior across all identities in this VideoLabels object.
+
+        Only renames behavior in memory; does not update any associated files on disk.
+        Behavior labels must be saved to disk again after renaming to persist changes.
+
+        Args:
+            old_name (str): The current name of the behavior to rename.
+            new_name (str): The new name for the behavior.
+
+        Returns:
+            None
+
+        Raises:
+            KeyError: If the old behavior name does not exist or
+                if the new behavior name already exists for any identity.
+        """
+        # validate that new_name doesn't already exist for any identity
+        for identity in self._identity_labels:
+            if new_name in self._identity_labels[identity]:
+                raise KeyError(f"Behavior '{new_name}' already exists for identity '{identity}'")
+
+        for identity in self._identity_labels:
+            if old_name in self._identity_labels[identity]:
+                self._identity_labels[identity][new_name] = self._identity_labels[identity].pop(
+                    old_name
+                )

--- a/src/jabs/scripts/cli.py
+++ b/src/jabs/scripts/cli.py
@@ -100,6 +100,59 @@ def export_training(ctx, directory: Path, behavior: str, classifier: str, outfil
     click.echo(f"Exported training data to {outfile}")
 
 
+@cli.command(name="rename-behavior")
+@click.argument(
+    "directory",
+    type=click.Path(
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        path_type=Path,
+    ),
+)
+@click.argument(
+    "old-name",
+    type=str,
+)
+@click.argument(
+    "new-name",
+    type=str,
+)
+@click.pass_context
+def rename_behavior(ctx, directory: Path, old_name: str, new_name: str) -> None:
+    """Rename a behavior in a JABS project."""
+    # Args:
+    #    ctx: Click context.
+    #    directory (Path): Path to the JABS project directory.
+    #    old_name (str): Current name of the behavior to rename.
+    #    new_name (str): New name for the behavior.
+    #
+    # Raises:
+    #    click.ClickException: If the old behavior name does not exist or
+    #        the new behavior name already exists.
+
+    if ctx.obj["VERBOSE"]:
+        click.echo("Renaming behavior with the following parameters:")
+        click.echo(f"\tOld behavior name: {old_name}")
+        click.echo(f"\tNew behavior name: {new_name}")
+        click.echo(f"\tJABS project directory: {directory}")
+
+    if not Project.is_valid_project_directory(directory):
+        raise click.ClickException(f"Invalid JABS project directory: {directory}")
+
+    jabs_project = Project(directory, enable_session_tracker=False)
+
+    # validate that the old behavior exists in the project
+    if old_name not in jabs_project.settings["behavior"]:
+        raise click.ClickException(f"Behavior '{old_name}' not found in project.")
+
+    # validate that the new behavior does not already exist in the project
+    if new_name in jabs_project.settings["behavior"]:
+        raise click.ClickException(f"Behavior '{new_name}' already exists in project.")
+
+    jabs_project.rename_behavior(old_name, new_name)
+
+
 def main():
     """Entry point for the JABS CLI."""
     cli(obj={})

--- a/src/jabs/scripts/cli.py
+++ b/src/jabs/scripts/cli.py
@@ -150,7 +150,10 @@ def rename_behavior(ctx, directory: Path, old_name: str, new_name: str) -> None:
     if new_name in jabs_project.settings["behavior"]:
         raise click.ClickException(f"Behavior '{new_name}' already exists in project.")
 
-    jabs_project.rename_behavior(old_name, new_name)
+    console = Console()
+    status_text = f"Renaming behavior '{old_name}' to '{new_name}'"
+    with console.status(status_text, spinner="dots"):
+        jabs_project.rename_behavior(old_name, new_name)
 
 
 def main():

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -2,9 +2,7 @@ import contextlib
 import gzip
 import json
 import shutil
-import unittest
 from pathlib import Path
-from typing import ClassVar
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -17,180 +15,199 @@ from jabs.utils import hide_stderr
 @pytest.fixture(autouse=True, scope="session")
 def patch_session_tracker():
     """Patch the SessionTracker to avoid side effects during tests."""
-    with (
-        patch("jabs.project.session_tracker.SessionTracker.__del__", return_value=None),
-    ):
+    with patch("jabs.project.session_tracker.SessionTracker.__del__", return_value=None):
         yield
 
 
-class TestProject(unittest.TestCase):
-    """
-    test project.project.Project
-
-    TODO consider adding test for save_predictions method
-    (save_predictions requires having pose_est file)
-    """
-
+@pytest.fixture(scope="module")
+def project_with_data():
+    """Fixture to create a project with empty video file and annotations,and clean up afterwards."""
     _EXISTING_PROJ_PATH = Path("test_project_with_data")
-    _FILENAMES: ClassVar[list[str]] = ["test_file_1.avi", "test_file_2.avi"]
+    _FILENAMES: list[str] = ["test_file_1.avi", "test_file_2.avi"]
 
     # filenames of some compressed sample pose files in the test/data directory.
     # must be at least as long as _FILENAMES
-    _POSE_FILES: ClassVar[list[str]] = [
+    _POSE_FILES: list[str] = [
         "identity_with_no_data_pose_est_v3.h5.gz",
         "sample_pose_est_v3.h5.gz",
     ]
 
-    @classmethod
-    def setUpClass(cls):
-        """create a project with empty video file and annotations"""
-        test_data_dir = Path(__file__).parent.parent / "data"
+    test_data_dir = Path(__file__).parent.parent / "data"
 
-        # make sure the test project dir is gone in case we previously
-        # threw an exception during setup
-        with contextlib.suppress(FileNotFoundError):
-            shutil.rmtree(cls._EXISTING_PROJ_PATH)
+    # make sure the test project dir is gone in case we previously
+    # threw an exception during setup
+    with contextlib.suppress(FileNotFoundError):
+        shutil.rmtree(_EXISTING_PROJ_PATH)
 
-        cls._EXISTING_PROJ_PATH.mkdir()
+    _EXISTING_PROJ_PATH.mkdir()
 
-        for i, name in enumerate(cls._FILENAMES):
-            # make a stub for the .avi file in the project directory
-            (cls._EXISTING_PROJ_PATH / name).touch()
+    for i, name in enumerate(_FILENAMES):
+        # make a stub for the .avi file in the project directory
+        (_EXISTING_PROJ_PATH / name).touch()
 
-            # extract the sample pose_est files
-            pose_filename = name.replace(".avi", "_pose_est_v3.h5")
-            pose_path = cls._EXISTING_PROJ_PATH / pose_filename
-            pose_source = test_data_dir / cls._POSE_FILES[i]
+        # extract the sample pose_est files
+        pose_filename = name.replace(".avi", "_pose_est_v3.h5")
+        pose_path = _EXISTING_PROJ_PATH / pose_filename
+        pose_source = test_data_dir / _POSE_FILES[i]
 
-            with gzip.open(pose_source, "rb") as f_in, open(pose_path, "wb") as f_out:
-                shutil.copyfileobj(f_in, f_out)
+        with gzip.open(pose_source, "rb") as f_in, open(pose_path, "wb") as f_out:
+            shutil.copyfileobj(f_in, f_out)
 
-        # set up a project directory with annotations
-        Project(cls._EXISTING_PROJ_PATH, enable_video_check=False, enable_session_tracker=False)
+    # set up a project directory with annotations
+    Project(_EXISTING_PROJ_PATH, enable_video_check=False, enable_session_tracker=False)
 
-        # Create a mock pose_est object with required methods
-        mock_pose_est = MagicMock()
-        mock_pose_est.identity_mask.return_value = np.full(10000, 1, dtype=bool)
+    # Create a mock pose_est object with required methods
+    mock_pose_est = MagicMock()
+    mock_pose_est.identity_mask.return_value = np.full(10000, 1, dtype=bool)
 
-        # create an annotation
-        labels = VideoLabels(cls._FILENAMES[0], 10000)
-        walking_labels = labels.get_track_labels("0", "Walking")
-        walking_labels.label_behavior(100, 200)
-        walking_labels.label_behavior(500, 1000)
-        walking_labels.label_not_behavior(1001, 2000)
+    # create an annotation
+    labels = VideoLabels(_FILENAMES[0], 10000)
+    walking_labels = labels.get_track_labels("0", "Walking")
+    walking_labels.label_behavior(100, 200)
+    walking_labels.label_behavior(500, 1000)
+    walking_labels.label_not_behavior(1001, 2000)
 
-        # and manually place the .json file in the project directory
-        with (
-            cls._EXISTING_PROJ_PATH
-            / "jabs"
-            / "annotations"
-            / Path(cls._FILENAMES[0]).with_suffix(".json")
-        ).open("w", newline="\n") as f:
-            json.dump(labels.as_dict(mock_pose_est), f)
+    # and manually place the .json file in the project directory
+    with (
+        _EXISTING_PROJ_PATH / "jabs" / "annotations" / Path(_FILENAMES[0]).with_suffix(".json")
+    ).open("w", newline="\n") as f:
+        json.dump(labels.as_dict(mock_pose_est), f)
 
-        # open project
-        cls.project = Project(cls._EXISTING_PROJ_PATH, enable_video_check=False)
+    # open project
+    project = Project(_EXISTING_PROJ_PATH, enable_video_check=False, enable_session_tracker=False)
 
-    @classmethod
-    def tearDownClass(cls):
-        """remove the test project directory"""
-        shutil.rmtree(cls._EXISTING_PROJ_PATH)
+    yield project
 
-    def test_create(self):
-        """test creating a new empty Project"""
-        project_dir = Path("test_project_dir")
-        project = Project(project_dir, enable_session_tracker=False)
+    # teardown
+    shutil.rmtree(_EXISTING_PROJ_PATH)
 
-        # make sure that the empty project directory was created
-        self.assertTrue(project_dir.exists())
 
-        # make sure the jabs directory was created
-        self.assertTrue(project.project_paths.jabs_dir.exists())
+def test_create():
+    """test creating a new empty Project"""
+    project_dir = Path("test_project_dir")
+    project = Project(project_dir, enable_session_tracker=False)
 
-        # make sure the jabs/annotations directory was created
-        self.assertTrue(project.project_paths.annotations_dir.exists())
+    # make sure that the empty project directory was created
+    assert project_dir.exists()
 
-        # make sure the jabs/predictions directory was created
-        self.assertTrue(project.project_paths.prediction_dir.exists())
+    # make sure the jabs directory was created
+    assert project.project_paths.jabs_dir.exists()
 
-        # remove project dir
-        shutil.rmtree(project_dir)
+    # make sure the jabs/annotations directory was created
+    assert project.project_paths.annotations_dir.exists()
 
-    def test_get_video_list(self):
-        """get list of video files in an existing project"""
-        self.assertListEqual(self.project.video_manager.videos, self._FILENAMES)
+    # make sure the jabs/predictions directory was created
+    assert project.project_paths.prediction_dir.exists()
 
-    def test_load_annotations(self):
-        """test loading annotations from a saved project"""
-        mock_pose_est = MagicMock()
-        mock_pose_est.identity_mask.return_value = np.full(10000, 1, dtype=bool)
-        mock_pose_est.num_frames = 10000
+    # remove project dir
+    shutil.rmtree(project_dir)
 
-        labels = self.project.video_manager.load_video_labels(self._FILENAMES[0])
 
-        with (
-            self._EXISTING_PROJ_PATH
-            / "jabs"
-            / "annotations"
-            / Path(self._FILENAMES[0]).with_suffix(".json")
-        ).open("r") as f:
-            dict_from_file = json.load(f)
+def test_get_video_list(project_with_data):
+    """get list of video files in an existing project"""
+    assert project_with_data.video_manager.videos == ["test_file_1.avi", "test_file_2.avi"]
 
-        self.assertTrue(len(self.project.video_manager.videos), 2)
 
-        # check to see that calling as_dict() on the VideoLabels object
-        # matches what was used to load the annotation track from disk
-        self.assertDictEqual(labels.as_dict(mock_pose_est), dict_from_file)
+def test_load_annotations(project_with_data):
+    """test loading annotations from a saved project"""
+    mock_pose_est = MagicMock()
+    mock_pose_est.identity_mask.return_value = np.full(10000, 1, dtype=bool)
+    mock_pose_est.num_frames = 10000
 
-    def test_save_annotations(self):
-        """test saving annotations"""
-        mock_pose_est = MagicMock()
-        mock_pose_est.identity_mask.return_value = np.full(10000, 1, dtype=bool)
-        mock_pose_est.num_frames = 10000
+    labels = project_with_data.video_manager.load_video_labels("test_file_1.avi")
 
-        labels = self.project.video_manager.load_video_labels(self._FILENAMES[0])
-        walking_labels = labels.get_track_labels("0", "Walking")
+    with (
+        Path("test_project_with_data")
+        / "jabs"
+        / "annotations"
+        / Path("test_file_1.avi").with_suffix(".json")
+    ).open("r") as f:
+        dict_from_file = json.load(f)
 
-        # make some changes
-        walking_labels.label_behavior(5000, 5500)
+    assert len(project_with_data.video_manager.videos) == 2
 
-        # save changes
-        self.project.save_annotations(labels, mock_pose_est)
+    # check to see that calling as_dict() on the VideoLabels object
+    # matches what was used to load the annotation track from disk
+    assert labels.as_dict(mock_pose_est) == dict_from_file
 
-        # make sure the .json file in the project directory matches the new
-        # state
-        with (
-            self._EXISTING_PROJ_PATH
-            / "jabs"
-            / "annotations"
-            / Path(self._FILENAMES[0]).with_suffix(".json")
-        ).open("r") as f:
-            dict_from_file = json.load(f)
 
-        # need to add the project labeler to the labels dict
-        labels_as_dict = labels.as_dict(mock_pose_est)
-        labels_as_dict["labeler"] = self.project.labeler
+def test_save_annotations(project_with_data):
+    """test saving annotations"""
+    mock_pose_est = MagicMock()
+    mock_pose_est.identity_mask.return_value = np.full(10000, 1, dtype=bool)
+    mock_pose_est.num_frames = 10000
 
-        self.assertDictEqual(labels_as_dict, dict_from_file)
+    labels = project_with_data.video_manager.load_video_labels("test_file_1.avi")
+    walking_labels = labels.get_track_labels("0", "Walking")
 
-    def test_load_annotations_bad_filename(self):
-        """test load annotations for a file that doesn't exist raises ValueError"""
-        with self.assertRaises(ValueError):
-            self.project.video_manager.load_video_labels("bad_filename.avi")
+    # make some changes
+    walking_labels.label_behavior(5000, 5500)
 
-    def test_no_saved_video_labels(self):
-        """test loading labels for a video with no saved labels returns None"""
-        assert self.project.video_manager.load_video_labels(self._FILENAMES[1]) is None
+    # save changes
+    project_with_data.save_annotations(labels, mock_pose_est)
 
-    def test_bad_video_file(self):
-        """test loading a video file that doesn't exist raises ValueError"""
-        with self.assertRaises(IOError), hide_stderr():
-            _ = Project(self._EXISTING_PROJ_PATH)
+    # make sure the .json file in the project directory matches the new
+    # state
+    with (
+        Path("test_project_with_data")
+        / "jabs"
+        / "annotations"
+        / Path("test_file_1.avi").with_suffix(".json")
+    ).open("r") as f:
+        dict_from_file = json.load(f)
 
-    def test_min_pose_version(self):
-        """dummy project contains version 3 and 4 pose files min should be 3"""
-        self.assertEqual(self.project.feature_manager.min_pose_version, 3)
+    # need to add the project labeler to the labels dict
+    labels_as_dict = labels.as_dict(mock_pose_est)
+    labels_as_dict["labeler"] = project_with_data.labeler
 
-    def test_can_use_social_true(self):
-        """test that can_use_social_features is True when social features are enabled"""
-        self.assertTrue(self.project.feature_manager.can_use_social_features)
+    assert labels_as_dict == dict_from_file
+
+
+def test_load_annotations_bad_filename(project_with_data):
+    """test load annotations for a file that doesn't exist raises ValueError"""
+    with pytest.raises(ValueError):
+        project_with_data.video_manager.load_video_labels("bad_filename.avi")
+
+
+def test_no_saved_video_labels(project_with_data):
+    """test loading labels for a video with no saved labels returns None"""
+    assert project_with_data.video_manager.load_video_labels("test_file_2.avi") is None
+
+
+def test_bad_video_file(project_with_data):
+    """test loading a video file that doesn't exist raises ValueError"""
+    with pytest.raises(IOError), hide_stderr():
+        _ = Project(Path("test_project_with_data"), enable_session_tracker=False)
+
+
+def test_min_pose_version(project_with_data):
+    """dummy project contains version 3 and 4 pose files min should be 3"""
+    assert project_with_data.feature_manager.min_pose_version == 3
+
+
+def test_can_use_social_true(project_with_data):
+    """test that can_use_social_features is True when social features are enabled"""
+    assert project_with_data.feature_manager.can_use_social_features
+
+
+def test_rename_behavior_raises_if_new_name_exists(tmp_path) -> None:
+    """Test that renaming a behavior to an existing name raises a ValueError."""
+    project = Project(tmp_path, enable_video_check=False, enable_session_tracker=False)
+
+    # Seed settings with two behaviors: one to rename, and one that already exists
+    existing_settings = {
+        "window_size": 5,
+        "balance_labels": True,
+        "symmetric_behavior": False,
+    }
+    project.settings_manager.save_behavior("Existing", existing_settings)
+    project.settings_manager.save_behavior("Old", existing_settings)
+
+    # Attempt to rename "Old" -> "Existing" should raise
+    with pytest.raises(ValueError):
+        project.rename_behavior("Old", "Existing")
+
+    # Ensure behaviors are unchanged after the failed rename
+    names = set(project.settings_manager.behavior_names)
+    assert "Existing" in names
+    assert "Old" in names

--- a/tests/test_video_labels.py
+++ b/tests/test_video_labels.py
@@ -105,3 +105,36 @@ class TestVideoLabels(unittest.TestCase):
             {"start": 100, "end": 200, "present": True},
         ]
         self.assertEqual(unfragmented_blocks, expected_unfragmented)
+
+    def test_rename_behavior(self):
+        """renaming a behavior should update both labels and unfragmented_labels"""
+        labels = VideoLabels("filename.avi", 100)
+
+        # Create an initial behavior with one block
+        track = labels.get_track_labels("0", "Walk")
+        track.label_behavior(10, 20)
+
+        # Sanity check before rename
+        d_before = labels.as_dict(mock_pose_est)
+        self.assertIn("Walk", d_before["labels"]["0"])  # old name present
+        self.assertIn("Walk", d_before["unfragmented_labels"]["0"])  # old name present
+
+        # Rename the behavior
+        labels.rename_behavior("Walk", "Walking")
+
+        # After rename, old key should be gone and new key present in both structures
+        d_after = labels.as_dict(mock_pose_est)
+        self.assertNotIn("Walk", d_after["labels"]["0"])  # old name removed
+        self.assertNotIn("Walk", d_after["unfragmented_labels"]["0"])  # old name removed
+        self.assertIn("Walking", d_after["labels"]["0"])  # new name present
+        self.assertIn("Walking", d_after["unfragmented_labels"]["0"])  # new name present
+
+        # Ensure the intervals were preserved under the new name
+        self.assertEqual(
+            d_before["labels"]["0"]["Walk"],
+            d_after["labels"]["0"]["Walking"],
+        )
+        self.assertEqual(
+            d_before["unfragmented_labels"]["0"]["Walk"],
+            d_after["unfragmented_labels"]["0"]["Walking"],
+        )


### PR DESCRIPTION
Note: branch name is misleading, should be *rename-behavior-util*

add cli utility for renaming a behavior in an existing JABS project

usage:

`jabs-cli rename-behavior <project dir> <old behavior name> <new behavior name>`