### PR TITLE
fall back to using nose to calculate animal bearing if pose does not include base neck keypoint

### DIFF
--- a/src/jabs/pose_estimation/pose_est.py
+++ b/src/jabs/pose_estimation/pose_est.py
@@ -358,6 +358,9 @@ class PoseEstimation(ABC):
     def compute_all_bearings(self, identity):
         """compute the bearing for each frame for a given identity"""
         use_nose = not self.get_reduced_point_mask()[self.KeypointIndex.BASE_NECK.value]
+        if use_nose:
+            logging.warning("Falling back to using nose keypoint for bearing computation")
+
         bearings = np.full(self.num_frames, np.nan, dtype=np.float32)
         for i in range(self.num_frames):
             points, mask = self.get_points(i, identity)


### PR DESCRIPTION
If the pose does not include the base neck key point, JABS does not compute animal bearings. 

This change falls back to using the nose key point in that case.