### PR TITLE
Update pytest command to include all tests

### DIFF
--- a/.github/workflows/_run-tests-action.yml
+++ b/.github/workflows/_run-tests-action.yml
@@ -32,4 +32,4 @@ jobs:
         run: uv sync
 
       - name: Test with pytest
-        run: uv run pytest --ignore=tests/test_search_bar_widget.py tests
+        run: uv run pytest tests


### PR DESCRIPTION
Modified pytest command to run all tests instead of ignoring a specific test file.

we were explicitly ignoring tests/test_search_bar_widget.py because required GUI libraries are not available on our runner. However, this is now outdated -- the file in question has moved to a new location and it has been updated to automatically skip if it is unable to import the UI components that depend on the missing shared library. 