### PR TITLE
Add segments between nose and ears and scale keypoint circles

### DIFF
--- a/packages/jabs-core/src/jabs/core/abstract/pose_est.py
+++ b/packages/jabs-core/src/jabs/core/abstract/pose_est.py
@@ -91,6 +91,11 @@ class PoseEstimation(ABC):
             KeypointIndex.MID_TAIL,
             KeypointIndex.TIP_TAIL,
         ),
+        (
+            KeypointIndex.LEFT_EAR,
+            KeypointIndex.NOSE,
+            KeypointIndex.RIGHT_EAR,
+        ),
     )
 
     # Pose based on the Envision Hydra model will have fewer keypoints,

--- a/src/jabs/ui/player_widget/overlays/pose_overlay.py
+++ b/src/jabs/ui/player_widget/overlays/pose_overlay.py
@@ -58,6 +58,9 @@ class PoseOverlay(Overlay):
         if self.parent.pose is None:
             return
 
+        zoom = self.parent.scaled_pix_width / max(crop_rect.width(), 1)
+        keypoint_size = max(1, round(_KEYPOINT_SIZE * zoom**0.8))
+
         # draw the pose estimation skeletons
         for identity in self.parent.pose.identities:
             if not all_identities and identity != self.parent.active_identity:
@@ -121,5 +124,5 @@ class PoseOverlay(Overlay):
                         painter.setBrush(color)
 
                     painter.drawEllipse(
-                        QtCore.QPoint(widget_x, widget_y), _KEYPOINT_SIZE, _KEYPOINT_SIZE
+                        QtCore.QPoint(widget_x, widget_y), keypoint_size, keypoint_size
                     )


### PR DESCRIPTION
This pull request introduces an improvement to the pose overlay rendering in the UI by making the keypoint marker size responsive to the current zoom level. Additionally, it updates the pose estimation skeleton definition to include a new connection between the ears and nose, which can enhance visualization of pose.

**Pose overlay rendering improvements:**

* The keypoint marker size in the pose overlay (`_overlay_pose` in `pose_overlay.py`) is now dynamically scaled based on the zoom level, providing better visual consistency at different zooms. (`[[1]](diffhunk://#diff-085fb2e1153f52819e4d67a4b698d68b5645db36b8fff03dafef20c403776452R61-R63)`, `[[2]](diffhunk://#diff-085fb2e1153f52819e4d67a4b698d68b5645db36b8fff03dafef20c403776452L124-R127)`)

**Pose skeleton definition update:**

* Added a new triplet (`LEFT_EAR`, `NOSE`, `RIGHT_EAR`) to the pose skeleton definition in `KeypointIndex`, allowing the visualization of a connection across the face for improved pose representation. (`[packages/jabs-core/src/jabs/core/abstract/pose_est.pyR94-R98](diffhunk://#diff-f0b6313870ab645e15d05a2d0caef42984a2c46963b740d8c756869c3ea9e96cR94-R98)`)