### PR TITLE
print top 10 features after training final classifier will all labeled data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jabs-behavior-classifier"
-version = "0.38.0"
+version = "0.38.1"
 description = ""
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/src/jabs/ui/training_thread.py
+++ b/src/jabs/ui/training_thread.py
@@ -216,20 +216,24 @@ class TrainingThread(QThread):
                     else "pixel"
                 )
                 print(f"Feature Distance Unit: {unit}")
-                print("-" * 70)
 
             # retrain with all training data and fixed random seed before saving:
             check_termination_requested()
             self.current_status.emit("Training and saving final classifier")
             full_dataset = self._classifier.combine_data(features["per_frame"], features["window"])
+            feature_names = full_dataset.columns.to_list()
             self._classifier.train(
                 {
                     "training_data": full_dataset,
                     "training_labels": features["labels"],
-                    "feature_names": full_dataset.columns.to_list(),
+                    "feature_names": feature_names,
                 },
                 random_seed=FINAL_TRAIN_SEED,
             )
+
+            print("\nFinal classifier, top 10 features by importance:")
+            self._classifier.print_feature_importance(feature_names, 10)
+            print("-" * 70)
 
             self._project.save_classifier(self._classifier, self._behavior)
             self._tasks_complete += 1


### PR DESCRIPTION
previously, JABS only printed the 10 most important features as part of each leave one group out cross validation iteration and it did not report the top features for the final trained classifier, which is trained with all labeled data after the cross validation iterations are completed

This change prints the top 10 features of the final classifier

Note: all reporting via printing to the console that occurs in TrainingThread.run() should be replaced with the suggestions in issue #140 