### PR TITLE
Implement ClassifierProtocol and refactor utility functions

### DIFF
--- a/packages/jabs-core/src/jabs/core/constants.py
+++ b/packages/jabs-core/src/jabs/core/constants.py
@@ -13,3 +13,7 @@ COMPRESSION_OPTS_DEFAULT = 6
 
 # settings keys for project settings stored in the project.json file
 CV_GROUPING_KEY = "cv_grouping"
+CLASSIFIER_MODE_KEY = "classifier_mode"
+
+# reserved behavior name used in multi-class mode to store explicit negative labels
+MULTICLASS_NONE_BEHAVIOR = "None"

--- a/packages/jabs-core/src/jabs/core/enums/__init__.py
+++ b/packages/jabs-core/src/jabs/core/enums/__init__.py
@@ -1,6 +1,7 @@
 """Module for defining enums used in JABS"""
 
 from .cache_format import CacheFormat
+from .classifier_mode import DEFAULT_CLASSIFIER_MODE, ClassifierMode
 from .classifier_types import ClassifierType
 from .cv_grouping import DEFAULT_CV_GROUPING_STRATEGY, CrossValidationGroupingStrategy
 from .inference import ConfidenceMetric, Method, SamplingStrategy
@@ -9,8 +10,10 @@ from .storage_format import StorageFormat
 from .units import ProjectDistanceUnit
 
 __all__ = [
+    "DEFAULT_CLASSIFIER_MODE",
     "DEFAULT_CV_GROUPING_STRATEGY",
     "CacheFormat",
+    "ClassifierMode",
     "ClassifierType",
     "ConfidenceMetric",
     "CrossValidationGroupingStrategy",

--- a/packages/jabs-core/src/jabs/core/enums/classifier_mode.py
+++ b/packages/jabs-core/src/jabs/core/enums/classifier_mode.py
@@ -1,0 +1,17 @@
+"""Module for classifier mode enum."""
+
+from enum import Enum
+
+
+class ClassifierMode(str, Enum):
+    """Classifier mode for the project.
+
+    Inheriting from str allows for easy serialization to/from JSON (the enum
+    will automatically be serialized using the enum value).
+    """
+
+    BINARY = "binary"
+    MULTICLASS = "multiclass"
+
+
+DEFAULT_CLASSIFIER_MODE = ClassifierMode.BINARY

--- a/src/jabs/classifier/__init__.py
+++ b/src/jabs/classifier/__init__.py
@@ -7,6 +7,7 @@ Gradient Boosting, and XGBoost), utilities for feature management, data splittin
 
 from .classifier import Classifier
 from .cross_validation import run_leave_one_group_out_cv
+from .protocols import ClassifierProtocol
 from .training_report import (
     CrossValidationResult,
     TrainingReportData,
@@ -16,6 +17,7 @@ from .training_report import (
 
 __all__ = [
     "Classifier",
+    "ClassifierProtocol",
     "CrossValidationResult",
     "TrainingReportData",
     "generate_markdown_report",

--- a/src/jabs/classifier/classifier.py
+++ b/src/jabs/classifier/classifier.py
@@ -1,6 +1,4 @@
 import logging
-import random
-import re
 import typing
 import warnings
 from pathlib import Path
@@ -9,12 +7,6 @@ import joblib
 import numpy as np
 import pandas as pd
 from sklearn.exceptions import InconsistentVersionWarning
-from sklearn.metrics import (
-    accuracy_score,
-    confusion_matrix,
-    precision_recall_fscore_support,
-)
-from sklearn.model_selection import LeaveOneGroupOut
 
 from jabs.core.enums import (
     DEFAULT_CV_GROUPING_STRATEGY,
@@ -24,6 +16,7 @@ from jabs.core.enums import (
 from jabs.core.utils import hash_file
 from jabs.project import Project, TrackLabels, load_training_data
 
+from . import classifier_utils
 from .factories import make_catboost, make_random_forest, make_xgboost
 
 _VERSION = 11
@@ -225,40 +218,13 @@ class Classifier:
             'feature_names': list of feature names
         }
         """
-        logo = LeaveOneGroupOut()
-        x = Classifier.combine_data(per_frame_features, window_features)
-        splits = list(logo.split(x, labels, groups))
-
-        # pick random split, make sure we pick a split where the test data
-        # has sufficient labels of both classes
-        random.shuffle(splits)
-        count = 0
-        for split in splits:
-            behavior_count = np.count_nonzero(labels[split[1]] == TrackLabels.Label.BEHAVIOR)
-            not_behavior_count = np.count_nonzero(
-                labels[split[1]] == TrackLabels.Label.NOT_BEHAVIOR
-            )
-
-            if (
-                behavior_count >= Classifier.LABEL_THRESHOLD
-                and not_behavior_count >= Classifier.LABEL_THRESHOLD
-            ):
-                count += 1
-                yield {
-                    "training_data": x.iloc[split[0]],
-                    "training_labels": labels[split[0]],
-                    "test_data": x.iloc[split[1]],
-                    "test_labels": labels[split[1]],
-                    "test_group": groups[split[1]][0],
-                    "feature_names": x.columns.to_list(),
-                }
-
-        # number of splits exhausted without finding at least one that meets
-        # criteria
-        # the UI won't allow us to reach this case
-        if count == 0:
-            raise ValueError("unable to split data")
-        # If there are no more splits to yield, just let generator end
+        yield from classifier_utils.leave_one_group_out(
+            per_frame_features,
+            window_features,
+            labels,
+            groups,
+            label_threshold=Classifier.LABEL_THRESHOLD,
+        )
 
     @staticmethod
     def downsample_balance(features, labels, random_seed=None):
@@ -272,18 +238,7 @@ class Classifier:
         Returns:
             tuple of downsampled features, labels
         """
-        label_states, label_counts = np.unique(labels, return_counts=True)
-        max_examples_per_class = np.min(label_counts)
-        selected_samples = []
-        for cur_label in label_states:
-            idxs = np.where(labels == cur_label)[0]
-            rng = np.random.default_rng(random_seed)
-            sampled_idxs = rng.choice(idxs, max_examples_per_class, replace=False)
-            selected_samples.append(sampled_idxs)
-        selected_samples = np.sort(np.concatenate(selected_samples))
-        features = features.iloc[selected_samples]
-        labels = labels[selected_samples]
-        return features, labels
+        return classifier_utils.downsample_balance(features, labels, random_seed)
 
     @staticmethod
     def augment_symmetric(features, labels, random_str="ASygRQDZJD"):
@@ -301,27 +256,7 @@ class Classifier:
         Returns:
             tuple of augmented features, labels
         """
-        # Figure out the L-R swapping of features
-        lowercase_features = np.array([x.lower() for x in features.columns.to_list()])
-        reflected_feature_names = [re.sub(r"left", random_str, x) for x in lowercase_features]
-        reflected_feature_names = [re.sub(r"right", "left", x) for x in reflected_feature_names]
-        reflected_feature_names = [re.sub(random_str, "right", x) for x in reflected_feature_names]
-        reflected_idxs = [
-            np.where(lowercase_features == x)[0][0] if x in lowercase_features else i
-            for i, x in enumerate(reflected_feature_names)
-        ]
-        # expand the features with reflections
-        features_duplicate = features.copy()
-        features_duplicate.columns = features.columns.to_numpy()[np.asarray(reflected_idxs)]
-        features = pd.concat([features, features_duplicate])
-        labels = np.concatenate([labels, labels])
-        # TODO: Add this as a test-case that these features are the complete list that should be swapped.
-        # They were manually checked with the full feature set
-        # print('Swapping the following features:')
-        # swapped_features = np.where(reflected_idxs!=np.arange(len(reflected_idxs)))[0]
-        # for idx in swapped_features:
-        #     print(str(lowercase_features[idx]) + ' -> ' + str(reflected_feature_names[idx]))
-        return features, labels
+        return classifier_utils.augment_symmetric(features, labels, random_str)
 
     def set_classifier(self, classifier: ClassifierType):
         """change the type of the classifier being used"""
@@ -536,17 +471,17 @@ class Classifier:
     @staticmethod
     def accuracy_score(truth, predictions):
         """return accuracy score"""
-        return accuracy_score(truth, predictions)
+        return classifier_utils.accuracy_score(truth, predictions)
 
     @staticmethod
     def precision_recall_score(truth, predictions):
         """return precision recall score"""
-        return precision_recall_fscore_support(truth, predictions)
+        return classifier_utils.precision_recall_score(truth, predictions)
 
     @staticmethod
     def confusion_matrix(truth, predictions):
         """return the confusion matrix using sklearn's confusion_matrix function"""
-        return confusion_matrix(truth, predictions)
+        return classifier_utils.confusion_matrix(truth, predictions)
 
     @staticmethod
     def combine_data(per_frame, window):
@@ -559,7 +494,7 @@ class Classifier:
         Returns:
             merged dataframe
         """
-        return pd.concat([per_frame, window], axis=1)
+        return classifier_utils.combine_data(per_frame, window)
 
     def get_feature_importance(self, limit=20) -> list[tuple[str, float]]:
         """get the most important features and their importance
@@ -700,15 +635,7 @@ class Classifier:
         Returns:
             Cleaned DataFrame with missing and infinite values handled.
         """
-        if self._classifier_type in (
-            ClassifierType.XGBOOST,
-            ClassifierType.CATBOOST,
-        ):
-            # these classifiers can handle NaN, just replace infinities
-            return features.replace([np.inf, -np.inf], np.nan)
-        else:
-            # Random forests can't handle NAs & infs, so fill them with 0s
-            return features.replace([np.inf, -np.inf], 0).fillna(0)
+        return classifier_utils.clean_features(features, self._classifier_type)
 
     @staticmethod
     def derive_predictions(probabilities: np.ndarray) -> tuple[np.ndarray, np.ndarray]:

--- a/src/jabs/classifier/classifier_utils.py
+++ b/src/jabs/classifier/classifier_utils.py
@@ -109,10 +109,10 @@ def downsample_balance(
     """
     label_states, label_counts = np.unique(labels, return_counts=True)
     max_examples_per_class = np.min(label_counts)
+    rng = np.random.default_rng(random_seed)
     selected_samples = []
     for cur_label in label_states:
         idxs = np.where(labels == cur_label)[0]
-        rng = np.random.default_rng(random_seed)
         sampled_idxs = rng.choice(idxs, max_examples_per_class, replace=False)
         selected_samples.append(sampled_idxs)
     selected_samples = np.sort(np.concatenate(selected_samples))

--- a/src/jabs/classifier/classifier_utils.py
+++ b/src/jabs/classifier/classifier_utils.py
@@ -131,8 +131,10 @@ def leave_one_group_out(
     """Implement the leave-one-group-out data splitting strategy.
 
     Splits are filtered so that the test set has at least `label_threshold`
-    samples for each class present in the test split. This ensures meaningful
-    evaluation regardless of the number of behavior classes.
+    samples for every class present in the full ``labels`` array. This ensures
+    all classes are represented in the test set, matching the original binary
+    behavior (both BEHAVIOR and NOT_BEHAVIOR must be above threshold) and
+    extending naturally to multi-class mode.
 
     Args:
         per_frame_features: Per-frame feature DataFrame for labeled data.
@@ -151,12 +153,12 @@ def leave_one_group_out(
     logo = LeaveOneGroupOut()
     x = combine_data(per_frame_features, window_features)
     splits = list(logo.split(x, labels, groups))
+    all_classes = np.unique(labels)
     random.shuffle(splits)
     count = 0
     for split in splits:
         test_labels = labels[split[1]]
-        unique_classes = np.unique(test_labels)
-        if all(np.count_nonzero(test_labels == cls) >= label_threshold for cls in unique_classes):
+        if all(np.count_nonzero(test_labels == cls) >= label_threshold for cls in all_classes):
             count += 1
             yield {
                 "training_data": x.iloc[split[0]],

--- a/src/jabs/classifier/classifier_utils.py
+++ b/src/jabs/classifier/classifier_utils.py
@@ -1,0 +1,213 @@
+"""Shared utilities for behavior classifier training and evaluation.
+
+These free functions are used by both binary and multi-class classifiers.
+"""
+
+import random
+import re
+from collections.abc import Generator
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+from sklearn.metrics import (
+    accuracy_score as _accuracy_score,
+)
+from sklearn.metrics import (
+    confusion_matrix as _confusion_matrix,
+)
+from sklearn.metrics import (
+    precision_recall_fscore_support,
+)
+from sklearn.model_selection import LeaveOneGroupOut
+
+from jabs.core.enums import ClassifierType
+
+LABEL_THRESHOLD: int = 20
+
+
+def clean_features(features: pd.DataFrame, classifier_type: ClassifierType) -> pd.DataFrame:
+    """Clean features for prediction, handling missing and infinite values.
+
+    Args:
+        features: DataFrame of feature data to clean.
+        classifier_type: Type of classifier being used.
+
+    Returns:
+        Cleaned DataFrame with missing and infinite values handled.
+    """
+    if classifier_type in (ClassifierType.XGBOOST, ClassifierType.CATBOOST):
+        # these classifiers can handle NaN, just replace infinities
+        return features.replace([np.inf, -np.inf], np.nan)
+    else:
+        # Random forests can't handle NAs & infs, so fill them with 0s
+        return features.replace([np.inf, -np.inf], 0).fillna(0)
+
+
+def combine_data(per_frame: pd.DataFrame, window: pd.DataFrame) -> pd.DataFrame:
+    """Combine per-frame and window feature DataFrames.
+
+    Args:
+        per_frame: Per-frame features DataFrame.
+        window: Window features DataFrame.
+
+    Returns:
+        Merged DataFrame with all features concatenated column-wise.
+    """
+    return pd.concat([per_frame, window], axis=1)
+
+
+def augment_symmetric(
+    features: pd.DataFrame,
+    labels: npt.NDArray,
+    random_str: str = "ASygRQDZJD",
+) -> tuple[pd.DataFrame, npt.NDArray]:
+    """Augment features to include L-R and R-L reflection duplicates.
+
+    Features with 'left' or 'right' in their name will have those terms
+    swapped to produce mirror-image augmented samples. Features without
+    these terms are duplicated unchanged.
+
+    Args:
+        features: Feature DataFrame to augment.
+        labels: Label array corresponding to features.
+        random_str: Temporary replacement string used when swapping left/right.
+
+    Returns:
+        Tuple of (augmented features DataFrame, augmented label array),
+        each twice the length of the inputs.
+    """
+    lowercase_features = np.array([x.lower() for x in features.columns.to_list()])
+    reflected_feature_names = [re.sub(r"left", random_str, x) for x in lowercase_features]
+    reflected_feature_names = [re.sub(r"right", "left", x) for x in reflected_feature_names]
+    reflected_feature_names = [re.sub(random_str, "right", x) for x in reflected_feature_names]
+    reflected_idxs = [
+        np.where(lowercase_features == x)[0][0] if x in lowercase_features else i
+        for i, x in enumerate(reflected_feature_names)
+    ]
+    features_duplicate = features.copy()
+    features_duplicate.columns = features.columns.to_numpy()[np.asarray(reflected_idxs)]
+    features = pd.concat([features, features_duplicate])
+    labels = np.concatenate([labels, labels])
+    return features, labels
+
+
+def downsample_balance(
+    features: pd.DataFrame,
+    labels: npt.NDArray,
+    random_seed: int | None = None,
+) -> tuple[pd.DataFrame, npt.NDArray]:
+    """Downsample features and labels so that all classes are equally represented.
+
+    Args:
+        features: Feature DataFrame to downsample.
+        labels: Label array to downsample.
+        random_seed: Optional random seed for reproducibility.
+
+    Returns:
+        Tuple of (downsampled features DataFrame, downsampled label array).
+    """
+    label_states, label_counts = np.unique(labels, return_counts=True)
+    max_examples_per_class = np.min(label_counts)
+    selected_samples = []
+    for cur_label in label_states:
+        idxs = np.where(labels == cur_label)[0]
+        rng = np.random.default_rng(random_seed)
+        sampled_idxs = rng.choice(idxs, max_examples_per_class, replace=False)
+        selected_samples.append(sampled_idxs)
+    selected_samples = np.sort(np.concatenate(selected_samples))
+    features = features.iloc[selected_samples]
+    labels = labels[selected_samples]
+    return features, labels
+
+
+def leave_one_group_out(
+    per_frame_features: pd.DataFrame,
+    window_features: pd.DataFrame,
+    labels: npt.NDArray,
+    groups: npt.NDArray,
+    label_threshold: int = LABEL_THRESHOLD,
+) -> Generator[dict, None, None]:
+    """Implement the leave-one-group-out data splitting strategy.
+
+    Splits are filtered so that the test set has at least `label_threshold`
+    samples for each class present in the test split. This ensures meaningful
+    evaluation regardless of the number of behavior classes.
+
+    Args:
+        per_frame_features: Per-frame feature DataFrame for labeled data.
+        window_features: Window feature DataFrame for labeled data.
+        labels: Label array corresponding to each feature row.
+        groups: Group ID array corresponding to each feature row.
+        label_threshold: Minimum number of samples per class in the test split.
+
+    Yields:
+        Dictionary with keys: training_data, training_labels, test_data,
+        test_labels, test_group, feature_names.
+
+    Raises:
+        ValueError: If no valid split satisfying the threshold can be found.
+    """
+    logo = LeaveOneGroupOut()
+    x = combine_data(per_frame_features, window_features)
+    splits = list(logo.split(x, labels, groups))
+    random.shuffle(splits)
+    count = 0
+    for split in splits:
+        test_labels = labels[split[1]]
+        unique_classes = np.unique(test_labels)
+        if all(np.count_nonzero(test_labels == cls) >= label_threshold for cls in unique_classes):
+            count += 1
+            yield {
+                "training_data": x.iloc[split[0]],
+                "training_labels": labels[split[0]],
+                "test_data": x.iloc[split[1]],
+                "test_labels": labels[split[1]],
+                "test_group": groups[split[1]][0],
+                "feature_names": x.columns.to_list(),
+            }
+    if count == 0:
+        raise ValueError("unable to split data")
+
+
+def accuracy_score(truth: npt.NDArray, predictions: npt.NDArray) -> float:
+    """Compute classification accuracy.
+
+    Args:
+        truth: Ground-truth label array.
+        predictions: Predicted label array.
+
+    Returns:
+        Accuracy as a float in [0, 1].
+    """
+    return _accuracy_score(truth, predictions)
+
+
+def precision_recall_score(
+    truth: npt.NDArray,
+    predictions: npt.NDArray,
+) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray]:
+    """Compute precision, recall, F-score, and support for each class.
+
+    Args:
+        truth: Ground-truth label array.
+        predictions: Predicted label array.
+
+    Returns:
+        Tuple of (precision, recall, f-score, support) arrays as returned
+        by sklearn's precision_recall_fscore_support.
+    """
+    return precision_recall_fscore_support(truth, predictions)
+
+
+def confusion_matrix(truth: npt.NDArray, predictions: npt.NDArray) -> npt.NDArray:
+    """Compute the confusion matrix.
+
+    Args:
+        truth: Ground-truth label array.
+        predictions: Predicted label array.
+
+    Returns:
+        Confusion matrix as a 2D integer array.
+    """
+    return _confusion_matrix(truth, predictions)

--- a/src/jabs/classifier/protocols.py
+++ b/src/jabs/classifier/protocols.py
@@ -1,0 +1,82 @@
+"""Protocol definitions for JABS classifiers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+
+
+class ClassifierProtocol(Protocol):
+    """Protocol defining the shared interface for JABS classifiers.
+
+    Both binary and multi-class classifiers implement this interface,
+    allowing consumers to type-hint against either classifier type without
+    isinstance checks.
+    """
+
+    @property
+    def feature_names(self) -> list[str] | None:
+        """Return the list of feature names used during training."""
+        ...
+
+    def train(self, data: dict, random_seed: int | None = None) -> None:
+        """Train the classifier on labeled data.
+
+        Args:
+            data: Dictionary containing training_data, training_labels,
+                and optionally feature_names.
+            random_seed: Optional random seed for reproducibility.
+        """
+        ...
+
+    def predict(
+        self,
+        features: pd.DataFrame,
+        frame_indexes: npt.NDArray[np.intp] | None = None,
+    ) -> npt.NDArray:
+        """Predict class labels for the given features.
+
+        Args:
+            features: DataFrame of feature data to classify.
+            frame_indexes: Optional frame indexes to restrict prediction to.
+
+        Returns:
+            Predicted class label array.
+        """
+        ...
+
+    def predict_proba(
+        self,
+        features: pd.DataFrame,
+        frame_indexes: npt.NDArray[np.intp] | None = None,
+    ) -> npt.NDArray:
+        """Predict class probabilities for the given features.
+
+        Args:
+            features: DataFrame of feature data to classify.
+            frame_indexes: Optional frame indexes to restrict prediction to.
+
+        Returns:
+            Predicted probability matrix.
+        """
+        ...
+
+    def save(self, path: Path) -> None:
+        """Serialize the classifier to disk.
+
+        Args:
+            path: Destination file path.
+        """
+        ...
+
+    def load(self, path: Path) -> None:
+        """Deserialize the classifier from disk, updating this instance.
+
+        Args:
+            path: Source file path.
+        """
+        ...


### PR DESCRIPTION
This is prep for future work to add a MultiClassClassifier complement to the current binary classifier implemented in Classifier.

- Introdues a ClassifierMode enum
- Adds ClassifierProtocol, which Classifier (and eventually MultiClassClassifier) implement
- Moves common utility functions from Classifier to a shared classifier_utils module replacing the Classifier methods with thin wrappers. MultiClassClassifier will utilize these shared utilities. 


AI-generated description follows:

This pull request introduces a new protocol interface for classifiers and refactors much of the classifier utility logic into a new shared module. It also adds support for a classifier mode enum (binary vs. multiclass) and updates project settings and constants accordingly. The main classifier implementation is simplified by delegating common operations to the new utilities module.

**Classifier architecture and protocol:**

* Added a new `ClassifierProtocol` in `src/jabs/classifier/protocols.py` to define a shared interface for both binary and multi-class classifiers, enabling consistent type hinting and usage.
* Exported `ClassifierProtocol` from `src/jabs/classifier/__init__.py` for external use. [[1]](diffhunk://#diff-18747ae371edd0a7462ff7b86d3f27f5491e11ee62bea948284634444312e409R10) [[2]](diffhunk://#diff-18747ae371edd0a7462ff7b86d3f27f5491e11ee62bea948284634444312e409R20)

**Classifier utilities refactoring:**

* Moved common functions (`leave_one_group_out`, `downsample_balance`, `augment_symmetric`, `combine_data`, `clean_features`, and metrics) from `src/jabs/classifier/classifier.py` into a new shared module `src/jabs/classifier/classifier_utils.py`, and updated all relevant calls to use this module. This greatly simplifies the main classifier code and improves code reuse. [[1]](diffhunk://#diff-fabaf95a3c7b5f89721a7e553771ee428ccec1240e497909dc726922180d3400R19) [[2]](diffhunk://#diff-fabaf95a3c7b5f89721a7e553771ee428ccec1240e497909dc726922180d3400L228-L262) [[3]](diffhunk://#diff-fabaf95a3c7b5f89721a7e553771ee428ccec1240e497909dc726922180d3400L275-R241) [[4]](diffhunk://#diff-fabaf95a3c7b5f89721a7e553771ee428ccec1240e497909dc726922180d3400L304-R259) [[5]](diffhunk://#diff-fabaf95a3c7b5f89721a7e553771ee428ccec1240e497909dc726922180d3400L539-R484) [[6]](diffhunk://#diff-fabaf95a3c7b5f89721a7e553771ee428ccec1240e497909dc726922180d3400L562-R497) [[7]](diffhunk://#diff-fabaf95a3c7b5f89721a7e553771ee428ccec1240e497909dc726922180d3400L703-R638) [[8]](diffhunk://#diff-da0d6ce3f8f0296654b353dbd6151f3c29e3d5e02db43e1261c498da1f5a0f8eR1-R213)

**Classifier mode and project settings:**

* Introduced a new `ClassifierMode` enum (with values `BINARY` and `MULTICLASS`) and `DEFAULT_CLASSIFIER_MODE` in `packages/jabs-core/src/jabs/core/enums/classifier_mode.py`, and updated the enum exports accordingly. [[1]](diffhunk://#diff-01b26dcb8d613cf5bbcc5274e0e5bebb5aae0fcef7ce42cb392b03e8291a27e4R1-R17) [[2]](diffhunk://#diff-121b03a2e92a01a1916fcf9fe35468bc322464d6e1b7ae743ebfd41b4fa7e46cR4) [[3]](diffhunk://#diff-121b03a2e92a01a1916fcf9fe35468bc322464d6e1b7ae743ebfd41b4fa7e46cR13-R16)
* Added new classifier mode-related constants to `packages/jabs-core/src/jabs/core/constants.py`, including the project settings key and a reserved behavior name for multiclass mode.