### PR TITLE
bump version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jabs-behavior-classifier"
-version = "0.38.1"
+version = "0.39.0"
 description = ""
 readme = "README.md"
 requires-python = ">=3.10,<3.15"


### PR DESCRIPTION
bump version to 0.39.0

main changes in release:

package now supports Python 3.14
user guide restructured into multiple markdown files, UserGuideDialog updated to browse new user guide structure
better link handling in user guide (links to external resources open in system browser, links to internal app markdown documentation render as html before display)
Scikit Learn Gradient Boosting removed as classifier option
new contributing and development guide documents