### PR TITLE
add parquet support for jabs.io feature cache

### DIFF
--- a/packages/jabs-core/src/jabs/core/enums/__init__.py
+++ b/packages/jabs-core/src/jabs/core/enums/__init__.py
@@ -1,5 +1,6 @@
 """Module for defining enums used in JABS"""
 
+from .cache_format import CacheFormat
 from .classifier_types import ClassifierType
 from .cv_grouping import DEFAULT_CV_GROUPING_STRATEGY, CrossValidationGroupingStrategy
 from .inference import ConfidenceMetric, Method, SamplingStrategy
@@ -9,6 +10,7 @@ from .units import ProjectDistanceUnit
 
 __all__ = [
     "DEFAULT_CV_GROUPING_STRATEGY",
+    "CacheFormat",
     "ClassifierType",
     "ConfidenceMetric",
     "CrossValidationGroupingStrategy",

--- a/packages/jabs-core/src/jabs/core/enums/cache_format.py
+++ b/packages/jabs-core/src/jabs/core/enums/cache_format.py
@@ -1,0 +1,10 @@
+"""Enum for feature cache storage format."""
+
+from enum import Enum
+
+
+class CacheFormat(Enum):
+    """Storage format for a project's feature cache."""
+
+    HDF5 = "hdf5"
+    PARQUET = "parquet"

--- a/packages/jabs-io/src/jabs/io/feature_cache/__init__.py
+++ b/packages/jabs-io/src/jabs/io/feature_cache/__init__.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 from jabs.core.enums import CacheFormat
+
+logger = logging.getLogger(__name__)
 
 
 def detect_cache_format(identity_dir: Path) -> CacheFormat | None:
@@ -33,3 +36,22 @@ def detect_cache_format(identity_dir: Path) -> CacheFormat | None:
     if (identity_dir / "features.h5").exists():
         return CacheFormat.HDF5
     return None
+
+
+def clear_cache(identity_dir: Path) -> None:
+    """Delete all feature cache files from ``identity_dir``, regardless of format.
+
+    Removes ``metadata.json``, ``per_frame.parquet``, ``window_*.parquet``, and
+    ``features.h5`` if present. The directory itself is not removed.
+
+    This is the correct way to discard a cache before writing in a different
+    format, and is also used by the "Clear Feature Cache" GUI action.
+
+    Args:
+        identity_dir: Per-identity cache directory to clear.
+    """
+    for path in identity_dir.glob("*.parquet"):
+        path.unlink(missing_ok=True)
+    (identity_dir / "metadata.json").unlink(missing_ok=True)
+    (identity_dir / "features.h5").unlink(missing_ok=True)
+    logger.debug("Cleared feature cache in %s", identity_dir)

--- a/packages/jabs-io/src/jabs/io/feature_cache/__init__.py
+++ b/packages/jabs-io/src/jabs/io/feature_cache/__init__.py
@@ -21,6 +21,12 @@ def detect_cache_format(identity_dir: Path) -> CacheFormat | None:
         ``CacheFormat.PARQUET`` if ``metadata.json`` exists,
         ``CacheFormat.HDF5`` if ``features.h5`` exists,
         ``None`` if no cache is present.
+
+    Note:
+        The sentinel filenames are written as literals here rather
+        than imported from the backend modules. They are stable on-disk format
+        contracts; changing either name constitutes a format-breaking change that
+        requires a versioned migration, so drift is not a practical risk.
     """
     if (identity_dir / "metadata.json").exists():
         return CacheFormat.PARQUET

--- a/packages/jabs-io/src/jabs/io/feature_cache/__init__.py
+++ b/packages/jabs-io/src/jabs/io/feature_cache/__init__.py
@@ -1,1 +1,29 @@
 """Feature cache I/O backends for jabs-io."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from jabs.core.enums import CacheFormat
+
+
+def detect_cache_format(identity_dir: Path) -> CacheFormat | None:
+    """Return the storage format of an existing cache, or ``None`` if absent.
+
+    Checks for ``metadata.json`` first (the Parquet sentinel file), then falls
+    back to ``features.h5``. Returns ``None`` when neither file is present so
+    the caller knows to compute features from scratch.
+
+    Args:
+        identity_dir: Per-identity cache directory to inspect.
+
+    Returns:
+        ``CacheFormat.PARQUET`` if ``metadata.json`` exists,
+        ``CacheFormat.HDF5`` if ``features.h5`` exists,
+        ``None`` if no cache is present.
+    """
+    if (identity_dir / "metadata.json").exists():
+        return CacheFormat.PARQUET
+    if (identity_dir / "features.h5").exists():
+        return CacheFormat.HDF5
+    return None

--- a/packages/jabs-io/src/jabs/io/feature_cache/base.py
+++ b/packages/jabs-io/src/jabs/io/feature_cache/base.py
@@ -174,6 +174,13 @@ class FeatureCacheWriter(ABC):
         from group or path names) may update whatever metadata is appropriate
         for that representation.
 
+        **Precondition:** ``write_per_frame()`` must have been called for
+        ``identity_dir`` before calling this method. The directory and any
+        backend-specific sentinel files (e.g. ``metadata.json``) must already
+        exist. Calling ``write_window()`` without a prior ``write_per_frame()``
+        produces undefined behavior and will typically raise
+        ``FileNotFoundError``.
+
         Args:
             identity_dir: Directory for this identity's cache.
             metadata: Current cache metadata; backends may use this to update

--- a/packages/jabs-io/src/jabs/io/feature_cache/parquet.py
+++ b/packages/jabs-io/src/jabs/io/feature_cache/parquet.py
@@ -171,9 +171,10 @@ class ParquetFeatureCacheWriter(FeatureCacheWriter):
         Args:
             identity_dir: Directory for this identity's cache.
             metadata: Current cache metadata. The ``cached_window_sizes`` field
-                is not used directly; the on-disk ``metadata.json`` is read
-                instead to capture any sizes written since ``metadata`` was
-                constructed.
+                is ignored; ``metadata.json`` is read from disk to obtain the
+                accumulated set of previously written window sizes, because
+                callers construct metadata fresh for each call without carrying
+                that set forward.
             window_size: Window size these features were computed for.
             data: Flat dict mapping ``"module_name window_op feature_name"``
                 to shape-``(n_frames,)`` arrays.
@@ -190,8 +191,9 @@ class ParquetFeatureCacheWriter(FeatureCacheWriter):
             parquet_path,
         )
 
-        # Update cached_window_sizes in metadata.json from the on-disk state so
-        # that concurrent window writes accumulate correctly.
+        # Read cached_window_sizes from disk rather than from the caller-supplied
+        # metadata, because callers construct metadata fresh for each call and do
+        # not carry forward the accumulated set of previously written window sizes.
         metadata_path = identity_dir / _METADATA_FILENAME
         with metadata_path.open() as f:
             raw: dict[str, object] = json.load(f)

--- a/packages/jabs-io/src/jabs/io/feature_cache/parquet.py
+++ b/packages/jabs-io/src/jabs/io/feature_cache/parquet.py
@@ -72,7 +72,8 @@ def _write_metadata_json(identity_dir: Path, metadata: FeatureCacheMetadata) -> 
         metadata: Metadata to serialize and write.
     """
     path = identity_dir / _METADATA_FILENAME
-    path.write_text(json.dumps(_metadata_to_dict(metadata), indent=2))
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(_metadata_to_dict(metadata), f, indent=2)
 
 
 def _require_pyarrow() -> None:
@@ -285,7 +286,7 @@ class ParquetFeatureCacheReader(FeatureCacheReader):
         """
         path = identity_dir / _METADATA_FILENAME
         try:
-            with path.open() as f:
+            with path.open(encoding="utf-8") as f:
                 return json.load(f)  # type: ignore[return-value]
         except ValueError as exc:
             # json.JSONDecodeError is a subclass of ValueError; normalize to OSError

--- a/packages/jabs-io/src/jabs/io/feature_cache/parquet.py
+++ b/packages/jabs-io/src/jabs/io/feature_cache/parquet.py
@@ -9,8 +9,13 @@ from pathlib import Path
 
 import numpy as np
 import numpy.typing as npt
-import pyarrow as pa
-import pyarrow.parquet as pq
+
+try:
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+except ImportError:
+    pa = None  # type: ignore[assignment]
+    pq = None  # type: ignore[assignment]
 
 from jabs.core.exceptions import FeatureVersionException
 from jabs.core.types import FeatureCacheMetadata, PerFrameCacheData
@@ -70,6 +75,16 @@ def _write_metadata_json(identity_dir: Path, metadata: FeatureCacheMetadata) -> 
     path.write_text(json.dumps(_metadata_to_dict(metadata), indent=2))
 
 
+def _require_pyarrow() -> None:
+    """Raise ``ImportError`` with an actionable message if pyarrow is not installed."""
+    if pa is None or pq is None:
+        raise ImportError(
+            "pyarrow is required to use the Parquet feature cache. "
+            "Install jabs-io with the 'parquet' extra: "
+            "pip install 'jabs-io[parquet]'"
+        )
+
+
 class ParquetFeatureCacheWriter(FeatureCacheWriter):
     """Writes per-frame and window features to Parquet files with LZ4 compression.
 
@@ -86,6 +101,10 @@ class ParquetFeatureCacheWriter(FeatureCacheWriter):
       with the new window size. A crash between the two steps leaves an
       unregistered window file that is simply ignored on the next read.
     """
+
+    def __init__(self) -> None:
+        """Initialize the writer, raising ``ImportError`` if pyarrow is absent."""
+        _require_pyarrow()
 
     def write_per_frame(
         self,
@@ -227,6 +246,29 @@ class ParquetFeatureCacheReader(FeatureCacheReader):
       ``cached_window_sizes`` in ``metadata.json`` and ``AttributeError`` is
       raised so only that window size is recomputed.
     """
+
+    def __init__(
+        self,
+        expected_feature_version: int,
+        expected_pose_hash: str,
+        expected_distance_scale_factor: float | None,
+    ) -> None:
+        """Initialize the reader, raising ``ImportError`` if pyarrow is absent.
+
+        Args:
+            expected_feature_version: Value of ``FEATURE_VERSION`` from
+                ``features.py``; used to detect stale caches.
+            expected_pose_hash: Hash of the pose file at the time features were
+                requested; used to detect caches built from a different pose file.
+            expected_distance_scale_factor: Pixels-to-cm scale factor, or ``None``
+                when not using cm units.
+        """
+        _require_pyarrow()
+        super().__init__(
+            expected_feature_version,
+            expected_pose_hash,
+            expected_distance_scale_factor,
+        )
 
     @staticmethod
     def _read_raw_metadata(identity_dir: Path) -> dict[str, object]:

--- a/packages/jabs-io/src/jabs/io/feature_cache/parquet.py
+++ b/packages/jabs-io/src/jabs/io/feature_cache/parquet.py
@@ -1,0 +1,500 @@
+"""Parquet feature cache reader and writer."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import replace
+from pathlib import Path
+
+import numpy as np
+import numpy.typing as npt
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from jabs.core.exceptions import FeatureVersionException
+from jabs.core.types import FeatureCacheMetadata, PerFrameCacheData
+from jabs.io.feature_cache.base import FeatureCacheReader, FeatureCacheWriter
+
+logger = logging.getLogger(__name__)
+
+# Increment when the Parquet cache layout changes in a backward-incompatible way.
+PARQUET_FORMAT_VERSION: int = 1
+
+# Column name constants for auxiliary (non-feature) columns in per_frame.parquet.
+_COL_FRAME_VALID = "_jabs_frame_valid"
+_COL_CLOSEST_IDENTITIES = "_jabs_closest_identities"
+_COL_CLOSEST_FOV_IDENTITIES = "_jabs_closest_fov_identities"
+_COL_CLOSEST_CORNERS = "_jabs_closest_corners"
+_COL_CLOSEST_LIXIT = "_jabs_closest_lixit"
+_COL_WALL_PREFIX = "_jabs_wall_"
+
+_METADATA_FILENAME = "metadata.json"
+_PER_FRAME_FILENAME = "per_frame.parquet"
+_WINDOW_FILENAME_TEMPLATE = "window_{size}.parquet"
+
+
+def _metadata_to_dict(metadata: FeatureCacheMetadata) -> dict[str, object]:
+    """Serialize ``FeatureCacheMetadata`` to a JSON-compatible dict.
+
+    ``cached_window_sizes`` is converted to a sorted list for a stable,
+    human-readable representation. ``format_version`` is always
+    ``PARQUET_FORMAT_VERSION``.
+
+    Args:
+        metadata: Metadata to serialize.
+
+    Returns:
+        Dict suitable for writing to ``metadata.json``.
+    """
+    return {
+        "feature_version": metadata.feature_version,
+        "format_version": PARQUET_FORMAT_VERSION,
+        "identity": metadata.identity,
+        "num_frames": metadata.num_frames,
+        "pose_hash": metadata.pose_hash,
+        "distance_scale_factor": metadata.distance_scale_factor,
+        "avg_wall_length": metadata.avg_wall_length,
+        "cached_window_sizes": sorted(metadata.cached_window_sizes),
+    }
+
+
+def _write_metadata_json(identity_dir: Path, metadata: FeatureCacheMetadata) -> None:
+    """Write ``metadata.json`` into ``identity_dir``.
+
+    Args:
+        identity_dir: Directory for this identity's cache.
+        metadata: Metadata to serialize and write.
+    """
+    path = identity_dir / _METADATA_FILENAME
+    path.write_text(json.dumps(_metadata_to_dict(metadata), indent=2))
+
+
+class ParquetFeatureCacheWriter(FeatureCacheWriter):
+    """Writes per-frame and window features to Parquet files with LZ4 compression.
+
+    Per-frame features and auxiliary arrays are written to ``per_frame.parquet``.
+    Window features for each window size are written to
+    ``window_{size}.parquet``. Cache metadata (versions, hashes, window size
+    bookkeeping) is stored in ``metadata.json``.
+
+    Write ordering guarantees:
+    - ``write_per_frame``: Parquet file first, then ``metadata.json``. An
+      incomplete write therefore leaves no sentinel file and the partial cache
+      is ignored by ``detect_cache_format()``.
+    - ``write_window``: Parquet file first, then ``metadata.json`` is updated
+      with the new window size. A crash between the two steps leaves an
+      unregistered window file that is simply ignored on the next read.
+    """
+
+    def write_per_frame(
+        self,
+        identity_dir: Path,
+        metadata: FeatureCacheMetadata,
+        data: PerFrameCacheData,
+    ) -> None:
+        """Write per-frame features and auxiliary arrays to ``per_frame.parquet``.
+
+        Creates ``identity_dir`` and any missing parents. Writes
+        ``per_frame.parquet`` first, then ``metadata.json`` with an empty
+        ``cached_window_sizes`` list so that an incomplete write leaves no
+        sentinel file.
+
+        Column ordering: ``_jabs_frame_valid`` first, then other ``_jabs_*``
+        auxiliary columns, then feature columns sorted alphabetically.
+
+        Args:
+            identity_dir: Directory for this identity's cache.
+            metadata: Versioning and validation metadata to persist in
+                ``metadata.json``.
+            data: Per-frame feature arrays and auxiliary arrays to write.
+
+        Raises:
+            ValueError: If exactly one of ``closest_identities`` /
+                ``closest_fov_identities`` is provided, or if
+                ``closest_corners`` is present but ``metadata.avg_wall_length``
+                is ``None``.
+        """
+        if (data.closest_identities is None) != (data.closest_fov_identities is None):
+            raise ValueError(
+                "closest_identities and closest_fov_identities must both be provided "
+                "or both be None; got one without the other"
+            )
+        if data.closest_corners is not None and metadata.avg_wall_length is None:
+            raise ValueError(
+                "metadata.avg_wall_length must be set when data.closest_corners is present"
+            )
+
+        identity_dir.mkdir(mode=0o775, exist_ok=True, parents=True)
+        parquet_path = identity_dir / _PER_FRAME_FILENAME
+        logger.info("Writing Parquet per-frame feature cache to %s", parquet_path)
+
+        # Build columns in the specified order first _jabs_frame_valid followed by other _jabs_*,
+        columns: dict[str, npt.NDArray[np.generic]] = {}
+        columns[_COL_FRAME_VALID] = data.frame_valid
+        if data.closest_identities is not None:
+            columns[_COL_CLOSEST_IDENTITIES] = data.closest_identities
+            columns[_COL_CLOSEST_FOV_IDENTITIES] = data.closest_fov_identities
+        if data.closest_corners is not None:
+            columns[_COL_CLOSEST_CORNERS] = data.closest_corners
+        if data.closest_lixit is not None:
+            columns[_COL_CLOSEST_LIXIT] = data.closest_lixit
+        for direction, values in sorted(data.wall_distances.items()):
+            columns[f"{_COL_WALL_PREFIX}{direction}"] = values
+
+        # then add  feature columns sorted alphabetically.
+        for feature_key in sorted(data.features):
+            columns[feature_key] = data.features[feature_key]
+
+        table = pa.table({k: pa.array(v) for k, v in columns.items()})
+        pq.write_table(table, parquet_path, compression="lz4")
+        logger.debug("Wrote %d per-frame feature columns to %s", len(data.features), parquet_path)
+
+        # metadata.json is written last; its presence is the sentinel for a valid cache.
+        initial_metadata = replace(metadata, cached_window_sizes=frozenset())
+        _write_metadata_json(identity_dir, initial_metadata)
+        logger.debug("Wrote metadata.json for identity %d", metadata.identity)
+
+    def write_window(
+        self,
+        identity_dir: Path,
+        metadata: FeatureCacheMetadata,
+        window_size: int,
+        data: dict[str, npt.NDArray[np.generic]],
+    ) -> None:
+        """Write window features for one window size to ``window_{size}.parquet``.
+
+        Writes the Parquet file first, then reads ``metadata.json``, appends
+        ``window_size`` to ``cached_window_sizes``, and writes ``metadata.json``
+        back. Columns are sorted alphabetically for a stable output layout.
+
+        Args:
+            identity_dir: Directory for this identity's cache.
+            metadata: Current cache metadata. The ``cached_window_sizes`` field
+                is not used directly; the on-disk ``metadata.json`` is read
+                instead to capture any sizes written since ``metadata`` was
+                constructed.
+            window_size: Window size these features were computed for.
+            data: Flat dict mapping ``"module_name window_op feature_name"``
+                to shape-``(n_frames,)`` arrays.
+        """
+        parquet_path = identity_dir / _WINDOW_FILENAME_TEMPLATE.format(size=window_size)
+        logger.info("Writing Parquet window-%d feature cache to %s", window_size, parquet_path)
+
+        table = pa.table({k: pa.array(data[k]) for k in sorted(data)})
+        pq.write_table(table, parquet_path, compression="lz4")
+        logger.debug(
+            "Wrote %d window-%d feature columns to %s",
+            len(data),
+            window_size,
+            parquet_path,
+        )
+
+        # Update cached_window_sizes in metadata.json from the on-disk state so
+        # that concurrent window writes accumulate correctly.
+        metadata_path = identity_dir / _METADATA_FILENAME
+        with metadata_path.open() as f:
+            raw: dict[str, object] = json.load(f)
+        existing_sizes: frozenset[int] = frozenset(int(s) for s in raw["cached_window_sizes"])  # type: ignore[arg-type]
+        updated_metadata = replace(metadata, cached_window_sizes=existing_sizes | {window_size})
+        _write_metadata_json(identity_dir, updated_metadata)
+        logger.debug(
+            "Updated metadata.json cached_window_sizes for identity %d: %s",
+            metadata.identity,
+            sorted(updated_metadata.cached_window_sizes),
+        )
+
+
+class ParquetFeatureCacheReader(FeatureCacheReader):
+    """Reads per-frame and window features from Parquet feature cache files.
+
+    The cache consists of ``per_frame.parquet``, zero or more
+    ``window_{size}.parquet`` files, and ``metadata.json`` in the identity
+    directory. ``metadata.json`` is the sentinel whose presence indicates a
+    complete cache.
+
+    Validation order on every read: ``format_version`` is checked first
+    (raises ``FeatureVersionException`` if it does not match
+    ``PARQUET_FORMAT_VERSION``), then the base-class checks for
+    ``feature_version``, ``pose_hash``, and ``distance_scale_factor``.
+
+    Error recovery:
+    - ``per_frame.parquet`` unreadable → all cache files are deleted and
+      ``OSError`` is raised so the caller falls back to recomputing.
+    - ``window_{size}.parquet`` unreadable → ``window_size`` is removed from
+      ``cached_window_sizes`` in ``metadata.json`` and ``AttributeError`` is
+      raised so only that window size is recomputed.
+    """
+
+    @staticmethod
+    def _read_raw_metadata(identity_dir: Path) -> dict[str, object]:
+        """Read and parse ``metadata.json``.
+
+        Args:
+            identity_dir: Directory for this identity's cache.
+
+        Returns:
+            Parsed JSON content as a plain dict.
+
+        Raises:
+            OSError: If ``metadata.json`` cannot be read.
+        """
+        path = identity_dir / _METADATA_FILENAME
+        with path.open() as f:
+            return json.load(f)  # type: ignore[return-value]
+
+    @staticmethod
+    def _metadata_from_dict(raw: dict[str, object]) -> FeatureCacheMetadata:
+        """Construct ``FeatureCacheMetadata`` from a parsed ``metadata.json`` dict.
+
+        Args:
+            raw: Dict as returned by ``_read_raw_metadata``.
+
+        Returns:
+            Populated ``FeatureCacheMetadata`` instance.
+        """
+        scale = raw["distance_scale_factor"]
+        wall = raw["avg_wall_length"]
+        return FeatureCacheMetadata(
+            feature_version=int(raw["feature_version"]),  # type: ignore[arg-type]
+            identity=int(raw["identity"]),  # type: ignore[arg-type]
+            num_frames=int(raw["num_frames"]),  # type: ignore[arg-type]
+            pose_hash=str(raw["pose_hash"]),
+            distance_scale_factor=float(scale) if scale is not None else None,  # type: ignore[arg-type]
+            avg_wall_length=float(wall) if wall is not None else None,  # type: ignore[arg-type]
+            cached_window_sizes=frozenset(
+                int(s)
+                for s in raw["cached_window_sizes"]  # type: ignore[union-attr]
+            ),
+        )
+
+    @staticmethod
+    def _check_format_version(raw: dict[str, object]) -> None:
+        """Raise ``FeatureVersionException`` if ``format_version`` is unexpected.
+
+        Args:
+            raw: Dict as returned by ``_read_raw_metadata``.
+
+        Raises:
+            FeatureVersionException: ``format_version`` does not equal
+                ``PARQUET_FORMAT_VERSION``.
+        """
+        stored = int(raw["format_version"])  # type: ignore[arg-type]
+        if stored != PARQUET_FORMAT_VERSION:
+            logger.debug(
+                "Parquet format version mismatch: expected %d, got %d",
+                PARQUET_FORMAT_VERSION,
+                stored,
+            )
+            raise FeatureVersionException
+
+    @staticmethod
+    def _delete_all_cache_files(identity_dir: Path) -> None:
+        """Delete all Parquet files and ``metadata.json`` from ``identity_dir``.
+
+        Called when ``per_frame.parquet`` is unreadable so the caller can
+        safely recompute from scratch.
+
+        Args:
+            identity_dir: Directory for this identity's cache.
+        """
+        for path in identity_dir.glob("*.parquet"):
+            path.unlink(missing_ok=True)
+
+        (identity_dir / _METADATA_FILENAME).unlink(missing_ok=True)
+        logger.debug("Deleted all Parquet cache files in %s", identity_dir)
+
+    def read_metadata(self, identity_dir: Path) -> FeatureCacheMetadata:
+        """Read and return validated cache metadata from ``metadata.json``.
+
+        Checks ``format_version`` before delegating to the base-class
+        ``_validate`` for the remaining fields.
+
+        Args:
+            identity_dir: Directory for this identity's cache.
+
+        Raises:
+            FeatureVersionException: ``feature_version`` or ``format_version``
+                mismatch.
+            PoseHashException: ``pose_hash`` mismatch.
+            DistanceScaleException: ``distance_scale_factor`` mismatch.
+            OSError: If ``metadata.json`` cannot be read.
+        """
+        logger.debug("Reading Parquet cache metadata from %s", identity_dir)
+
+        raw = self._read_raw_metadata(identity_dir)
+        self._check_format_version(raw)
+
+        metadata = self._metadata_from_dict(raw)
+        self._validate(metadata)
+
+        return metadata
+
+    def read_per_frame(self, identity_dir: Path) -> PerFrameCacheData:
+        """Read per-frame features and auxiliary arrays from ``per_frame.parquet``.
+
+        Validates metadata first. If ``per_frame.parquet`` is missing or
+        unreadable, all cache files are deleted and ``OSError`` is raised so
+        the caller falls back to recomputing all features.
+
+        ``_jabs_*`` columns are mapped to their corresponding ``PerFrameCacheData``
+        fields; all remaining columns are treated as feature columns.
+
+        Args:
+            identity_dir: Directory for this identity's cache.
+
+        Raises:
+            FeatureVersionException: ``feature_version`` or ``format_version``
+                mismatch.
+            PoseHashException: ``pose_hash`` mismatch.
+            DistanceScaleException: ``distance_scale_factor`` mismatch.
+            OSError: If ``per_frame.parquet`` is missing or unreadable (cache
+                files are deleted before raising).
+        """
+        self.read_metadata(identity_dir)  # validate before touching data files
+        parquet_path = identity_dir / _PER_FRAME_FILENAME
+        logger.info("Loading Parquet per-frame feature cache from %s", parquet_path)
+
+        try:
+            table = pq.read_table(parquet_path)
+        except Exception as exc:
+            logger.warning(
+                "Failed to read per-frame Parquet cache %s; deleting all cache files: %s",
+                parquet_path,
+                exc,
+                exc_info=True,
+            )
+            self._delete_all_cache_files(identity_dir)
+            raise OSError(f"Unreadable per-frame cache at {parquet_path}") from exc
+
+        col_names: set[str] = set(table.schema.names)
+
+        frame_valid: npt.NDArray[np.uint8] = (
+            table.column(_COL_FRAME_VALID).to_numpy(zero_copy_only=False).astype(np.uint8)
+        )
+
+        closest_identities: npt.NDArray[np.int64] | None = None
+        closest_fov_identities: npt.NDArray[np.int64] | None = None
+        if _COL_CLOSEST_IDENTITIES in col_names:
+            closest_identities = (
+                table.column(_COL_CLOSEST_IDENTITIES)
+                .to_numpy(zero_copy_only=False)
+                .astype(np.int64)
+            )
+            closest_fov_identities = (
+                table.column(_COL_CLOSEST_FOV_IDENTITIES)
+                .to_numpy(zero_copy_only=False)
+                .astype(np.int64)
+            )
+
+        closest_corners: npt.NDArray[np.float64] | None = None
+        if _COL_CLOSEST_CORNERS in col_names:
+            closest_corners = (
+                table.column(_COL_CLOSEST_CORNERS)
+                .to_numpy(zero_copy_only=False)
+                .astype(np.float64)
+            )
+
+        closest_lixit: npt.NDArray[np.float64] | None = None
+        if _COL_CLOSEST_LIXIT in col_names:
+            closest_lixit = (
+                table.column(_COL_CLOSEST_LIXIT).to_numpy(zero_copy_only=False).astype(np.float64)
+            )
+
+        wall_distances: dict[str, npt.NDArray[np.float64]] = {}
+        for col_name in col_names:
+            if col_name.startswith(_COL_WALL_PREFIX):
+                direction = col_name[len(_COL_WALL_PREFIX) :]
+                wall_distances[direction] = (
+                    table.column(col_name).to_numpy(zero_copy_only=False).astype(np.float64)
+                )
+
+        _jabs_cols: set[str] = {
+            _COL_FRAME_VALID,
+            _COL_CLOSEST_IDENTITIES,
+            _COL_CLOSEST_FOV_IDENTITIES,
+            _COL_CLOSEST_CORNERS,
+            _COL_CLOSEST_LIXIT,
+        } | {c for c in col_names if c.startswith(_COL_WALL_PREFIX)}
+
+        features: dict[str, npt.NDArray[np.generic]] = {}
+        for col_name in table.schema.names:
+            if col_name not in _jabs_cols:
+                features[col_name] = table.column(col_name).to_numpy(zero_copy_only=False)
+
+        logger.debug("Loaded %d per-frame feature columns from %s", len(features), parquet_path)
+        return PerFrameCacheData(
+            frame_valid=frame_valid,
+            features=features,
+            closest_identities=closest_identities,
+            closest_fov_identities=closest_fov_identities,
+            closest_corners=closest_corners,
+            closest_lixit=closest_lixit,
+            wall_distances=wall_distances,
+        )
+
+    def read_window(
+        self, identity_dir: Path, window_size: int
+    ) -> dict[str, npt.NDArray[np.generic]]:
+        """Read window features for a specific window size.
+
+        If ``window_size`` is not recorded in ``cached_window_sizes``,
+        ``AttributeError`` is raised immediately. If the Parquet file exists
+        in the metadata but is unreadable, ``window_size`` is removed from
+        ``cached_window_sizes`` in ``metadata.json`` and ``AttributeError`` is
+        raised so only that window size is recomputed.
+
+        Args:
+            identity_dir: Directory for this identity's cache.
+            window_size: Window size to load.
+
+        Raises:
+            AttributeError: If ``window_size`` is not cached, or if the
+                corresponding Parquet file is unreadable (size is removed from
+                ``metadata.json`` before raising).
+            FeatureVersionException: ``feature_version`` or ``format_version``
+                mismatch.
+            PoseHashException: ``pose_hash`` mismatch.
+            DistanceScaleException: ``distance_scale_factor`` mismatch.
+            OSError: If ``metadata.json`` cannot be read.
+        """
+        metadata = self.read_metadata(identity_dir)
+
+        if window_size not in metadata.cached_window_sizes:
+            raise AttributeError(
+                f"Window size {window_size} not found in Parquet cache at {identity_dir}"
+            )
+
+        parquet_path = identity_dir / _WINDOW_FILENAME_TEMPLATE.format(size=window_size)
+        logger.info("Loading Parquet window-%d feature cache from %s", window_size, parquet_path)
+
+        try:
+            table = pq.read_table(parquet_path)
+        except Exception as exc:
+            logger.warning(
+                "Failed to read window-%d Parquet cache %s; removing from cached_window_sizes: %s",
+                window_size,
+                parquet_path,
+                exc,
+                exc_info=True,
+            )
+            updated_metadata = replace(
+                metadata,
+                cached_window_sizes=metadata.cached_window_sizes - {window_size},
+            )
+            _write_metadata_json(identity_dir, updated_metadata)
+            raise AttributeError(
+                f"Unreadable window-{window_size} cache at {parquet_path}"
+            ) from exc
+
+        window_features: dict[str, npt.NDArray[np.generic]] = {}
+        for col_name in table.schema.names:
+            window_features[col_name] = table.column(col_name).to_numpy(zero_copy_only=False)
+
+        logger.debug(
+            "Loaded %d window-%d feature columns from %s",
+            len(window_features),
+            window_size,
+            parquet_path,
+        )
+        return window_features

--- a/packages/jabs-io/src/jabs/io/feature_cache/parquet.py
+++ b/packages/jabs-io/src/jabs/io/feature_cache/parquet.py
@@ -239,11 +239,16 @@ class ParquetFeatureCacheReader(FeatureCacheReader):
             Parsed JSON content as a plain dict.
 
         Raises:
-            OSError: If ``metadata.json`` cannot be read.
+            OSError: If ``metadata.json`` cannot be opened or contains invalid JSON.
         """
         path = identity_dir / _METADATA_FILENAME
-        with path.open() as f:
-            return json.load(f)  # type: ignore[return-value]
+        try:
+            with path.open() as f:
+                return json.load(f)  # type: ignore[return-value]
+        except ValueError as exc:
+            # json.JSONDecodeError is a subclass of ValueError; normalize to OSError
+            # so callers treat malformed metadata the same as a missing file.
+            raise OSError(f"Invalid JSON in cache metadata at {path}") from exc
 
     @staticmethod
     def _metadata_from_dict(raw: dict[str, object]) -> FeatureCacheMetadata:
@@ -254,21 +259,29 @@ class ParquetFeatureCacheReader(FeatureCacheReader):
 
         Returns:
             Populated ``FeatureCacheMetadata`` instance.
+
+        Raises:
+            FeatureVersionException: A required key is missing or has an
+                incompatible type, indicating a schema change or corrupt file.
         """
-        scale = raw["distance_scale_factor"]
-        wall = raw["avg_wall_length"]
-        return FeatureCacheMetadata(
-            feature_version=int(raw["feature_version"]),  # type: ignore[arg-type]
-            identity=int(raw["identity"]),  # type: ignore[arg-type]
-            num_frames=int(raw["num_frames"]),  # type: ignore[arg-type]
-            pose_hash=str(raw["pose_hash"]),
-            distance_scale_factor=float(scale) if scale is not None else None,  # type: ignore[arg-type]
-            avg_wall_length=float(wall) if wall is not None else None,  # type: ignore[arg-type]
-            cached_window_sizes=frozenset(
-                int(s)
-                for s in raw["cached_window_sizes"]  # type: ignore[union-attr]
-            ),
-        )
+        try:
+            scale = raw["distance_scale_factor"]
+            wall = raw["avg_wall_length"]
+            return FeatureCacheMetadata(
+                feature_version=int(raw["feature_version"]),  # type: ignore[arg-type]
+                identity=int(raw["identity"]),  # type: ignore[arg-type]
+                num_frames=int(raw["num_frames"]),  # type: ignore[arg-type]
+                pose_hash=str(raw["pose_hash"]),
+                distance_scale_factor=float(scale) if scale is not None else None,  # type: ignore[arg-type]
+                avg_wall_length=float(wall) if wall is not None else None,  # type: ignore[arg-type]
+                cached_window_sizes=frozenset(
+                    int(s)
+                    for s in raw["cached_window_sizes"]  # type: ignore[union-attr]
+                ),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            logger.debug("Failed to parse cache metadata: %s", exc)
+            raise FeatureVersionException from exc
 
     @staticmethod
     def _check_format_version(raw: dict[str, object]) -> None:
@@ -278,10 +291,14 @@ class ParquetFeatureCacheReader(FeatureCacheReader):
             raw: Dict as returned by ``_read_raw_metadata``.
 
         Raises:
-            FeatureVersionException: ``format_version`` does not equal
-                ``PARQUET_FORMAT_VERSION``.
+            FeatureVersionException: ``format_version`` is missing, has an
+                incompatible type, or does not equal ``PARQUET_FORMAT_VERSION``.
         """
-        stored = int(raw["format_version"])  # type: ignore[arg-type]
+        try:
+            stored = int(raw["format_version"])  # type: ignore[arg-type]
+        except (KeyError, TypeError, ValueError) as exc:
+            logger.debug("Missing or invalid format_version in cache metadata: %s", exc)
+            raise FeatureVersionException from exc
         if stored != PARQUET_FORMAT_VERSION:
             logger.debug(
                 "Parquet format version mismatch: expected %d, got %d",

--- a/packages/jabs-io/tests/feature_cache/test_parquet.py
+++ b/packages/jabs-io/tests/feature_cache/test_parquet.py
@@ -1,0 +1,377 @@
+"""Tests for ParquetFeatureCacheReader and ParquetFeatureCacheWriter."""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import numpy.typing as npt
+import pyarrow.parquet as pq
+import pytest
+
+from jabs.core.exceptions import DistanceScaleException, FeatureVersionException
+from jabs.core.types import FeatureCacheMetadata, PerFrameCacheData
+from jabs.io.feature_cache import detect_cache_format
+from jabs.io.feature_cache.parquet import (
+    PARQUET_FORMAT_VERSION,
+    ParquetFeatureCacheReader,
+    ParquetFeatureCacheWriter,
+)
+from jabs.pose_estimation import PoseHashException
+
+# ---------------------------------------------------------------------------
+# Test constants
+# ---------------------------------------------------------------------------
+
+_N_FRAMES = 50
+_FEATURE_VERSION = 10
+_POSE_HASH = "deadbeef"
+_DISTANCE_SCALE: float | None = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _metadata(**overrides) -> FeatureCacheMetadata:
+    """Return a FeatureCacheMetadata with sensible defaults."""
+    return FeatureCacheMetadata(
+        feature_version=overrides.get("feature_version", _FEATURE_VERSION),
+        identity=overrides.get("identity", 0),
+        num_frames=overrides.get("num_frames", _N_FRAMES),
+        pose_hash=overrides.get("pose_hash", _POSE_HASH),
+        distance_scale_factor=overrides.get("distance_scale_factor", _DISTANCE_SCALE),
+        avg_wall_length=overrides.get("avg_wall_length"),
+    )
+
+
+def _flat_features(rng: np.random.Generator, n: int = 5) -> dict[str, npt.NDArray[np.float64]]:
+    """Return a flat feature dict with n synthetic columns."""
+    return {f"mod feat_{i}": rng.standard_normal(_N_FRAMES) for i in range(n)}
+
+
+def _per_frame_data(
+    rng: np.random.Generator,
+    *,
+    with_aux: bool = False,
+) -> PerFrameCacheData:
+    """Return a PerFrameCacheData; optionally populate all optional fields."""
+    frame_valid = rng.integers(0, 2, size=_N_FRAMES, dtype=np.uint8)
+    features = _flat_features(rng)
+    if not with_aux:
+        return PerFrameCacheData(frame_valid=frame_valid, features=features)
+    return PerFrameCacheData(
+        frame_valid=frame_valid,
+        features=features,
+        closest_identities=rng.integers(0, 3, size=_N_FRAMES, dtype=np.int64),
+        closest_fov_identities=rng.integers(0, 3, size=_N_FRAMES, dtype=np.int64),
+        closest_corners=rng.standard_normal(_N_FRAMES),
+        closest_lixit=rng.standard_normal(_N_FRAMES),
+        wall_distances={
+            "top": rng.standard_normal(_N_FRAMES),
+            "bottom": rng.standard_normal(_N_FRAMES),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def writer() -> ParquetFeatureCacheWriter:
+    """Return a ParquetFeatureCacheWriter instance."""
+    return ParquetFeatureCacheWriter()
+
+
+@pytest.fixture
+def reader() -> ParquetFeatureCacheReader:
+    """Return a ParquetFeatureCacheReader configured with the default test values."""
+    return ParquetFeatureCacheReader(_FEATURE_VERSION, _POSE_HASH, _DISTANCE_SCALE)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip tests
+# ---------------------------------------------------------------------------
+
+
+def test_parquet_per_frame_round_trip(
+    tmp_path, writer: ParquetFeatureCacheWriter, reader: ParquetFeatureCacheReader
+) -> None:
+    """Written per-frame arrays must be recovered identically on read."""
+    rng = np.random.default_rng(0)
+    identity_dir = tmp_path / "identity_0"
+    data = _per_frame_data(rng)
+
+    writer.write_per_frame(identity_dir, _metadata(), data)
+    result = reader.read_per_frame(identity_dir)
+
+    np.testing.assert_array_equal(result.frame_valid, data.frame_valid)
+    assert set(result.features) == set(data.features)
+    for key in data.features:
+        np.testing.assert_array_almost_equal(result.features[key], data.features[key], err_msg=key)
+    assert result.closest_identities is None
+    assert result.closest_corners is None
+    assert result.closest_lixit is None
+    assert result.wall_distances == {}
+
+
+def test_parquet_window_round_trip(
+    tmp_path, writer: ParquetFeatureCacheWriter, reader: ParquetFeatureCacheReader
+) -> None:
+    """Written window arrays must be recovered identically on read."""
+    rng = np.random.default_rng(1)
+    identity_dir = tmp_path / "identity_0"
+    window_size = 5
+    window_data = {f"mod op feat_{i}": rng.standard_normal(_N_FRAMES) for i in range(4)}
+
+    writer.write_per_frame(identity_dir, _metadata(), _per_frame_data(rng))
+    writer.write_window(identity_dir, _metadata(), window_size, window_data)
+    result = reader.read_window(identity_dir, window_size)
+
+    assert set(result) == set(window_data)
+    for key in window_data:
+        np.testing.assert_array_almost_equal(result[key], window_data[key], err_msg=key)
+
+
+def test_parquet_multiple_window_sizes(
+    tmp_path, writer: ParquetFeatureCacheWriter, reader: ParquetFeatureCacheReader
+) -> None:
+    """Both window sizes are readable and cached_window_sizes is updated correctly."""
+    rng = np.random.default_rng(2)
+    identity_dir = tmp_path / "identity_0"
+    data_5 = {f"mod op feat_{i}": rng.standard_normal(_N_FRAMES) for i in range(3)}
+    data_10 = {f"mod op feat_{i}": rng.standard_normal(_N_FRAMES) for i in range(3)}
+
+    writer.write_per_frame(identity_dir, _metadata(), _per_frame_data(rng))
+    writer.write_window(identity_dir, _metadata(), 5, data_5)
+    writer.write_window(identity_dir, _metadata(), 10, data_10)
+
+    metadata = reader.read_metadata(identity_dir)
+    assert metadata.cached_window_sizes == frozenset({5, 10})
+
+    result_5 = reader.read_window(identity_dir, 5)
+    result_10 = reader.read_window(identity_dir, 10)
+    for key in data_5:
+        np.testing.assert_array_almost_equal(result_5[key], data_5[key], err_msg=key)
+    for key in data_10:
+        np.testing.assert_array_almost_equal(result_10[key], data_10[key], err_msg=key)
+
+
+# ---------------------------------------------------------------------------
+# Sentinel / write-ordering test
+# ---------------------------------------------------------------------------
+
+
+def test_parquet_metadata_sentinel(tmp_path, writer: ParquetFeatureCacheWriter) -> None:
+    """detect_cache_format returns None when only per_frame.parquet exists (no metadata.json).
+
+    This simulates a crash between the Parquet write and the metadata.json write,
+    ensuring the incomplete cache is safely ignored.
+    """
+    identity_dir = tmp_path / "identity_0"
+    identity_dir.mkdir()
+    # Simulate an incomplete write: per_frame.parquet present, metadata.json absent.
+    (identity_dir / "per_frame.parquet").touch()
+
+    assert detect_cache_format(identity_dir) is None
+
+
+# ---------------------------------------------------------------------------
+# Validation mismatch tests
+# ---------------------------------------------------------------------------
+
+
+def test_parquet_version_mismatch_feature(tmp_path, writer: ParquetFeatureCacheWriter) -> None:
+    """FeatureVersionException raised when stored feature_version differs from expected."""
+    rng = np.random.default_rng(3)
+    identity_dir = tmp_path / "identity_0"
+    writer.write_per_frame(identity_dir, _metadata(), _per_frame_data(rng))
+
+    bad_reader = ParquetFeatureCacheReader(_FEATURE_VERSION + 1, _POSE_HASH, _DISTANCE_SCALE)
+    with pytest.raises(FeatureVersionException):
+        bad_reader.read_per_frame(identity_dir)
+
+
+def test_parquet_version_mismatch_format(
+    tmp_path, writer: ParquetFeatureCacheWriter, reader: ParquetFeatureCacheReader
+) -> None:
+    """FeatureVersionException raised when stored format_version differs from PARQUET_FORMAT_VERSION."""
+    rng = np.random.default_rng(4)
+    identity_dir = tmp_path / "identity_0"
+    writer.write_per_frame(identity_dir, _metadata(), _per_frame_data(rng))
+
+    # Overwrite metadata.json with a wrong format_version.
+    metadata_path = identity_dir / "metadata.json"
+    raw = json.loads(metadata_path.read_text())
+    raw["format_version"] = PARQUET_FORMAT_VERSION + 99
+    metadata_path.write_text(json.dumps(raw))
+
+    with pytest.raises(FeatureVersionException):
+        reader.read_per_frame(identity_dir)
+
+
+def test_parquet_pose_hash_mismatch(tmp_path, writer: ParquetFeatureCacheWriter) -> None:
+    """PoseHashException raised when stored pose_hash differs from expected."""
+    rng = np.random.default_rng(5)
+    identity_dir = tmp_path / "identity_0"
+    writer.write_per_frame(identity_dir, _metadata(), _per_frame_data(rng))
+
+    bad_reader = ParquetFeatureCacheReader(_FEATURE_VERSION, "wronghash", _DISTANCE_SCALE)
+    with pytest.raises(PoseHashException):
+        bad_reader.read_per_frame(identity_dir)
+
+
+def test_parquet_distance_scale_mismatch(tmp_path, writer: ParquetFeatureCacheWriter) -> None:
+    """DistanceScaleException raised when stored distance_scale_factor differs from expected."""
+    rng = np.random.default_rng(6)
+    identity_dir = tmp_path / "identity_0"
+    writer.write_per_frame(identity_dir, _metadata(), _per_frame_data(rng))
+
+    bad_reader = ParquetFeatureCacheReader(_FEATURE_VERSION, _POSE_HASH, 0.25)
+    with pytest.raises(DistanceScaleException):
+        bad_reader.read_per_frame(identity_dir)
+
+
+def test_parquet_window_size_not_cached(
+    tmp_path, writer: ParquetFeatureCacheWriter, reader: ParquetFeatureCacheReader
+) -> None:
+    """AttributeError raised when the requested window size was never written."""
+    rng = np.random.default_rng(7)
+    identity_dir = tmp_path / "identity_0"
+    writer.write_per_frame(identity_dir, _metadata(), _per_frame_data(rng))
+
+    with pytest.raises(AttributeError):
+        reader.read_window(identity_dir, window_size=99)
+
+
+# ---------------------------------------------------------------------------
+# Error recovery tests
+# ---------------------------------------------------------------------------
+
+
+def test_parquet_partial_loss_per_frame(
+    tmp_path, writer: ParquetFeatureCacheWriter, reader: ParquetFeatureCacheReader
+) -> None:
+    """OSError raised when per_frame.parquet is missing; all cache files are deleted."""
+    rng = np.random.default_rng(8)
+    identity_dir = tmp_path / "identity_0"
+    writer.write_per_frame(identity_dir, _metadata(), _per_frame_data(rng))
+    writer.write_window(
+        identity_dir,
+        _metadata(),
+        5,
+        {f"mod op f_{i}": rng.standard_normal(_N_FRAMES) for i in range(3)},
+    )
+
+    (identity_dir / "per_frame.parquet").unlink()
+
+    with pytest.raises(OSError):
+        reader.read_per_frame(identity_dir)
+
+    # All cache files must be deleted so detect_cache_format returns None.
+    assert not (identity_dir / "metadata.json").exists()
+    assert not any(identity_dir.glob("*.parquet"))
+
+
+def test_parquet_partial_loss_window(
+    tmp_path, writer: ParquetFeatureCacheWriter, reader: ParquetFeatureCacheReader
+) -> None:
+    """AttributeError raised when a window file is missing; only that size is removed from metadata."""
+    rng = np.random.default_rng(9)
+    identity_dir = tmp_path / "identity_0"
+    writer.write_per_frame(identity_dir, _metadata(), _per_frame_data(rng))
+    writer.write_window(
+        identity_dir,
+        _metadata(),
+        5,
+        {f"mod op f_{i}": rng.standard_normal(_N_FRAMES) for i in range(3)},
+    )
+    writer.write_window(
+        identity_dir,
+        _metadata(),
+        10,
+        {f"mod op f_{i}": rng.standard_normal(_N_FRAMES) for i in range(3)},
+    )
+
+    (identity_dir / "window_5.parquet").unlink()
+
+    with pytest.raises(AttributeError):
+        reader.read_window(identity_dir, 5)
+
+    # Only size 5 must be removed; size 10 must remain.
+    metadata = reader.read_metadata(identity_dir)
+    assert 5 not in metadata.cached_window_sizes
+    assert 10 in metadata.cached_window_sizes
+
+
+# ---------------------------------------------------------------------------
+# Auxiliary field tests
+# ---------------------------------------------------------------------------
+
+
+def test_parquet_auxiliary_optional_absent(
+    tmp_path, writer: ParquetFeatureCacheWriter, reader: ParquetFeatureCacheReader
+) -> None:
+    """Reads correctly when no social or landmark auxiliary fields are present."""
+    rng = np.random.default_rng(10)
+    identity_dir = tmp_path / "identity_0"
+    writer.write_per_frame(identity_dir, _metadata(), _per_frame_data(rng, with_aux=False))
+    result = reader.read_per_frame(identity_dir)
+
+    assert result.closest_identities is None
+    assert result.closest_fov_identities is None
+    assert result.closest_corners is None
+    assert result.closest_lixit is None
+    assert result.wall_distances == {}
+
+
+def test_parquet_auxiliary_present(
+    tmp_path, writer: ParquetFeatureCacheWriter, reader: ParquetFeatureCacheReader
+) -> None:
+    """All optional auxiliary arrays round-trip correctly."""
+    rng = np.random.default_rng(11)
+    identity_dir = tmp_path / "identity_0"
+    data = _per_frame_data(rng, with_aux=True)
+    meta = _metadata(avg_wall_length=42.5)
+    writer.write_per_frame(identity_dir, meta, data)
+    result = reader.read_per_frame(identity_dir)
+
+    np.testing.assert_array_equal(result.closest_identities, data.closest_identities)
+    np.testing.assert_array_equal(result.closest_fov_identities, data.closest_fov_identities)
+    np.testing.assert_array_almost_equal(result.closest_corners, data.closest_corners)
+    np.testing.assert_array_almost_equal(result.closest_lixit, data.closest_lixit)
+    assert set(result.wall_distances) == set(data.wall_distances)
+    for direction in data.wall_distances:
+        np.testing.assert_array_almost_equal(
+            result.wall_distances[direction],
+            data.wall_distances[direction],
+            err_msg=direction,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Compression test
+# ---------------------------------------------------------------------------
+
+
+def test_parquet_lz4_compression(tmp_path, writer: ParquetFeatureCacheWriter) -> None:
+    """per_frame.parquet and window Parquet files must use LZ4 compression."""
+    rng = np.random.default_rng(12)
+    identity_dir = tmp_path / "identity_0"
+    window_data = {f"mod op feat_{i}": rng.standard_normal(_N_FRAMES) for i in range(3)}
+
+    writer.write_per_frame(identity_dir, _metadata(), _per_frame_data(rng))
+    writer.write_window(identity_dir, _metadata(), 5, window_data)
+
+    for parquet_path in [identity_dir / "per_frame.parquet", identity_dir / "window_5.parquet"]:
+        file_metadata = pq.read_metadata(parquet_path)
+        for rg_idx in range(file_metadata.num_row_groups):
+            row_group = file_metadata.row_group(rg_idx)
+            for col_idx in range(row_group.num_columns):
+                compression = row_group.column(col_idx).compression
+                assert compression.lower() == "lz4", (
+                    f"{parquet_path.name} column {col_idx} uses {compression!r}, expected LZ4"
+                )

--- a/src/jabs/feature_extraction/features.py
+++ b/src/jabs/feature_extraction/features.py
@@ -9,7 +9,7 @@ import jabs.project.track_labels
 from jabs.core.enums import CacheFormat
 from jabs.core.exceptions import DistanceScaleException, FeatureVersionException
 from jabs.core.types import FeatureCacheMetadata, PerFrameCacheData
-from jabs.io.feature_cache import detect_cache_format
+from jabs.io.feature_cache import clear_cache, detect_cache_format
 from jabs.io.feature_cache.base import FeatureCacheReader, FeatureCacheWriter
 from jabs.io.feature_cache.hdf5 import HDF5FeatureCacheReader, HDF5FeatureCacheWriter
 from jabs.io.feature_cache.parquet import ParquetFeatureCacheReader, ParquetFeatureCacheWriter
@@ -161,6 +161,26 @@ class IdentityFeatures:
         detected: CacheFormat | None = None
         if self._identity_feature_dir is not None:
             detected = detect_cache_format(self._identity_feature_dir)
+
+        # When force=True and the on-disk format differs from the requested
+        # cache_format, remove the old sentinel and data files before writing.
+        # Without this, the old sentinel (e.g. metadata.json from a Parquet
+        # cache) would remain after writing features.h5, causing subsequent
+        # force=False runs to read the stale cache instead of the new one.
+        if (
+            force
+            and detected is not None
+            and detected != cache_format
+            and self._identity_feature_dir is not None
+        ):
+            logger.info(
+                "Clearing stale %s cache for identity %d (switching to %s)",
+                detected.value,
+                self._identity,
+                cache_format.value,
+            )
+            clear_cache(self._identity_feature_dir)
+            detected = None
 
         write_format = detected if (not force and detected is not None) else cache_format
 

--- a/src/jabs/feature_extraction/features.py
+++ b/src/jabs/feature_extraction/features.py
@@ -162,18 +162,8 @@ class IdentityFeatures:
         self._reader: FeatureCacheReader | None = None
         if self._identity_feature_dir is not None:
             detected = detect_cache_format(self._identity_feature_dir)
-            if detected == CacheFormat.PARQUET:
-                self._reader = ParquetFeatureCacheReader(
-                    FEATURE_VERSION,
-                    self._pose_hash,
-                    self._distance_scale_factor,
-                )
-            elif detected == CacheFormat.HDF5:
-                self._reader = HDF5FeatureCacheReader(
-                    FEATURE_VERSION,
-                    self._pose_hash,
-                    self._distance_scale_factor,
-                )
+            if detected is not None:
+                self._reader = self.__make_reader(detected)
 
         # load or compute remaining per frame features
         if force or self._identity_feature_dir is None or self._reader is None:
@@ -205,18 +195,28 @@ class IdentityFeatures:
         # so that subsequent get_window_features() calls within this instance can
         # load from cache instead of always falling through to recompute.
         if self._reader is None and self._identity_feature_dir is not None:
-            if cache_format == CacheFormat.PARQUET:
-                self._reader = ParquetFeatureCacheReader(
-                    FEATURE_VERSION,
-                    self._pose_hash,
-                    self._distance_scale_factor,
-                )
-            else:
-                self._reader = HDF5FeatureCacheReader(
-                    FEATURE_VERSION,
-                    self._pose_hash,
-                    self._distance_scale_factor,
-                )
+            self._reader = self.__make_reader(cache_format)
+
+    def __make_reader(self, fmt: CacheFormat) -> FeatureCacheReader:
+        """Instantiate a cache reader for the given format using this instance's validation params.
+
+        Args:
+            fmt: The cache format to read.
+
+        Returns:
+            A configured ``FeatureCacheReader`` for ``fmt``.
+        """
+        if fmt == CacheFormat.PARQUET:
+            return ParquetFeatureCacheReader(
+                FEATURE_VERSION,
+                self._pose_hash,
+                self._distance_scale_factor,
+            )
+        return HDF5FeatureCacheReader(
+            FEATURE_VERSION,
+            self._pose_hash,
+            self._distance_scale_factor,
+        )
 
     def __initialize_from_pose_estimation(self, pose_est: PoseEstimation):
         """Initialize from a PoseEstimation object and save them in an h5 file

--- a/src/jabs/feature_extraction/features.py
+++ b/src/jabs/feature_extraction/features.py
@@ -200,6 +200,24 @@ class IdentityFeatures:
                 )
                 self.__initialize_from_pose_estimation(pose_est)
 
+        # If _reader is still None after the load/compute step, per-frame features
+        # were just written to disk for the first time.  Initialize the reader now
+        # so that subsequent get_window_features() calls within this instance can
+        # load from cache instead of always falling through to recompute.
+        if self._reader is None and self._identity_feature_dir is not None:
+            if cache_format == CacheFormat.PARQUET:
+                self._reader = ParquetFeatureCacheReader(
+                    FEATURE_VERSION,
+                    self._pose_hash,
+                    self._distance_scale_factor,
+                )
+            else:
+                self._reader = HDF5FeatureCacheReader(
+                    FEATURE_VERSION,
+                    self._pose_hash,
+                    self._distance_scale_factor,
+                )
+
     def __initialize_from_pose_estimation(self, pose_est: PoseEstimation):
         """Initialize from a PoseEstimation object and save them in an h5 file
 

--- a/src/jabs/feature_extraction/features.py
+++ b/src/jabs/feature_extraction/features.py
@@ -6,9 +6,13 @@ import numpy as np
 import numpy.typing as npt
 
 import jabs.project.track_labels
+from jabs.core.enums import CacheFormat
 from jabs.core.exceptions import DistanceScaleException, FeatureVersionException
 from jabs.core.types import FeatureCacheMetadata, PerFrameCacheData
+from jabs.io.feature_cache import detect_cache_format
+from jabs.io.feature_cache.base import FeatureCacheReader, FeatureCacheWriter
 from jabs.io.feature_cache.hdf5 import HDF5FeatureCacheReader, HDF5FeatureCacheWriter
+from jabs.io.feature_cache.parquet import ParquetFeatureCacheReader, ParquetFeatureCacheWriter
 from jabs.pose_estimation import PoseEstimation, PoseEstimationV6, PoseHashException
 
 from .base_features import BaseFeatureGroup
@@ -92,6 +96,7 @@ class IdentityFeatures:
         fps: int = 30,
         op_settings: dict | None = None,
         cache_window: bool = True,
+        cache_format: CacheFormat = CacheFormat.HDF5,
     ) -> None:
         self._pose_version = pose_est.format_major_version
         self._num_frames = pose_est.num_frames
@@ -147,19 +152,35 @@ class IdentityFeatures:
             }
         }
 
-        self._reader = HDF5FeatureCacheReader(
-            FEATURE_VERSION,
-            self._pose_hash,
-            self._distance_scale_factor,
-        )
-        self._writer = HDF5FeatureCacheWriter()
+        # Select writer based on cache_format; reader is auto-detected from disk.
+        self._writer: FeatureCacheWriter
+        if cache_format == CacheFormat.PARQUET:
+            self._writer = ParquetFeatureCacheWriter()
+        else:
+            self._writer = HDF5FeatureCacheWriter()
+
+        self._reader: FeatureCacheReader | None = None
+        if self._identity_feature_dir is not None:
+            detected = detect_cache_format(self._identity_feature_dir)
+            if detected == CacheFormat.PARQUET:
+                self._reader = ParquetFeatureCacheReader(
+                    FEATURE_VERSION,
+                    self._pose_hash,
+                    self._distance_scale_factor,
+                )
+            elif detected == CacheFormat.HDF5:
+                self._reader = HDF5FeatureCacheReader(
+                    FEATURE_VERSION,
+                    self._pose_hash,
+                    self._distance_scale_factor,
+                )
 
         # load or compute remaining per frame features
-        if force or self._identity_feature_dir is None:
+        if force or self._identity_feature_dir is None or self._reader is None:
             self.__initialize_from_pose_estimation(pose_est)
         else:
             try:
-                # try to load from a h5 file if it exists
+                # try to load from cache if it exists
                 self.__load_from_file()
                 logger.debug(
                     "Loaded per-frame features from cache for identity %d", self._identity

--- a/src/jabs/feature_extraction/features.py
+++ b/src/jabs/feature_extraction/features.py
@@ -235,17 +235,21 @@ class IdentityFeatures:
         Returns:
             A configured ``FeatureCacheReader`` for ``fmt``.
         """
-        if fmt == CacheFormat.PARQUET:
-            return ParquetFeatureCacheReader(
-                FEATURE_VERSION,
-                self._pose_hash,
-                self._distance_scale_factor,
-            )
-        return HDF5FeatureCacheReader(
-            FEATURE_VERSION,
-            self._pose_hash,
-            self._distance_scale_factor,
-        )
+        match fmt:
+            case CacheFormat.PARQUET:
+                return ParquetFeatureCacheReader(
+                    FEATURE_VERSION,
+                    self._pose_hash,
+                    self._distance_scale_factor,
+                )
+            case CacheFormat.HDF5:
+                return HDF5FeatureCacheReader(
+                    FEATURE_VERSION,
+                    self._pose_hash,
+                    self._distance_scale_factor,
+                )
+            case _:
+                raise NotImplementedError(f"Unsupported cache format: {fmt}")
 
     def __initialize_from_pose_estimation(self, pose_est: PoseEstimation):
         """Initialize from a PoseEstimation object and save them in an h5 file

--- a/src/jabs/feature_extraction/features.py
+++ b/src/jabs/feature_extraction/features.py
@@ -152,18 +152,27 @@ class IdentityFeatures:
             }
         }
 
-        # Select writer based on cache_format; reader is auto-detected from disk.
+        # Detect the on-disk format so that reader and writer always agree.
+        # When an existing cache is found and force=False, use its format for
+        # writing too — mixing formats within one identity directory causes
+        # write_window() to fail (e.g. Parquet writer requires metadata.json,
+        # HDF5 writer requires features.h5).  When force=True or no cache
+        # exists yet, use the caller-supplied cache_format.
+        detected: CacheFormat | None = None
+        if self._identity_feature_dir is not None:
+            detected = detect_cache_format(self._identity_feature_dir)
+
+        write_format = detected if (not force and detected is not None) else cache_format
+
         self._writer: FeatureCacheWriter
-        if cache_format == CacheFormat.PARQUET:
+        if write_format == CacheFormat.PARQUET:
             self._writer = ParquetFeatureCacheWriter()
         else:
             self._writer = HDF5FeatureCacheWriter()
 
         self._reader: FeatureCacheReader | None = None
-        if self._identity_feature_dir is not None:
-            detected = detect_cache_format(self._identity_feature_dir)
-            if detected is not None:
-                self._reader = self.__make_reader(detected)
+        if not force and detected is not None:
+            self._reader = self.__make_reader(detected)
 
         # load or compute remaining per frame features
         if force or self._identity_feature_dir is None or self._reader is None:
@@ -195,7 +204,7 @@ class IdentityFeatures:
         # so that subsequent get_window_features() calls within this instance can
         # load from cache instead of always falling through to recompute.
         if self._reader is None and self._identity_feature_dir is not None:
-            self._reader = self.__make_reader(cache_format)
+            self._reader = self.__make_reader(write_format)
 
     def __make_reader(self, fmt: CacheFormat) -> FeatureCacheReader:
         """Instantiate a cache reader for the given format using this instance's validation params.

--- a/tests/feature_extraction/test_identity_features.py
+++ b/tests/feature_extraction/test_identity_features.py
@@ -160,3 +160,30 @@ def test_window_cache_readable_after_first_compute(tmp_path, pose_est_v5) -> Non
     assert set(first_flat) == set(second_flat)
     for key in first_flat:
         np.testing.assert_array_equal(second_flat[key], first_flat[key], err_msg=key)
+
+
+def test_force_with_format_change_removes_stale_sentinel(tmp_path, pose_est_v5) -> None:
+    """force=True with a different cache_format removes the old sentinel before writing.
+
+    Regression test: when an existing Parquet cache (metadata.json) was present
+    and force=True + cache_format=HDF5 wrote a new features.h5, the stale
+    metadata.json remained. Subsequent force=False runs would find metadata.json
+    first and read the stale Parquet cache instead of the freshly written HDF5 one.
+    """
+    # Write an initial Parquet cache.
+    _make_identity_features(pose_est_v5, tmp_path, force=True, cache_format=CacheFormat.PARQUET)
+    identity_dir = tmp_path / Path(_SOURCE_FILE).stem / str(_IDENTITY)
+    assert (identity_dir / "metadata.json").exists()
+
+    # Force-recompute into HDF5 format.
+    _make_identity_features(pose_est_v5, tmp_path, force=True, cache_format=CacheFormat.HDF5)
+
+    # The stale Parquet sentinel must be gone; only the HDF5 file should remain.
+    assert not (identity_dir / "metadata.json").exists()
+    assert not any(identity_dir.glob("*.parquet"))
+    assert (identity_dir / "features.h5").exists()
+
+    # A subsequent force=False run must read the HDF5 cache, not a stale Parquet one.
+    from jabs.io.feature_cache import detect_cache_format
+
+    assert detect_cache_format(identity_dir) == CacheFormat.HDF5

--- a/tests/feature_extraction/test_identity_features.py
+++ b/tests/feature_extraction/test_identity_features.py
@@ -146,6 +146,11 @@ def test_window_cache_readable_after_first_compute(tmp_path, pose_est_v5) -> Non
     # First call with no existing cache — writes per-frame cache and initializes reader.
     instance = _make_identity_features(pose_est_v5, tmp_path, force=False)
 
+    # The regression: _reader was left None after the first compute.  The fix
+    # initializes it inside __init__ so this assertion catches a regression before
+    # get_window_features is even called.
+    assert instance._reader is not None, "_reader must be set after first compute"
+
     # First get_window_features call: computes and writes window cache.
     first = instance.get_window_features(_WINDOW_SIZE)
 

--- a/tests/feature_extraction/test_identity_features.py
+++ b/tests/feature_extraction/test_identity_features.py
@@ -1,0 +1,136 @@
+"""Tests for IdentityFeatures auto-detection and Parquet cache round-trip."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import jabs.pose_estimation as pose_est_module
+from jabs.core.enums import CacheFormat
+from jabs.feature_extraction.features import IdentityFeatures
+from jabs.io.feature_cache import detect_cache_format
+
+_SAMPLE_POSE_V5 = Path(__file__).parent.parent / "data" / "sample_pose_est_v5.h5"
+
+_SOURCE_FILE = "sample_pose_est_v5.h5"
+_IDENTITY = 0
+_WINDOW_SIZE = 5
+
+
+@pytest.fixture(scope="module")
+def pose_est_v5():
+    """Load the sample v5 pose estimation from a temporary copy.
+
+    Yields:
+        PoseEstimationV5: Pose estimation object backed by a temporary file.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        pose_path = Path(tmpdir) / _SAMPLE_POSE_V5.name
+        shutil.copy(_SAMPLE_POSE_V5, pose_path)
+        yield pose_est_module.open_pose_file(pose_path)
+
+
+def _make_identity_features(
+    pose_est,
+    directory,
+    *,
+    force: bool,
+    cache_format: CacheFormat = CacheFormat.HDF5,
+) -> IdentityFeatures:
+    """Construct an IdentityFeatures instance with consistent settings."""
+    return IdentityFeatures(
+        source_file=_SOURCE_FILE,
+        identity=_IDENTITY,
+        directory=directory,
+        pose_est=pose_est,
+        force=force,
+        op_settings={},
+        cache_format=cache_format,
+    )
+
+
+# ---------------------------------------------------------------------------
+# detect_cache_format tests
+# ---------------------------------------------------------------------------
+
+
+def test_autodetect_parquet(tmp_path) -> None:
+    """detect_cache_format returns PARQUET when metadata.json is present."""
+    identity_dir = tmp_path / "identity_0"
+    identity_dir.mkdir()
+    (identity_dir / "metadata.json").touch()
+
+    assert detect_cache_format(identity_dir) == CacheFormat.PARQUET
+
+
+def test_autodetect_hdf5(tmp_path) -> None:
+    """detect_cache_format returns HDF5 when features.h5 is present and metadata.json is absent."""
+    identity_dir = tmp_path / "identity_0"
+    identity_dir.mkdir()
+    (identity_dir / "features.h5").touch()
+
+    assert detect_cache_format(identity_dir) == CacheFormat.HDF5
+
+
+def test_autodetect_none(tmp_path) -> None:
+    """detect_cache_format returns None when neither sentinel file is present."""
+    identity_dir = tmp_path / "identity_0"
+    identity_dir.mkdir()
+
+    assert detect_cache_format(identity_dir) is None
+
+
+def test_autodetect_parquet_takes_priority(tmp_path) -> None:
+    """detect_cache_format returns PARQUET when both metadata.json and features.h5 are present."""
+    identity_dir = tmp_path / "identity_0"
+    identity_dir.mkdir()
+    (identity_dir / "metadata.json").touch()
+    (identity_dir / "features.h5").touch()
+
+    assert detect_cache_format(identity_dir) == CacheFormat.PARQUET
+
+
+# ---------------------------------------------------------------------------
+# Parquet round-trip integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_identity_features_parquet_round_trip(tmp_path, pose_est_v5) -> None:
+    """Per-frame features loaded from a Parquet cache must equal freshly computed values."""
+    computed = _make_identity_features(
+        pose_est_v5, tmp_path, force=True, cache_format=CacheFormat.PARQUET
+    )
+    cached = _make_identity_features(
+        pose_est_v5, tmp_path, force=False, cache_format=CacheFormat.PARQUET
+    )
+
+    computed_flat = IdentityFeatures.merge_per_frame_features(computed.get_per_frame())
+    cached_flat = IdentityFeatures.merge_per_frame_features(cached.get_per_frame())
+
+    assert set(computed_flat) == set(cached_flat)
+    for key in computed_flat:
+        np.testing.assert_array_almost_equal(cached_flat[key], computed_flat[key], err_msg=key)
+
+
+def test_identity_features_parquet_window_round_trip(tmp_path, pose_est_v5) -> None:
+    """Window features loaded from a Parquet cache must equal freshly computed values."""
+    computed = _make_identity_features(
+        pose_est_v5, tmp_path, force=True, cache_format=CacheFormat.PARQUET
+    )
+    computed_window = computed.get_window_features(_WINDOW_SIZE, force=True)
+
+    cached = _make_identity_features(
+        pose_est_v5, tmp_path, force=False, cache_format=CacheFormat.PARQUET
+    )
+    cached_window = cached.get_window_features(_WINDOW_SIZE)
+
+    computed_flat = IdentityFeatures.merge_window_features(computed_window)
+    cached_flat = IdentityFeatures.merge_window_features(cached_window)
+
+    assert set(computed_flat) == set(cached_flat)
+    for key in computed_flat:
+        np.testing.assert_array_almost_equal(cached_flat[key], computed_flat[key], err_msg=key)

--- a/tests/feature_extraction/test_identity_features.py
+++ b/tests/feature_extraction/test_identity_features.py
@@ -134,3 +134,29 @@ def test_identity_features_parquet_window_round_trip(tmp_path, pose_est_v5) -> N
     assert set(computed_flat) == set(cached_flat)
     for key in computed_flat:
         np.testing.assert_array_almost_equal(cached_flat[key], computed_flat[key], err_msg=key)
+
+
+def test_window_cache_readable_after_first_compute(tmp_path, pose_est_v5) -> None:
+    """A single IdentityFeatures instance can load window features it just wrote.
+
+    Regression test: when no cache exists at construction time, _reader was left
+    as None after writing the per-frame cache, causing every get_window_features()
+    call on the same instance to recompute instead of loading from disk.
+    """
+    # First call with no existing cache — writes per-frame cache and initializes reader.
+    instance = _make_identity_features(pose_est_v5, tmp_path, force=False)
+
+    # First get_window_features call: computes and writes window cache.
+    first = instance.get_window_features(_WINDOW_SIZE)
+
+    # Second call on the same instance: should load from cache, not recompute.
+    # If _reader were still None this would silently recompute; results are
+    # identical either way, but the cache file must exist.
+    second = instance.get_window_features(_WINDOW_SIZE)
+
+    first_flat = IdentityFeatures.merge_window_features(first)
+    second_flat = IdentityFeatures.merge_window_features(second)
+
+    assert set(first_flat) == set(second_flat)
+    for key in first_flat:
+        np.testing.assert_array_equal(second_flat[key], first_flat[key], err_msg=key)


### PR DESCRIPTION
This pull request introduces support for using Parquet as an alternative storage format for feature caches, alongside the existing HDF5 format. It adds a new enum to represent cache formats, implements detection logic for existing cache formats on disk, and refactors feature extraction to support both formats. Additionally, comprehensive tests for the new Parquet feature cache backend are included.

This completes the second phase of the ADR-0001 implementation. The final phase will be integration into the GUI and cli apps.

**Support for multiple feature cache formats:**

* Added a new `CacheFormat` enum in `jabs.core.enums` to represent available feature cache storage formats (`HDF5` and `PARQUET`). 
* Implemented the `detect_cache_format` function in `jabs.io.feature_cache` to determine whether an identity's cache is stored as Parquet or HDF5 based on sentinel files.

**Feature extraction refactor:**

* Updated `FeatureExtractor` (in `features.py`) to accept a `cache_format` parameter, select the appropriate writer, and auto-detect the reader based on existing cache files.

**Testing and validation:**

* Added a comprehensive test suite for the Parquet feature cache backend, including round-trip, error handling, auxiliary field, and compression tests, in `test_parquet.py`.
