### PR TITLE
Add MultiClassClassifier implementation 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ cache invalidation logic (version mismatch, pose hash, distance scale).
 - `__init__.py` files: unused imports (F401) are allowed
 - **Naming**: `PascalCase` classes, `snake_case` functions/methods/files,
   `UPPER_SNAKE_CASE` constants, `_` prefix for private members
-- Prefer American English spelling (e.g., "behavior" not "behaviour").
+- Use American English spelling (e.g., "behavior" not "behaviour").
 - Prefer importing at the top of the module. It is acceptable to import within
   functions/methods if an expensive import is only needed in specific code paths.
 

--- a/src/jabs/classifier/__init__.py
+++ b/src/jabs/classifier/__init__.py
@@ -7,6 +7,7 @@ Gradient Boosting, and XGBoost), utilities for feature management, data splittin
 
 from .classifier import Classifier
 from .cross_validation import run_leave_one_group_out_cv
+from .multi_class_classifier import MultiClassClassifier
 from .protocols import ClassifierProtocol
 from .training_report import (
     CrossValidationResult,
@@ -19,6 +20,7 @@ __all__ = [
     "Classifier",
     "ClassifierProtocol",
     "CrossValidationResult",
+    "MultiClassClassifier",
     "TrainingReportData",
     "generate_markdown_report",
     "run_leave_one_group_out_cv",

--- a/src/jabs/classifier/classifier.py
+++ b/src/jabs/classifier/classifier.py
@@ -183,20 +183,30 @@ class Classifier:
 
         Note: labels excludes label for frames with no identity.
         """
+        labels = np.asarray(labels)
+        groups = np.asarray(groups)
         unique_groups = np.unique(groups)
-        count_behavior = [
-            np.sum(np.asarray(labels)[np.asarray(groups) == x] == TrackLabels.Label.BEHAVIOR)
-            for x in unique_groups
-        ]
-        count_not_behavior = [
-            np.sum(np.asarray(labels)[np.asarray(groups) == x] == TrackLabels.Label.NOT_BEHAVIOR)
-            for x in unique_groups
-        ]
-        can_kfold = np.logical_and(
-            np.asarray(count_behavior) > Classifier.LABEL_THRESHOLD,
-            np.asarray(count_not_behavior) > Classifier.LABEL_THRESHOLD,
-        )
-        return np.sum(can_kfold)
+        count = 0
+        for g in unique_groups:
+            test_mask = groups == g
+            test_labels = labels[test_mask]
+            train_labels = labels[~test_mask]
+            # Test split must have both classes above threshold.
+            test_ok = (
+                np.sum(test_labels == TrackLabels.Label.BEHAVIOR) > Classifier.LABEL_THRESHOLD
+                and np.sum(test_labels == TrackLabels.Label.NOT_BEHAVIOR)
+                > Classifier.LABEL_THRESHOLD
+            )
+            # Training split must also have both classes above threshold so the
+            # model can learn every class regardless of which group is held out.
+            train_ok = (
+                np.sum(train_labels == TrackLabels.Label.BEHAVIOR) > Classifier.LABEL_THRESHOLD
+                and np.sum(train_labels == TrackLabels.Label.NOT_BEHAVIOR)
+                > Classifier.LABEL_THRESHOLD
+            )
+            if test_ok and train_ok:
+                count += 1
+        return count
 
     @staticmethod
     def leave_one_group_out(per_frame_features, window_features, labels, groups):

--- a/src/jabs/classifier/classifier.py
+++ b/src/jabs/classifier/classifier.py
@@ -17,32 +17,21 @@ from jabs.core.utils import hash_file
 from jabs.project import Project, TrackLabels, load_training_data
 
 from . import classifier_utils
-from .factories import make_catboost, make_random_forest, make_xgboost
+from .factories import XGBOOST_AVAILABLE, make_catboost, make_random_forest, make_xgboost
 
 _VERSION = 11
 
 # _CLASSIFIER_FACTORIES serves as both the single source of truth for classifiers
 # supported by the current JABS environment, in addition to the mapping of ClassifierTypes
-# to factory functions that produce instantiated classifiers for that type
+# to factory functions that produce instantiated classifiers for that type.
+# XGBoost availability is detected once in factories.py; import XGBOOST_AVAILABLE here
+# rather than re-probing so that the warning is emitted exactly once.
 _CLASSIFIER_FACTORIES: dict[ClassifierType, typing.Callable[[int, int | None], typing.Any]] = {
     ClassifierType.RANDOM_FOREST: make_random_forest,
     ClassifierType.CATBOOST: make_catboost,
 }
 
-# Attempt to register XGBoost if available. While it will be installed, because it is a
-# package dependency, it might not be usable on macOS due to missing libomp. In this case
-# xgboost will raise an ImportError, so we try importing and catch ImportError to see if it
-# is usable in the current environment.
-# Users will be warned if XGBoost support is unavailable. This can be resolved by installing
-# libomp using homebrew.
-try:
-    import xgboost  # noqa F401
-except ImportError:
-    logging.warning(
-        "Unable to import xgboost. XGBoost support will be unavailable. "
-        "You may need to install xgboost and/or libomp."
-    )
-else:
+if XGBOOST_AVAILABLE:
     _CLASSIFIER_FACTORIES[ClassifierType.XGBOOST] = make_xgboost
 
 

--- a/src/jabs/classifier/classifier.py
+++ b/src/jabs/classifier/classifier.py
@@ -182,16 +182,16 @@ class Classifier:
             train_labels = labels[~test_mask]
             # Test split must have both classes above threshold.
             test_ok = (
-                np.sum(test_labels == TrackLabels.Label.BEHAVIOR) > Classifier.LABEL_THRESHOLD
+                np.sum(test_labels == TrackLabels.Label.BEHAVIOR) >= Classifier.LABEL_THRESHOLD
                 and np.sum(test_labels == TrackLabels.Label.NOT_BEHAVIOR)
-                > Classifier.LABEL_THRESHOLD
+                >= Classifier.LABEL_THRESHOLD
             )
             # Training split must also have both classes above threshold so the
             # model can learn every class regardless of which group is held out.
             train_ok = (
-                np.sum(train_labels == TrackLabels.Label.BEHAVIOR) > Classifier.LABEL_THRESHOLD
+                np.sum(train_labels == TrackLabels.Label.BEHAVIOR) >= Classifier.LABEL_THRESHOLD
                 and np.sum(train_labels == TrackLabels.Label.NOT_BEHAVIOR)
-                > Classifier.LABEL_THRESHOLD
+                >= Classifier.LABEL_THRESHOLD
             )
             if test_ok and train_ok:
                 count += 1

--- a/src/jabs/classifier/classifier_utils.py
+++ b/src/jabs/classifier/classifier_utils.py
@@ -169,10 +169,17 @@ def leave_one_group_out(
     for split in splits:
         test_labels = labels[split[1]]
         if min_test_classes is None:
-            # Binary mode: all classes must appear above threshold in test split.
+            # Binary mode: all classes must appear above threshold in both splits.
             test_ok = all(
                 np.count_nonzero(test_labels == cls) >= label_threshold for cls in all_classes
             )
+            if test_ok:
+                # Also require all classes above threshold in the training split
+                # so the model can learn every class regardless of the test group.
+                train_labels = labels[split[0]]
+                test_ok = all(
+                    np.count_nonzero(train_labels == cls) >= label_threshold for cls in all_classes
+                )
         else:
             # Multi-class mode: test split needs at least min_test_classes
             # classes above threshold; training split must have all classes.

--- a/src/jabs/classifier/classifier_utils.py
+++ b/src/jabs/classifier/classifier_utils.py
@@ -131,9 +131,17 @@ def leave_one_group_out(
 ) -> Generator[dict, None, None]:
     """Implement the leave-one-group-out data splitting strategy.
 
-    When ``min_test_classes`` is ``None`` (default, binary mode), every class
-    present in the full ``labels`` array must appear at least ``label_threshold``
-    times in the test split.
+    A split is accepted only when **both** the test and training portions satisfy
+    their respective class-count requirements.
+
+    When ``min_test_classes`` is ``None`` (default, binary mode), a split is
+    accepted when:
+
+    - Every class present in the full ``labels`` array appears at least
+      ``label_threshold`` times in the test split.
+    - The training split also contains every class at least ``label_threshold``
+      times (guards against the held-out group being the sole source of a rare
+      class).
 
     When ``min_test_classes`` is an integer (multi-class mode), a split is
     accepted when:

--- a/src/jabs/classifier/classifier_utils.py
+++ b/src/jabs/classifier/classifier_utils.py
@@ -127,21 +127,31 @@ def leave_one_group_out(
     labels: npt.NDArray,
     groups: npt.NDArray,
     label_threshold: int = LABEL_THRESHOLD,
+    min_test_classes: int | None = None,
 ) -> Generator[dict, None, None]:
     """Implement the leave-one-group-out data splitting strategy.
 
-    Splits are filtered so that the test set has at least `label_threshold`
-    samples for every class present in the full ``labels`` array. This ensures
-    all classes are represented in the test set, matching the original binary
-    behavior (both BEHAVIOR and NOT_BEHAVIOR must be above threshold) and
-    extending naturally to multi-class mode.
+    When ``min_test_classes`` is ``None`` (default, binary mode), every class
+    present in the full ``labels`` array must appear at least ``label_threshold``
+    times in the test split.
+
+    When ``min_test_classes`` is an integer (multi-class mode), a split is
+    accepted when:
+
+    - The test split contains at least ``min_test_classes`` distinct classes each
+      with at least ``label_threshold`` samples.
+    - The training split contains **all** classes at least ``label_threshold``
+      times (so the model can learn every class regardless of what appears in
+      the test split).
 
     Args:
         per_frame_features: Per-frame feature DataFrame for labeled data.
         window_features: Window feature DataFrame for labeled data.
         labels: Label array corresponding to each feature row.
         groups: Group ID array corresponding to each feature row.
-        label_threshold: Minimum number of samples per class in the test split.
+        label_threshold: Minimum number of samples per class required.
+        min_test_classes: Minimum number of distinct classes required in the
+            test split. ``None`` requires all classes (binary default).
 
     Yields:
         Dictionary with keys: training_data, training_labels, test_data,
@@ -158,7 +168,24 @@ def leave_one_group_out(
     count = 0
     for split in splits:
         test_labels = labels[split[1]]
-        if all(np.count_nonzero(test_labels == cls) >= label_threshold for cls in all_classes):
+        if min_test_classes is None:
+            # Binary mode: all classes must appear above threshold in test split.
+            test_ok = all(
+                np.count_nonzero(test_labels == cls) >= label_threshold for cls in all_classes
+            )
+        else:
+            # Multi-class mode: test split needs at least min_test_classes
+            # classes above threshold; training split must have all classes.
+            n_test_classes = sum(
+                np.count_nonzero(test_labels == cls) >= label_threshold for cls in all_classes
+            )
+            train_labels = labels[split[0]]
+            train_has_all = all(
+                np.count_nonzero(train_labels == cls) >= label_threshold for cls in all_classes
+            )
+            test_ok = n_test_classes >= min_test_classes and train_has_all
+
+        if test_ok:
             count += 1
             yield {
                 "training_data": x.iloc[split[0]],

--- a/src/jabs/classifier/classifier_utils.py
+++ b/src/jabs/classifier/classifier_utils.py
@@ -167,7 +167,11 @@ def leave_one_group_out(
 
     Raises:
         ValueError: If no valid split satisfying the threshold can be found.
+        ValueError: If ``min_test_classes`` is not ``None`` and is less than 1.
     """
+    if min_test_classes is not None and min_test_classes < 1:
+        raise ValueError(f"min_test_classes must be None or >= 1, got {min_test_classes}")
+
     logo = LeaveOneGroupOut()
     x = combine_data(per_frame_features, window_features)
     splits = list(logo.split(x, labels, groups))

--- a/src/jabs/classifier/factories.py
+++ b/src/jabs/classifier/factories.py
@@ -1,8 +1,30 @@
-"""Factory functions for various classifiers."""
+"""Factory functions for various classifiers.
+
+``XGBOOST_AVAILABLE`` is set at import time by probing for the ``xgboost``
+package.  Both ``Classifier`` and ``MultiClassClassifier`` import this flag
+to conditionally register XGBoost support, so the availability check and
+warning are emitted exactly once regardless of how many classifier modules
+are imported.
+"""
+
+import logging
 
 from catboost import CatBoostClassifier
 from sklearn.base import ClassifierMixin
 from sklearn.ensemble import RandomForestClassifier
+
+logger = logging.getLogger(__name__)
+
+try:
+    import xgboost as _xgboost  # noqa: F401
+
+    XGBOOST_AVAILABLE: bool = True
+except ImportError:
+    XGBOOST_AVAILABLE = False
+    logger.warning(
+        "Unable to import xgboost. XGBoost support will be unavailable. "
+        "You may need to install xgboost and/or libomp."
+    )
 
 
 def make_random_forest(n_jobs: int, random_seed: int | None) -> RandomForestClassifier:

--- a/src/jabs/classifier/factories.py
+++ b/src/jabs/classifier/factories.py
@@ -36,6 +36,28 @@ def make_catboost(n_jobs: int, random_seed: int | None) -> CatBoostClassifier:
     )
 
 
+def make_catboost_multiclass(n_jobs: int, random_seed: int | None) -> CatBoostClassifier:
+    """Factory function to construct a CatBoost classifier for multi-class problems.
+
+    Uses ``loss_function="MultiClass"`` (softmax over all classes), which is
+    required when the label set has more than two classes.
+
+    Args:
+        n_jobs: Number of parallel jobs.
+        random_seed: Random seed for reproducibility.
+
+    Returns:
+        CatBoostClassifier configured for multi-class classification.
+    """
+    return CatBoostClassifier(
+        loss_function="MultiClass",
+        thread_count=n_jobs,
+        random_state=random_seed,
+        verbose=False,
+        allow_writing_files=False,
+    )
+
+
 def make_xgboost(n_jobs: int, random_seed: int | None) -> ClassifierMixin:
     """Factory function to construct an XGBoost classifier.
 

--- a/src/jabs/classifier/multi_class_classifier.py
+++ b/src/jabs/classifier/multi_class_classifier.py
@@ -434,6 +434,14 @@ class MultiClassClassifier:
 
         n_frames = next(iter(labels_by_behavior.values())).shape[0]
 
+        for name, arr in labels_by_behavior.items():
+            if arr.ndim != 1:
+                raise ValueError(f"Label array for '{name}' must be 1-D, got shape {arr.shape}")
+            if arr.shape[0] != n_frames:
+                raise ValueError(
+                    f"Label array for '{name}' has length {arr.shape[0]}, expected {n_frames}"
+                )
+
         # Check for frames labeled BEHAVIOR in more than one behavior.
         all_names = [MULTICLASS_NONE_BEHAVIOR, *behavior_names]
         behavior_mask = np.zeros(n_frames, dtype=np.intp)

--- a/src/jabs/classifier/multi_class_classifier.py
+++ b/src/jabs/classifier/multi_class_classifier.py
@@ -20,7 +20,12 @@ from jabs.core.utils import hash_file
 from jabs.project import TrackLabels
 
 from . import classifier_utils
-from .factories import make_catboost_multiclass, make_random_forest, make_xgboost
+from .factories import (
+    XGBOOST_AVAILABLE,
+    make_catboost_multiclass,
+    make_random_forest,
+    make_xgboost,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -31,14 +36,7 @@ _CLASSIFIER_FACTORIES: dict[ClassifierType, typing.Callable[[int, int | None], t
     ClassifierType.CATBOOST: make_catboost_multiclass,
 }
 
-try:
-    import xgboost  # noqa: F401
-except ImportError:
-    logger.warning(
-        "Unable to import xgboost. XGBoost support will be unavailable. "
-        "You may need to install xgboost and/or libomp."
-    )
-else:
+if XGBOOST_AVAILABLE:
     _CLASSIFIER_FACTORIES[ClassifierType.XGBOOST] = make_xgboost
 
 

--- a/src/jabs/classifier/multi_class_classifier.py
+++ b/src/jabs/classifier/multi_class_classifier.py
@@ -420,6 +420,9 @@ class MultiClassClassifier:
             - ``include_mask``: boolean array of length n_frames; True where the
               frame is included in training.
         """
+        if not labels_by_behavior:
+            raise ValueError("labels_by_behavior must not be empty")
+
         n_frames = next(iter(labels_by_behavior.values())).shape[0]
         class_indices = np.full(n_frames, -1, dtype=np.intp)
 

--- a/src/jabs/classifier/multi_class_classifier.py
+++ b/src/jabs/classifier/multi_class_classifier.py
@@ -20,7 +20,7 @@ from jabs.core.utils import hash_file
 from jabs.project import TrackLabels
 
 from . import classifier_utils
-from .factories import make_catboost, make_random_forest, make_xgboost
+from .factories import make_catboost_multiclass, make_random_forest, make_xgboost
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +28,7 @@ _VERSION = 1
 
 _CLASSIFIER_FACTORIES: dict[ClassifierType, typing.Callable[[int, int | None], typing.Any]] = {
     ClassifierType.RANDOM_FOREST: make_random_forest,
-    ClassifierType.CATBOOST: make_catboost,
+    ClassifierType.CATBOOST: make_catboost_multiclass,
 }
 
 try:

--- a/src/jabs/classifier/multi_class_classifier.py
+++ b/src/jabs/classifier/multi_class_classifier.py
@@ -176,6 +176,7 @@ class MultiClassClassifier:
 
         if "feature_names" in data:
             self._feature_names = data["feature_names"]
+            features = features[self._feature_names]
         else:
             self._feature_names = features.columns.to_list()
 

--- a/src/jabs/classifier/multi_class_classifier.py
+++ b/src/jabs/classifier/multi_class_classifier.py
@@ -424,6 +424,23 @@ class MultiClassClassifier:
             raise ValueError("labels_by_behavior must not be empty")
 
         n_frames = next(iter(labels_by_behavior.values())).shape[0]
+
+        # Check for frames labeled BEHAVIOR in more than one behavior.
+        all_names = [MULTICLASS_NONE_BEHAVIOR, *behavior_names]
+        behavior_mask = np.zeros(n_frames, dtype=np.intp)
+        for name in all_names:
+            if name in labels_by_behavior:
+                behavior_mask += (labels_by_behavior[name] == TrackLabels.Label.BEHAVIOR).astype(
+                    np.intp
+                )
+        conflict_frames = np.where(behavior_mask > 1)[0]
+        if len(conflict_frames) > 0:
+            raise ValueError(
+                f"Conflicting BEHAVIOR labels found on {len(conflict_frames)} frame(s): "
+                f"{conflict_frames.tolist()}. Each frame may be labeled for at "
+                f"most one behavior."
+            )
+
         class_indices = np.full(n_frames, -1, dtype=np.intp)
 
         # MULTICLASS_NONE_BEHAVIOR BEHAVIOR frames → class 0 (explicit background)

--- a/src/jabs/classifier/multi_class_classifier.py
+++ b/src/jabs/classifier/multi_class_classifier.py
@@ -92,8 +92,21 @@ class MultiClassClassifier:
             n_jobs: Number of parallel jobs for training and inference.
 
         Raises:
+            ValueError: If ``behavior_names`` is empty, contains duplicates, or
+                includes the reserved name ``MULTICLASS_NONE_BEHAVIOR``.
             ValueError: If ``classifier_type`` is not supported in the current environment.
         """
+        if not behavior_names:
+            raise ValueError("behavior_names must not be empty")
+        if MULTICLASS_NONE_BEHAVIOR in behavior_names:
+            raise ValueError(
+                f"behavior_names must not include the reserved name {MULTICLASS_NONE_BEHAVIOR!r}"
+            )
+        if len(behavior_names) != len(set(behavior_names)):
+            raise ValueError("behavior_names must not contain duplicate entries")
+        if classifier_type not in self._supported_classifier_choices():
+            raise ValueError("Invalid classifier type")
+
         self._behavior_names: list[str] = list(behavior_names)
         self._classifier_type = classifier_type
         self._n_jobs = n_jobs
@@ -103,9 +116,6 @@ class MultiClassClassifier:
         self._classifier_file: str | None = None
         self._classifier_hash: str | None = None
         self._classifier_source: str | None = None
-
-        if classifier_type not in self._supported_classifier_choices():
-            raise ValueError("Invalid classifier type")
 
     @property
     def behavior_names(self) -> list[str]:

--- a/src/jabs/classifier/multi_class_classifier.py
+++ b/src/jabs/classifier/multi_class_classifier.py
@@ -169,6 +169,15 @@ class MultiClassClassifier:
             data["labels_by_behavior"], self._behavior_names
         )
 
+        n_classes_present = len(np.unique(multiclass_labels))
+        if n_classes_present < 2:
+            raise ValueError(
+                f"Training requires at least 2 distinct classes, but only "
+                f"{n_classes_present} found. Ensure that at least two behaviors have "
+                f"BEHAVIOR-labeled frames, or combine one behavior with explicit "
+                f"background labels via the '{MULTICLASS_NONE_BEHAVIOR}' behavior entry."
+            )
+
         combined = classifier_utils.combine_data(data["per_frame"], data["window"])
         features = combined[include_mask].reset_index(drop=True)
 

--- a/src/jabs/classifier/multi_class_classifier.py
+++ b/src/jabs/classifier/multi_class_classifier.py
@@ -1,0 +1,368 @@
+"""Multi-class behavior classifier for simultaneous N-behavior classification."""
+
+from __future__ import annotations
+
+import logging
+import typing
+import warnings
+from pathlib import Path
+
+import joblib
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+from sklearn.exceptions import InconsistentVersionWarning
+
+from jabs.core.constants import MULTICLASS_NONE_BEHAVIOR
+from jabs.core.enums import ClassifierType
+from jabs.core.utils import hash_file
+from jabs.project import TrackLabels
+
+from . import classifier_utils
+from .factories import make_catboost, make_random_forest, make_xgboost
+
+logger = logging.getLogger(__name__)
+
+_VERSION = 1
+
+_CLASSIFIER_FACTORIES: dict[ClassifierType, typing.Callable[[int, int | None], typing.Any]] = {
+    ClassifierType.RANDOM_FOREST: make_random_forest,
+    ClassifierType.CATBOOST: make_catboost,
+}
+
+try:
+    import xgboost  # noqa: F401
+except ImportError:
+    logger.warning(
+        "Unable to import xgboost. XGBoost support will be unavailable. "
+        "You may need to install xgboost and/or libomp."
+    )
+else:
+    _CLASSIFIER_FACTORIES[ClassifierType.XGBOOST] = make_xgboost
+
+
+class MultiClassClassifier:
+    """Multi-class behavior classifier for simultaneous classification of N behaviors.
+
+    Trains a single classifier over all annotated behaviors, outputting one of N
+    behavior classes (or background) per frame. Per-behavior TrackLabels arrays are
+    merged into a single class-index array before training.
+
+    The background class (index 0) is the multi-class analog of the binary
+    classifier's "not {behavior}" class, except that it represents the absence of
+    *all* annotated behaviors rather than the negation of a single one. It is
+    populated exclusively via explicit ``MULTICLASS_NONE_BEHAVIOR`` labels; frames
+    that are simply unlabeled are excluded from training entirely.
+
+    Merging rules:
+        - BEHAVIOR in ``MULTICLASS_NONE_BEHAVIOR`` TrackLabels → class 0 (background)
+        - BEHAVIOR in behavior X's TrackLabels → class X's 1-based index
+        - All other frames → excluded from training
+
+    Attributes:
+        LABEL_THRESHOLD: Minimum number of labeled frames required per class.
+    """
+
+    LABEL_THRESHOLD: int = classifier_utils.LABEL_THRESHOLD
+
+    def __init__(
+        self,
+        behavior_names: list[str],
+        classifier_type: ClassifierType = ClassifierType.RANDOM_FOREST,
+        n_jobs: int = 1,
+    ) -> None:
+        """Initialize a MultiClassClassifier.
+
+        Args:
+            behavior_names: Ordered list of behavior names to classify (must not include
+                ``MULTICLASS_NONE_BEHAVIOR``). Class index 0 is reserved for background;
+                ``behavior_names[i]`` maps to class index ``i + 1``.
+            classifier_type: Underlying algorithm to use.
+            n_jobs: Number of parallel jobs for training and inference.
+
+        Raises:
+            ValueError: If ``classifier_type`` is not supported in the current environment.
+        """
+        self._behavior_names: list[str] = list(behavior_names)
+        self._classifier_type = classifier_type
+        self._n_jobs = n_jobs
+        self._classifier = None
+        self._feature_names: list[str] | None = None
+        self._version = _VERSION
+        self._classifier_file: str | None = None
+        self._classifier_hash: str | None = None
+        self._classifier_source: str | None = None
+
+        if classifier_type not in self._supported_classifier_choices():
+            raise ValueError("Invalid classifier type")
+
+    @property
+    def behavior_names(self) -> list[str]:
+        """Ordered list of behavior names (does not include background)."""
+        return list(self._behavior_names)
+
+    @property
+    def feature_names(self) -> list[str] | None:
+        """Feature names used when training this classifier."""
+        return self._feature_names
+
+    @property
+    def classifier_type(self) -> ClassifierType:
+        """Underlying classifier algorithm."""
+        return self._classifier_type
+
+    def get_class_names(self) -> list[str]:
+        """Return the ordered list of class names for this classifier.
+
+        Returns:
+            List with ``"background"`` at index 0 followed by behavior names.
+        """
+        return ["background", *self._behavior_names]
+
+    def train(self, data: dict, random_seed: int | None = None) -> None:
+        """Train the multi-class classifier.
+
+        Required keys in ``data``:
+            - ``per_frame``: per-frame feature DataFrame (one row per labeled frame)
+            - ``window``: window feature DataFrame (same shape as per_frame)
+            - ``labels_by_behavior``: dict mapping behavior name → label array of
+              ``TrackLabels.Label`` values, one element per row in ``per_frame``
+
+        Optional keys:
+            - ``settings``: dict with ``symmetric_behavior`` (bool) and
+              ``balance_labels`` (bool), both default False
+            - ``feature_names``: explicit list of feature column names
+
+        Args:
+            data: Training data dictionary (see above).
+            random_seed: Optional random seed for reproducibility.
+
+        Raises:
+            ValueError: If required keys are missing from ``data``.
+        """
+        for key in ("per_frame", "window", "labels_by_behavior"):
+            if key not in data:
+                raise ValueError(f"Missing required key in training data: '{key}'")
+
+        settings = data.get("settings", {})
+
+        multiclass_labels, include_mask = self.merge_labels(
+            data["labels_by_behavior"], self._behavior_names
+        )
+
+        combined = classifier_utils.combine_data(data["per_frame"], data["window"])
+        features = combined[include_mask].reset_index(drop=True)
+
+        if "feature_names" in data:
+            self._feature_names = data["feature_names"]
+        else:
+            self._feature_names = features.columns.to_list()
+
+        if settings.get("symmetric_behavior", False):
+            features, multiclass_labels = classifier_utils.augment_symmetric(
+                features, multiclass_labels
+            )
+        if settings.get("balance_labels", False):
+            features, multiclass_labels = classifier_utils.downsample_balance(
+                features, multiclass_labels, random_seed
+            )
+
+        clf = self._create_classifier(random_seed=random_seed)
+        cleaned = classifier_utils.clean_features(features, self._classifier_type)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=FutureWarning)
+            self._classifier = clf.fit(cleaned, multiclass_labels)
+
+        self._classifier_file = None
+        self._classifier_hash = None
+        self._classifier_source = None
+        logger.info("MultiClassClassifier trained on %d behaviors", len(self._behavior_names))
+
+    def predict(
+        self,
+        features: pd.DataFrame,
+        frame_indexes: npt.NDArray[np.intp] | None = None,
+    ) -> npt.NDArray[np.int8]:
+        """Predict class indices for the given features.
+
+        Args:
+            features: DataFrame of feature data.
+            frame_indexes: Indexes of frames with valid pose data. Frames absent
+                from this array receive a prediction of -1 (no pose).
+
+        Returns:
+            Integer array of shape ``(n_frames,)`` with class indices 0..N,
+            or -1 for frames with no pose data.
+        """
+        cleaned = self._get_features_to_classify(
+            classifier_utils.clean_features(features, self._classifier_type)
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=FutureWarning)
+            result = self._classifier.predict(cleaned).astype(np.int8)
+
+        if frame_indexes is not None:
+            result_adjusted = np.full(result.shape, -1, dtype=np.int8)
+            result_adjusted[frame_indexes] = result[frame_indexes]
+            result = result_adjusted
+
+        return result
+
+    def predict_proba(
+        self,
+        features: pd.DataFrame,
+        frame_indexes: npt.NDArray[np.intp] | None = None,
+    ) -> npt.NDArray[np.float32]:
+        """Predict class probabilities for the given features.
+
+        Args:
+            features: DataFrame of feature data.
+            frame_indexes: Indexes of frames with valid pose data. Frames absent
+                from this array receive zero probability across all classes.
+
+        Returns:
+            Float array of shape ``(n_frames, N+1)`` where N is the number of
+            behaviors. Column 0 is the background class.
+        """
+        cleaned = self._get_features_to_classify(
+            classifier_utils.clean_features(features, self._classifier_type)
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=FutureWarning)
+            result = self._classifier.predict_proba(cleaned).astype(np.float32)
+
+        if frame_indexes is not None:
+            result_adjusted = np.zeros(result.shape, dtype=np.float32)
+            result_adjusted[frame_indexes] = result[frame_indexes]
+            result = result_adjusted
+
+        return result
+
+    def save(self, path: Path) -> None:
+        """Serialize the classifier to disk using joblib.
+
+        Args:
+            path: Destination file path.
+        """
+        joblib.dump(self, path)
+        if self._classifier_file is None:
+            self._classifier_file = Path(path).name
+            self._classifier_hash = hash_file(Path(path))
+            self._classifier_source = "serialized"
+        logger.info("MultiClassClassifier saved to %s", path)
+
+    def load(self, path: Path) -> None:
+        """Deserialize a classifier from disk, updating this instance in place.
+
+        Args:
+            path: Source file path.
+
+        Raises:
+            ValueError: If the file is not a ``MultiClassClassifier``, was saved
+                with a different version, or uses an unsupported classifier type.
+        """
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            warnings.simplefilter("always", InconsistentVersionWarning)
+            c = joblib.load(path)
+            for warning in caught_warnings:
+                if issubclass(warning.category, InconsistentVersionWarning):
+                    raise ValueError("Classifier trained with different version of sklearn.")
+                else:
+                    warnings.warn(warning.message, warning.category, stacklevel=2)
+
+        if not isinstance(c, MultiClassClassifier):
+            raise ValueError(f"{path} is not an instance of MultiClassClassifier")
+
+        if c._version != _VERSION:
+            raise ValueError(
+                f"Unable to deserialize pickled classifier. "
+                f"File version {c._version}, expected {_VERSION}."
+            )
+
+        if c._classifier_type not in self._supported_classifier_choices():
+            raise ValueError("Invalid classifier type")
+
+        self._classifier = c._classifier
+        self._behavior_names = c._behavior_names
+        self._classifier_type = c._classifier_type
+        self._feature_names = c._feature_names
+        if c._classifier_file is not None:
+            self._classifier_file = c._classifier_file
+            self._classifier_hash = c._classifier_hash
+            self._classifier_source = c._classifier_source
+        else:
+            self._classifier_file = Path(path).name
+            self._classifier_hash = hash_file(Path(path))
+            self._classifier_source = "pickle"
+
+        logger.info("MultiClassClassifier loaded from %s", path)
+
+    @staticmethod
+    def merge_labels(
+        labels_by_behavior: dict[str, npt.NDArray[np.int8]],
+        behavior_names: list[str],
+    ) -> tuple[npt.NDArray[np.intp], npt.NDArray[np.bool_]]:
+        """Merge per-behavior label arrays into a single multi-class label array.
+
+        Merging rules:
+            - ``TrackLabels.Label.BEHAVIOR`` in ``MULTICLASS_NONE_BEHAVIOR`` entry
+              → class 0 (background)
+            - ``TrackLabels.Label.BEHAVIOR`` in behavior X's entry
+              → class index (1-based, by position in ``behavior_names``)
+            - All other frames → excluded (not in the returned mask)
+
+        Args:
+            labels_by_behavior: dict mapping behavior name to a label array of
+                ``TrackLabels.Label`` integer values, one element per frame.
+            behavior_names: Ordered list of N behavior names (must not include
+                ``MULTICLASS_NONE_BEHAVIOR``).
+
+        Returns:
+            Tuple of ``(multiclass_labels, include_mask)`` where:
+
+            - ``multiclass_labels``: integer array of class indices (0..N) for
+              the included frames only, length M ≤ n_frames.
+            - ``include_mask``: boolean array of length n_frames; True where the
+              frame is included in training.
+        """
+        n_frames = next(iter(labels_by_behavior.values())).shape[0]
+        class_indices = np.full(n_frames, -1, dtype=np.intp)
+
+        # MULTICLASS_NONE_BEHAVIOR BEHAVIOR frames → class 0 (explicit background)
+        if MULTICLASS_NONE_BEHAVIOR in labels_by_behavior:
+            none_arr = labels_by_behavior[MULTICLASS_NONE_BEHAVIOR]
+            class_indices[none_arr == TrackLabels.Label.BEHAVIOR] = 0
+
+        # Named behavior BEHAVIOR frames → class 1..N
+        for i, behavior in enumerate(behavior_names, start=1):
+            if behavior in labels_by_behavior:
+                beh_arr = labels_by_behavior[behavior]
+                class_indices[beh_arr == TrackLabels.Label.BEHAVIOR] = i
+
+        include_mask = class_indices >= 0
+        return class_indices[include_mask], include_mask
+
+    def _create_classifier(self, random_seed: int | None = None) -> typing.Any:
+        """Instantiate the underlying sklearn/xgboost/catboost classifier."""
+        try:
+            factory = _CLASSIFIER_FACTORIES[self._classifier_type]
+        except KeyError:
+            raise ValueError(f"Unsupported classifier type: {self._classifier_type!r}") from None
+        return factory(self._n_jobs, random_seed)
+
+    def _get_features_to_classify(self, features: pd.DataFrame) -> pd.DataFrame:
+        """Reorder/select feature columns to match the trained model's expectations."""
+        if self._classifier_type == ClassifierType.XGBOOST:
+            classifier_columns = self._classifier.get_booster().feature_names
+        elif hasattr(self._classifier, "feature_names_in_"):
+            classifier_columns = list(self._classifier.feature_names_in_)
+        elif hasattr(self._classifier, "feature_names_"):
+            classifier_columns = list(self._classifier.feature_names_)
+        else:
+            raise RuntimeError("Error obtaining feature names from classifier.")
+        return features[classifier_columns]
+
+    @staticmethod
+    def _supported_classifier_choices() -> set[ClassifierType]:
+        """Determine supported classifier types in the current environment."""
+        return set(_CLASSIFIER_FACTORIES.keys())

--- a/src/jabs/classifier/multi_class_classifier.py
+++ b/src/jabs/classifier/multi_class_classifier.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import typing
 import warnings
+from collections.abc import Generator
 from pathlib import Path
 
 import joblib
@@ -58,6 +59,16 @@ class MultiClassClassifier:
         - BEHAVIOR in ``MULTICLASS_NONE_BEHAVIOR`` TrackLabels → class 0 (background)
         - BEHAVIOR in behavior X's TrackLabels → class X's 1-based index
         - All other frames → excluded from training
+
+    Cross-validation note:
+        Leave-one-group-out CV uses a relaxed split criterion compared to binary
+        mode. Because individual groups (videos or animals) are often labeled for
+        only a subset of behaviors, requiring all classes in every test split would
+        yield no valid splits. Instead, a test split is accepted when it contains at
+        least 2 classes above ``LABEL_THRESHOLD`` and the remaining training groups
+        collectively contain all classes above ``LABEL_THRESHOLD``. A follow-up
+        ticket should introduce a multi-video grouping strategy that aggregates
+        groups to improve class coverage in test splits.
 
     Attributes:
         LABEL_THRESHOLD: Minimum number of labeled frames required per class.
@@ -296,6 +307,80 @@ class MultiClassClassifier:
             self._classifier_source = "pickle"
 
         logger.info("MultiClassClassifier loaded from %s", path)
+
+    @staticmethod
+    def leave_one_group_out(
+        per_frame_features: pd.DataFrame,
+        window_features: pd.DataFrame,
+        labels: npt.NDArray,
+        groups: npt.NDArray,
+    ) -> Generator[dict, None, None]:
+        """Generate leave-one-group-out splits for multi-class cross-validation.
+
+        Uses a relaxed acceptance criterion: a split is valid when the test group
+        has at least 2 classes above ``LABEL_THRESHOLD`` and the training portion
+        has all classes above ``LABEL_THRESHOLD``. See the class docstring for
+        rationale.
+
+        Args:
+            per_frame_features: Per-frame feature DataFrame for labeled data.
+            window_features: Window feature DataFrame for labeled data.
+            labels: Multi-class label array (class indices).
+            groups: Group ID array corresponding to each feature row.
+
+        Yields:
+            Split dictionaries with keys: training_data, training_labels,
+            test_data, test_labels, test_group, feature_names.
+
+        Raises:
+            ValueError: If no valid split can be found.
+        """
+        yield from classifier_utils.leave_one_group_out(
+            per_frame_features,
+            window_features,
+            labels,
+            groups,
+            label_threshold=MultiClassClassifier.LABEL_THRESHOLD,
+            min_test_classes=2,
+        )
+
+    @staticmethod
+    def get_leave_one_group_out_max(
+        labels: npt.NDArray,
+        groups: npt.NDArray,
+    ) -> int:
+        """Count the number of valid LOGO splits for multi-class cross-validation.
+
+        A group is counted as a valid test split when it contains at least 2
+        distinct classes above ``LABEL_THRESHOLD`` and the remaining training
+        groups collectively contain all classes above ``LABEL_THRESHOLD``.
+
+        Args:
+            labels: Multi-class label array (class indices).
+            groups: Group ID array corresponding to each label.
+
+        Returns:
+            Number of groups that can serve as a valid test split.
+        """
+        all_classes = np.unique(labels)
+        unique_groups = np.unique(groups)
+        count = 0
+        for g in unique_groups:
+            test_mask = np.asarray(groups) == g
+            test_labels = np.asarray(labels)[test_mask]
+            train_labels = np.asarray(labels)[~test_mask]
+
+            n_test_classes = sum(
+                np.count_nonzero(test_labels == cls) >= MultiClassClassifier.LABEL_THRESHOLD
+                for cls in all_classes
+            )
+            train_has_all = all(
+                np.count_nonzero(train_labels == cls) >= MultiClassClassifier.LABEL_THRESHOLD
+                for cls in all_classes
+            )
+            if n_test_classes >= 2 and train_has_all:
+                count += 1
+        return count
 
     @staticmethod
     def merge_labels(

--- a/src/jabs/classifier/multi_class_classifier.py
+++ b/src/jabs/classifier/multi_class_classifier.py
@@ -220,7 +220,8 @@ class MultiClassClassifier:
         )
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=FutureWarning)
-            result = self._classifier.predict(cleaned).astype(np.int8)
+            # ravel() normalizes CatBoost MultiClass, which returns (n, 1).
+            result = np.ravel(self._classifier.predict(cleaned)).astype(np.int8)
 
         if frame_indexes is not None:
             result_adjusted = np.full(result.shape, -1, dtype=np.int8)

--- a/tests/classifier/test_multi_class_classifier.py
+++ b/tests/classifier/test_multi_class_classifier.py
@@ -1,0 +1,359 @@
+"""Tests for MultiClassClassifier."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from jabs.classifier.multi_class_classifier import MultiClassClassifier
+from jabs.core.constants import MULTICLASS_NONE_BEHAVIOR
+from jabs.core.enums import ClassifierType
+from jabs.project import TrackLabels
+
+# Shorthand for label enum values used throughout tests
+_B = TrackLabels.Label.BEHAVIOR
+_N = TrackLabels.Label.NOT_BEHAVIOR
+_X = TrackLabels.Label.NONE
+
+BEHAVIOR_NAMES = ["running", "grooming"]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def two_behavior_labels() -> dict[str, np.ndarray]:
+    """Label arrays for two behaviors across 12 frames.
+
+    Layout:
+        Frames 0-2:  running  (class 1)
+        Frames 3-5:  grooming (class 2)
+        Frames 6-8:  "None" explicit background (class 0)
+        Frames 9-11: unlabeled (NONE — excluded)
+    """
+    n = 12
+    running = np.full(n, _X, dtype=np.int8)
+    grooming = np.full(n, _X, dtype=np.int8)
+    none_beh = np.full(n, _X, dtype=np.int8)
+
+    running[0:3] = _B
+    grooming[3:6] = _B
+    none_beh[6:9] = _B
+
+    return {
+        "running": running,
+        "grooming": grooming,
+        MULTICLASS_NONE_BEHAVIOR: none_beh,
+    }
+
+
+@pytest.fixture
+def synthetic_features() -> tuple[pd.DataFrame, pd.DataFrame]:
+    """12-row per-frame and window feature DataFrames."""
+    rng = np.random.default_rng(0)
+    per_frame = pd.DataFrame(
+        {
+            "feat_a": rng.standard_normal(12),
+            "feat_b": rng.standard_normal(12),
+        }
+    )
+    window = pd.DataFrame({"feat_c": rng.standard_normal(12)})
+    return per_frame, window
+
+
+@pytest.fixture
+def trained_clf(two_behavior_labels, synthetic_features) -> MultiClassClassifier:
+    """A MultiClassClassifier trained on the synthetic fixture data."""
+    per_frame, window = synthetic_features
+    clf = MultiClassClassifier(BEHAVIOR_NAMES)
+    clf.train(
+        {
+            "per_frame": per_frame,
+            "window": window,
+            "labels_by_behavior": two_behavior_labels,
+        },
+        random_seed=42,
+    )
+    return clf
+
+
+@pytest.fixture
+def combined_features(synthetic_features) -> pd.DataFrame:
+    """Combined per-frame + window feature DataFrame (as passed to predict)."""
+    per_frame, window = synthetic_features
+    return pd.concat([per_frame, window], axis=1)
+
+
+# ---------------------------------------------------------------------------
+# merge_labels — label merging logic
+# ---------------------------------------------------------------------------
+
+
+class TestMergeLabels:
+    """Tests for MultiClassClassifier.merge_labels."""
+
+    def test_behavior_frames_map_to_correct_class_index(self, two_behavior_labels):
+        """Frames labeled BEHAVIOR for each behavior map to class 1 and 2."""
+        labels, mask = MultiClassClassifier.merge_labels(two_behavior_labels, BEHAVIOR_NAMES)
+
+        # 9 frames included: 3 running (class 1) + 3 grooming (class 2) + 3 none (class 0)
+        assert mask.sum() == 9
+        assert np.count_nonzero(labels == 1) == 3  # running
+        assert np.count_nonzero(labels == 2) == 3  # grooming
+        assert np.count_nonzero(labels == 0) == 3  # background
+
+    def test_none_label_frames_excluded(self, two_behavior_labels):
+        """Frames with NONE label on all behaviors are excluded from training."""
+        _, mask = MultiClassClassifier.merge_labels(two_behavior_labels, BEHAVIOR_NAMES)
+
+        # frames 9-11 are unlabeled → excluded
+        assert not mask[9]
+        assert not mask[10]
+        assert not mask[11]
+
+    def test_not_behavior_frames_excluded(self):
+        """NOT_BEHAVIOR frames (without a matching "None" BEHAVIOR label) are excluded."""
+        labels_by_behavior = {
+            "walking": np.array([_B, _B, _N, _N, _X, _X], dtype=np.int8),
+        }
+        _, mask = MultiClassClassifier.merge_labels(labels_by_behavior, ["walking"])
+
+        # only the first two BEHAVIOR frames are included
+        assert mask.sum() == 2
+        assert mask[0] and mask[1]
+        assert not mask[2] and not mask[3]
+
+    def test_none_behavior_maps_to_class_zero(self):
+        """BEHAVIOR in MULTICLASS_NONE_BEHAVIOR TrackLabels maps to class 0."""
+        labels_by_behavior = {
+            "walking": np.array([_B, _B, _X, _X], dtype=np.int8),
+            MULTICLASS_NONE_BEHAVIOR: np.array([_X, _X, _B, _B], dtype=np.int8),
+        }
+        labels, mask = MultiClassClassifier.merge_labels(labels_by_behavior, ["walking"])
+
+        assert mask.sum() == 4
+        np.testing.assert_array_equal(labels, [1, 1, 0, 0])
+
+    def test_behavior_ordering_respected(self):
+        """Class indices follow the order of behavior_names (1-based)."""
+        labels_by_behavior = {
+            "c": np.array([_B, _X, _X, _X, _X, _X], dtype=np.int8),
+            "a": np.array([_X, _X, _B, _X, _X, _X], dtype=np.int8),
+            "b": np.array([_X, _X, _X, _X, _B, _X], dtype=np.int8),
+        }
+        behavior_names = ["a", "b", "c"]  # alphabetical, class 1/2/3
+        labels, _ = MultiClassClassifier.merge_labels(labels_by_behavior, behavior_names)
+
+        # "a" → class 1, "b" → class 2, "c" → class 3
+        assert 3 in labels  # "c" at frame 0
+        assert 1 in labels  # "a" at frame 2
+        assert 2 in labels  # "b" at frame 4
+
+    def test_missing_behavior_in_dict_is_skipped(self):
+        """Behavior names not present in labels_by_behavior are silently skipped."""
+        labels_by_behavior = {
+            "running": np.array([_B, _B, _X, _X], dtype=np.int8),
+            # "grooming" intentionally absent
+        }
+        labels, mask = MultiClassClassifier.merge_labels(
+            labels_by_behavior, ["running", "grooming"]
+        )
+        assert mask.sum() == 2
+        np.testing.assert_array_equal(labels, [1, 1])
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+
+class TestMultiClassClassifierInit:
+    """Tests for MultiClassClassifier.__init__."""
+
+    def test_default_initialization(self):
+        """Classifier initializes with expected defaults."""
+        clf = MultiClassClassifier(BEHAVIOR_NAMES)
+        assert clf.classifier_type == ClassifierType.RANDOM_FOREST
+        assert clf.behavior_names == BEHAVIOR_NAMES
+        assert clf.feature_names is None
+
+    def test_behavior_names_stored_as_copy(self):
+        """Mutating the input list does not affect the stored behavior names."""
+        names = ["a", "b"]
+        clf = MultiClassClassifier(names)
+        names.append("c")
+        assert clf.behavior_names == ["a", "b"]
+
+    def test_invalid_classifier_type_raises(self):
+        """Unsupported classifier type raises ValueError."""
+        from unittest.mock import patch
+
+        with (
+            patch.object(
+                MultiClassClassifier, "_supported_classifier_choices", return_value=set()
+            ),
+            pytest.raises(ValueError, match="Invalid classifier type"),
+        ):
+            MultiClassClassifier(BEHAVIOR_NAMES, ClassifierType.RANDOM_FOREST)
+
+
+# ---------------------------------------------------------------------------
+# get_class_names
+# ---------------------------------------------------------------------------
+
+
+def test_get_class_names():
+    """get_class_names returns background + behavior names in order."""
+    clf = MultiClassClassifier(["walking", "rearing"])
+    assert clf.get_class_names() == ["background", "walking", "rearing"]
+
+
+# ---------------------------------------------------------------------------
+# train
+# ---------------------------------------------------------------------------
+
+
+class TestTrain:
+    """Tests for MultiClassClassifier.train."""
+
+    def test_train_sets_feature_names(self, trained_clf):
+        """Training populates feature_names."""
+        assert trained_clf.feature_names is not None
+        assert len(trained_clf.feature_names) > 0
+
+    def test_train_missing_key_raises(self, synthetic_features):
+        """Missing required key in data raises ValueError."""
+        per_frame, window = synthetic_features
+        clf = MultiClassClassifier(BEHAVIOR_NAMES)
+        with pytest.raises(ValueError, match="Missing required key"):
+            clf.train({"per_frame": per_frame, "window": window})
+
+    def test_train_with_balance_labels(self, two_behavior_labels, synthetic_features):
+        """Training with balance_labels does not raise."""
+        per_frame, window = synthetic_features
+        clf = MultiClassClassifier(BEHAVIOR_NAMES)
+        clf.train(
+            {
+                "per_frame": per_frame,
+                "window": window,
+                "labels_by_behavior": two_behavior_labels,
+                "settings": {"balance_labels": True},
+            },
+            random_seed=42,
+        )
+        assert clf.feature_names is not None
+
+    def test_train_with_symmetric_augmentation(self, two_behavior_labels):
+        """Training with symmetric_behavior does not raise."""
+        per_frame = pd.DataFrame(
+            {
+                "left_angle": np.random.default_rng(1).standard_normal(12),
+                "right_angle": np.random.default_rng(2).standard_normal(12),
+            }
+        )
+        window = pd.DataFrame({"w": np.zeros(12)})
+        clf = MultiClassClassifier(BEHAVIOR_NAMES)
+        clf.train(
+            {
+                "per_frame": per_frame,
+                "window": window,
+                "labels_by_behavior": two_behavior_labels,
+                "settings": {"symmetric_behavior": True},
+            },
+            random_seed=42,
+        )
+        assert clf.feature_names is not None
+
+
+# ---------------------------------------------------------------------------
+# predict / predict_proba
+# ---------------------------------------------------------------------------
+
+
+class TestPrediction:
+    """Tests for predict and predict_proba."""
+
+    def test_predict_returns_correct_shape(self, trained_clf, combined_features):
+        """predict returns a 1-D array with one entry per row."""
+        predictions = trained_clf.predict(combined_features)
+        assert predictions.shape == (len(combined_features),)
+
+    def test_predict_values_in_valid_range(self, trained_clf, combined_features):
+        """predict outputs class indices in {-1, 0, 1, ..., N}."""
+        n_classes = len(BEHAVIOR_NAMES)
+        predictions = trained_clf.predict(combined_features)
+        assert np.all((predictions >= -1) & (predictions <= n_classes))
+
+    def test_predict_with_frame_indexes_fills_minus_one(self, trained_clf, combined_features):
+        """Frames outside frame_indexes are set to -1."""
+        frame_indexes = np.array([0, 1, 2], dtype=np.intp)
+        predictions = trained_clf.predict(combined_features, frame_indexes=frame_indexes)
+        assert np.all(predictions[3:] == -1)
+
+    def test_predict_proba_shape(self, trained_clf, combined_features):
+        """predict_proba returns (n_frames, N+1) where N = len(behavior_names)."""
+        proba = trained_clf.predict_proba(combined_features)
+        assert proba.shape == (len(combined_features), len(BEHAVIOR_NAMES) + 1)
+
+    def test_predict_proba_sums_to_one(self, trained_clf, combined_features):
+        """Probabilities across classes sum to 1 for each frame."""
+        proba = trained_clf.predict_proba(combined_features)
+        np.testing.assert_allclose(proba.sum(axis=1), np.ones(len(combined_features)), atol=1e-5)
+
+    def test_predict_proba_with_frame_indexes_zeros_missing(self, trained_clf, combined_features):
+        """Frames outside frame_indexes have zero probability."""
+        frame_indexes = np.array([0, 1], dtype=np.intp)
+        proba = trained_clf.predict_proba(combined_features, frame_indexes=frame_indexes)
+        assert np.all(proba[2:] == 0.0)
+
+
+# ---------------------------------------------------------------------------
+# save / load
+# ---------------------------------------------------------------------------
+
+
+class TestSaveLoad:
+    """Tests for MultiClassClassifier save and load."""
+
+    def test_save_and_load_round_trip(self, trained_clf, combined_features, tmp_path):
+        """Saving and loading produces identical predictions."""
+        path = tmp_path / "multi.pkl"
+        trained_clf.save(path)
+        assert path.exists()
+
+        clf2 = MultiClassClassifier(BEHAVIOR_NAMES)
+        clf2.load(path)
+
+        assert clf2.behavior_names == trained_clf.behavior_names
+        assert clf2.classifier_type == trained_clf.classifier_type
+        np.testing.assert_array_equal(
+            trained_clf.predict(combined_features),
+            clf2.predict(combined_features),
+        )
+
+    def test_load_non_multiclass_raises(self, tmp_path):
+        """Loading a file that is not a MultiClassClassifier raises ValueError."""
+        import joblib
+
+        path = tmp_path / "bad.pkl"
+        joblib.dump({"not": "a classifier"}, path)
+
+        clf = MultiClassClassifier(BEHAVIOR_NAMES)
+        with pytest.raises(ValueError, match="not an instance of MultiClassClassifier"):
+            clf.load(path)
+
+
+# ---------------------------------------------------------------------------
+# Protocol compliance
+# ---------------------------------------------------------------------------
+
+
+def test_satisfies_classifier_protocol():
+    """MultiClassClassifier structurally satisfies ClassifierProtocol."""
+    # Runtime check: verify all required attributes are present
+    clf = MultiClassClassifier(BEHAVIOR_NAMES)
+    protocol_methods = ("train", "predict", "predict_proba", "save", "load")
+    for method in protocol_methods:
+        assert callable(getattr(clf, method, None)), f"Missing method: {method}"
+    assert hasattr(clf, "feature_names"), "Missing property: feature_names"

--- a/tests/classifier/test_multi_class_classifier.py
+++ b/tests/classifier/test_multi_class_classifier.py
@@ -9,6 +9,13 @@ from jabs.core.constants import MULTICLASS_NONE_BEHAVIOR
 from jabs.core.enums import ClassifierType
 from jabs.project import TrackLabels
 
+try:
+    import xgboost  # noqa: F401
+
+    _XGBOOST_AVAILABLE = True
+except ImportError:
+    _XGBOOST_AVAILABLE = False
+
 # Shorthand for label enum values used throughout tests
 _B = TrackLabels.Label.BEHAVIOR
 _N = TrackLabels.Label.NOT_BEHAVIOR
@@ -272,6 +279,37 @@ class TestTrain:
             random_seed=42,
         )
         assert clf.feature_names is not None
+
+    @pytest.mark.parametrize(
+        "classifier_type",
+        [
+            ClassifierType.CATBOOST,
+            pytest.param(
+                ClassifierType.XGBOOST,
+                marks=pytest.mark.skipif(not _XGBOOST_AVAILABLE, reason="xgboost not installed"),
+            ),
+        ],
+    )
+    def test_train_and_predict_alternate_classifier_types(
+        self,
+        classifier_type,
+        two_behavior_labels,
+        synthetic_features,
+        combined_features,
+    ):
+        """Train and predict smoke test for non-default classifier types."""
+        per_frame, window = synthetic_features
+        clf = MultiClassClassifier(BEHAVIOR_NAMES, classifier_type)
+        clf.train(
+            {
+                "per_frame": per_frame,
+                "window": window,
+                "labels_by_behavior": two_behavior_labels,
+            },
+            random_seed=42,
+        )
+        predictions = clf.predict(combined_features)
+        assert predictions.shape == (len(combined_features),)
 
     def test_train_with_symmetric_augmentation(self, two_behavior_labels):
         """Training with symmetric_behavior does not raise."""

--- a/tests/classifier/test_multi_class_classifier.py
+++ b/tests/classifier/test_multi_class_classifier.py
@@ -345,6 +345,84 @@ class TestSaveLoad:
 
 
 # ---------------------------------------------------------------------------
+# leave_one_group_out / get_leave_one_group_out_max
+# ---------------------------------------------------------------------------
+
+
+class TestLeaveOneGroupOut:
+    """Tests for MultiClassClassifier LOGO cross-validation helpers."""
+
+    @pytest.fixture
+    def multiclass_logo_data(self):
+        """Three groups; each group has 2 of 3 behavior classes plus background.
+
+        Group 0: classes 0 and 1 (30 samples each)
+        Group 1: classes 0 and 2 (30 samples each)
+        Group 2: classes 1 and 2 (30 samples each)
+
+        No single group has all 3 classes, but the training set for any held-out
+        group always contains all 3.
+        """
+        rng = np.random.default_rng(0)
+        n = 30
+        labels = np.array(
+            [0] * n
+            + [1] * n  # group 0
+            + [0] * n
+            + [2] * n  # group 1
+            + [1] * n
+            + [2] * n,  # group 2
+            dtype=np.intp,
+        )
+        groups = np.array([0] * (2 * n) + [1] * (2 * n) + [2] * (2 * n))
+        per_frame = pd.DataFrame({"f": rng.standard_normal(len(labels))})
+        window = pd.DataFrame({"w": rng.standard_normal(len(labels))})
+        return per_frame, window, labels, groups
+
+    def test_yields_splits_when_no_group_has_all_classes(self, multiclass_logo_data):
+        """LOGO succeeds even when no single group contains all classes."""
+        per_frame, window, labels, groups = multiclass_logo_data
+        splits = list(MultiClassClassifier.leave_one_group_out(per_frame, window, labels, groups))
+        assert len(splits) > 0
+
+    def test_split_structure(self, multiclass_logo_data):
+        """Each split dict has the expected keys."""
+        per_frame, window, labels, groups = multiclass_logo_data
+        split = next(MultiClassClassifier.leave_one_group_out(per_frame, window, labels, groups))
+        for key in (
+            "training_data",
+            "training_labels",
+            "test_data",
+            "test_labels",
+            "test_group",
+            "feature_names",
+        ):
+            assert key in split
+
+    def test_training_split_has_all_classes(self, multiclass_logo_data):
+        """Every yielded split has all classes in the training portion."""
+        per_frame, window, labels, groups = multiclass_logo_data
+        all_classes = np.unique(labels)
+        for split in MultiClassClassifier.leave_one_group_out(per_frame, window, labels, groups):
+            for cls in all_classes:
+                assert np.count_nonzero(split["training_labels"] == cls) > 0
+
+    def test_get_leave_one_group_out_max(self, multiclass_logo_data):
+        """get_leave_one_group_out_max counts groups that yield valid splits."""
+        _, _, labels, groups = multiclass_logo_data
+        max_splits = MultiClassClassifier.get_leave_one_group_out_max(labels, groups)
+        assert max_splits == 3  # all three groups are valid test sets
+
+    def test_get_leave_one_group_out_max_zero_when_training_incomplete(self):
+        """Returns 0 when no split leaves a training set with all classes."""
+        # Only 2 groups; each has only one class — training set always missing classes.
+        labels = np.array([0] * 30 + [1] * 30, dtype=np.intp)
+        groups = np.array([0] * 30 + [1] * 30)
+        # group 0 test: training only has class 1; group 1 test: training only has class 0
+        assert MultiClassClassifier.get_leave_one_group_out_max(labels, groups) == 0
+
+
+# ---------------------------------------------------------------------------
 # Protocol compliance
 # ---------------------------------------------------------------------------
 

--- a/tests/classifier/test_multi_class_classifier.py
+++ b/tests/classifier/test_multi_class_classifier.py
@@ -197,6 +197,21 @@ class TestMultiClassClassifierInit:
         ):
             MultiClassClassifier(BEHAVIOR_NAMES, ClassifierType.RANDOM_FOREST)
 
+    def test_empty_behavior_names_raises(self):
+        """Empty behavior_names raises ValueError."""
+        with pytest.raises(ValueError, match="must not be empty"):
+            MultiClassClassifier([])
+
+    def test_reserved_none_behavior_name_raises(self):
+        """Including MULTICLASS_NONE_BEHAVIOR in behavior_names raises ValueError."""
+        with pytest.raises(ValueError, match="reserved name"):
+            MultiClassClassifier(["running", MULTICLASS_NONE_BEHAVIOR])
+
+    def test_duplicate_behavior_names_raises(self):
+        """Duplicate entries in behavior_names raise ValueError."""
+        with pytest.raises(ValueError, match="duplicate"):
+            MultiClassClassifier(["running", "grooming", "running"])
+
 
 # ---------------------------------------------------------------------------
 # get_class_names

--- a/tests/classifier/test_multi_class_classifier.py
+++ b/tests/classifier/test_multi_class_classifier.py
@@ -155,6 +155,15 @@ class TestMergeLabels:
         with pytest.raises(ValueError, match="must not be empty"):
             MultiClassClassifier.merge_labels({}, ["running"])
 
+    def test_conflicting_behavior_labels_raises(self):
+        """Frames with BEHAVIOR in more than one behavior raise ValueError."""
+        labels_by_behavior = {
+            "running": np.array([_B, _X, _X, _X], dtype=np.int8),
+            "grooming": np.array([_B, _B, _X, _X], dtype=np.int8),
+        }
+        with pytest.raises(ValueError, match="Conflicting BEHAVIOR labels"):
+            MultiClassClassifier.merge_labels(labels_by_behavior, ["running", "grooming"])
+
     def test_missing_behavior_in_dict_is_skipped(self):
         """Behavior names not present in labels_by_behavior are silently skipped."""
         labels_by_behavior = {

--- a/tests/classifier/test_multi_class_classifier.py
+++ b/tests/classifier/test_multi_class_classifier.py
@@ -150,6 +150,11 @@ class TestMergeLabels:
         assert 1 in labels  # "a" at frame 2
         assert 2 in labels  # "b" at frame 4
 
+    def test_empty_labels_by_behavior_raises(self):
+        """Empty labels_by_behavior raises ValueError."""
+        with pytest.raises(ValueError, match="must not be empty"):
+            MultiClassClassifier.merge_labels({}, ["running"])
+
     def test_missing_behavior_in_dict_is_skipped(self):
         """Behavior names not present in labels_by_behavior are silently skipped."""
         labels_by_behavior = {


### PR DESCRIPTION
This pull request introduces support for multi-class classification. The most significant changes include enhancing the `leave_one_group_out` splitting strategy to support both binary and multi-class scenarios and making the new `MultiClassClassifier` available for import.

**Multi-class cross-validation enhancements:**

* Updated the `leave_one_group_out` function in `classifier_utils.py` to accept a new `min_test_classes` parameter, allowing flexible handling of binary and multi-class splits. In multi-class mode, the test split must contain at least the specified number of distinct classes (each above a sample threshold), while the training split must include all classes above the threshold.

**Classifier API updates:**

* Added `MultiClassClassifier` to the `src/jabs/classifier/__init__.py` exports and imports, making it available as part of the public API. 
