### PR TITLE
Add classifier mode selection to project settings dialog

### DIFF
--- a/src/jabs/project/settings_manager.py
+++ b/src/jabs/project/settings_manager.py
@@ -2,7 +2,8 @@ import json
 import typing
 
 import jabs.feature_extraction as feature_extraction
-from jabs.core.constants import CV_GROUPING_KEY
+from jabs.core.constants import CLASSIFIER_MODE_KEY, CV_GROUPING_KEY
+from jabs.core.enums.classifier_mode import DEFAULT_CLASSIFIER_MODE, ClassifierMode
 from jabs.core.enums.cv_grouping import (
     DEFAULT_CV_GROUPING_STRATEGY,
     CrossValidationGroupingStrategy,
@@ -87,6 +88,21 @@ class SettingsManager:
             Dictionary of project-level metadata, or empty dict if none exists.
         """
         return self._project_info.get("metadata", {})
+
+    @property
+    def classifier_mode(self) -> ClassifierMode:
+        """Get the classifier mode for the project.
+
+        Returns:
+            ClassifierMode: The configured classifier mode, defaulting to BINARY.
+        """
+        mode_str = self._project_info.get("settings", {}).get(
+            CLASSIFIER_MODE_KEY, DEFAULT_CLASSIFIER_MODE.value
+        )
+        try:
+            return ClassifierMode(mode_str)
+        except ValueError:
+            return DEFAULT_CLASSIFIER_MODE
 
     @property
     def cv_grouping_strategy(self) -> CrossValidationGroupingStrategy:

--- a/src/jabs/ui/settings_dialog/classifier_mode_settings_group.py
+++ b/src/jabs/ui/settings_dialog/classifier_mode_settings_group.py
@@ -8,6 +8,11 @@ from jabs.core.enums import DEFAULT_CLASSIFIER_MODE, ClassifierMode
 
 from .settings_group import SettingsGroup
 
+_CLASSIFIER_MODE_LABELS: dict[ClassifierMode, str] = {
+    ClassifierMode.BINARY: "Binary",
+    ClassifierMode.MULTICLASS: "Multi-class",
+}
+
 
 class ClassifierModeSettingsGroup(SettingsGroup):
     """Settings group for classifier mode configuration.
@@ -24,7 +29,7 @@ class ClassifierModeSettingsGroup(SettingsGroup):
         """Create the classifier mode combo box control."""
         self._mode_combo = QComboBox()
         for enum_val in ClassifierMode:
-            self._mode_combo.addItem(enum_val.value, enum_val)
+            self._mode_combo.addItem(_CLASSIFIER_MODE_LABELS[enum_val], enum_val)
         self._mode_combo.setCurrentIndex(self._mode_combo.findData(DEFAULT_CLASSIFIER_MODE))
         self._mode_combo.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
         self.add_control_row("Mode:", self._mode_combo)

--- a/src/jabs/ui/settings_dialog/classifier_mode_settings_group.py
+++ b/src/jabs/ui/settings_dialog/classifier_mode_settings_group.py
@@ -1,0 +1,86 @@
+"""Classifier mode settings group for configuring binary vs. multi-class training."""
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QComboBox, QLabel, QSizePolicy
+
+from jabs.core.constants import CLASSIFIER_MODE_KEY
+from jabs.core.enums import DEFAULT_CLASSIFIER_MODE, ClassifierMode
+
+from .settings_group import SettingsGroup
+
+
+class ClassifierModeSettingsGroup(SettingsGroup):
+    """Settings group for classifier mode configuration.
+
+    Controls whether JABS trains one binary classifier per behavior or a single
+    multi-class classifier across all behaviors simultaneously.
+    """
+
+    def __init__(self, parent=None):
+        """Initialize the classifier mode settings group."""
+        super().__init__("Classifier Mode", parent)
+
+    def _create_controls(self) -> None:
+        """Create the classifier mode combo box control."""
+        self._mode_combo = QComboBox()
+        for enum_val in ClassifierMode:
+            self._mode_combo.addItem(enum_val.value, enum_val)
+        self._mode_combo.setCurrentIndex(self._mode_combo.findData(DEFAULT_CLASSIFIER_MODE))
+        self._mode_combo.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
+        self.add_control_row("Mode:", self._mode_combo)
+
+    def _create_documentation(self) -> QLabel:
+        """Create help documentation for classifier mode settings."""
+        help_label = QLabel(self)
+        help_label.setTextFormat(Qt.TextFormat.RichText)
+        help_label.setWordWrap(True)
+        help_label.setText(
+            """
+            <h3>What is Classifier Mode?</h3>
+            <p>Classifier mode controls whether JABS trains one classifier per behavior
+            or a single multi-class classifier across all behaviors simultaneously.</p>
+
+            <ul>
+              <li><b>Binary (default):</b> Trains one independent binary classifier for 
+              the currently active behavior. Each classifier predicts whether a given
+              frame contains that behavior or not. This is the standard JABS mode and
+              works well for non-exclusive behaviors.</li>
+
+              <li><b>Multi-class:</b> Trains a single classifier across all annotated
+              behaviors at once. The classifier assigns each frame to exactly one behavior
+              class (or background). Multi-class mode is appropriate when behaviors are
+              mutually exclusive.</li>
+            </ul>
+
+            <p><b>Note:</b> In multi-class mode, behaviors must be mutually exclusive.
+            Frames labeled with more than one behavior simultaneously will cause a conflict and must be resolved before training.</p>
+            """
+        )
+        help_label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
+        return help_label
+
+    def get_values(self) -> dict:
+        """Get current classifier mode settings values.
+
+        Returns:
+            Dictionary with setting names and their current values.
+        """
+        return {CLASSIFIER_MODE_KEY: self._mode_combo.currentData()}
+
+    def set_values(self, values: dict) -> None:
+        """Set classifier mode settings values from a dictionary.
+
+        Args:
+            values: Dictionary with setting names and values to apply.
+        """
+        mode = values.get(CLASSIFIER_MODE_KEY, DEFAULT_CLASSIFIER_MODE)
+        try:
+            enum_val = ClassifierMode(mode)
+            index = self._mode_combo.findData(enum_val)
+        except ValueError:
+            index = -1
+
+        if index >= 0:
+            self._mode_combo.setCurrentIndex(index)
+        else:
+            self._mode_combo.setCurrentIndex(self._mode_combo.findData(DEFAULT_CLASSIFIER_MODE))

--- a/src/jabs/ui/settings_dialog/classifier_mode_settings_group.py
+++ b/src/jabs/ui/settings_dialog/classifier_mode_settings_group.py
@@ -1,5 +1,7 @@
 """Classifier mode settings group for configuring binary vs. multi-class training."""
 
+import logging
+
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QComboBox, QLabel, QSizePolicy
 
@@ -7,6 +9,8 @@ from jabs.core.constants import CLASSIFIER_MODE_KEY
 from jabs.core.enums import DEFAULT_CLASSIFIER_MODE, ClassifierMode
 
 from .settings_group import SettingsGroup
+
+logger = logging.getLogger(__name__)
 
 _CLASSIFIER_MODE_LABELS: dict[ClassifierMode, str] = {
     ClassifierMode.BINARY: "Binary",
@@ -88,4 +92,7 @@ class ClassifierModeSettingsGroup(SettingsGroup):
         if index >= 0:
             self._mode_combo.setCurrentIndex(index)
         else:
+            logger.warning(
+                f"Invalid classifier mode value: {mode}. Defaulting to {DEFAULT_CLASSIFIER_MODE}."
+            )
             self._mode_combo.setCurrentIndex(self._mode_combo.findData(DEFAULT_CLASSIFIER_MODE))

--- a/src/jabs/ui/settings_dialog/settings_dialog.py
+++ b/src/jabs/ui/settings_dialog/settings_dialog.py
@@ -17,6 +17,7 @@ from PySide6.QtWidgets import (
 from jabs.core.constants import APP_NAME, ORG_NAME
 from jabs.project.settings_manager import SettingsManager
 
+from .classifier_mode_settings_group import ClassifierModeSettingsGroup
 from .cross_validation_settings_group import CrossValidationSettingsGroup
 from .postprocessing_group import (
     DurationStageSettingsGroup,
@@ -236,6 +237,8 @@ class ProjectSettingsDialog(BaseSettingsDialog):
         Args:
             parent (QWidget): Parent widget for the settings groups.
         """
+        mode_group = ClassifierModeSettingsGroup(parent)
+        self._settings_groups.append(mode_group)
         cv_group = CrossValidationSettingsGroup(parent)
         self._settings_groups.append(cv_group)
 


### PR DESCRIPTION
This pull request adds a new settings group to the JABS UI for configuring classifier mode, allowing users to choose between binary and multi-class training. The most important changes are:

**Classifier Mode Settings UI:**

* Added a new `ClassifierModeSettingsGroup` class in `classifier_mode_settings_group.py` that provides a combo box for selecting between binary and multi-class classifier modes, along with detailed help documentation explaining the options.
* Integrated the new `ClassifierModeSettingsGroup` into the settings dialog by importing it and adding it to the list of settings groups in `settings_dialog.py`. 