### PR TITLE
Add Parquet feature cache format and CLI options

### DIFF
--- a/docs/user-guide/cli-tools.md
+++ b/docs/user-guide/cli-tools.md
@@ -161,7 +161,7 @@ jabs-init <project_dir> [--metadata <metadata.json>] [--force] [--processes <N>]
 - `--force`: Recompute features even if cache files already exist.
 - `--processes <N>`: Number of parallel workers to use for feature computation. If omitted, this defaults to the logical CPU count.
 - `-w WINDOW_SIZE`: Window size(s) to pre-compute. Can be repeated (e.g. `-w 2 -w 5`). Defaults to 5 if omitted.
-- `--cache-format {hdf5,parquet}`: Feature cache storage format. Defaults to `parquet`. Use `hdf5` only for compatibility with older JABS versions.
+- `--cache-format {hdf5,parquet}`: Feature cache storage format. If omitted, the existing project setting is preserved. New projects default to `parquet`; projects created before this option existed default to `hdf5`. Pass `--cache-format` explicitly only when you want to change or set the format — use `--force` alongside it to rewrite existing cache files in the new format.
 - `--skip-feature-generation`: Validate and initialize the project without computing features.
 
 **Examples:**

--- a/docs/user-guide/cli-tools.md
+++ b/docs/user-guide/cli-tools.md
@@ -20,7 +20,8 @@ See `jabs-classify COMMAND --help` for information on a specific command.
 usage: jabs-classify classify [-h] [--random-forest | --xgboost]
                             (--training TRAINING | --classifier CLASSIFIER) --input-pose
                             INPUT_POSE --out-dir OUT_DIR [--fps FPS]
-                            [--feature-dir FEATURE_DIR]
+                            [--feature-dir FEATURE_DIR] [--skip-window-cache]
+                            [--use-pose-hash]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -28,6 +29,12 @@ optional arguments:
   --feature-dir FEATURE_DIR
                         Feature cache dir. If present, look here for features before computing.
                         If features need to be computed, they will be saved here.
+  --skip-window-cache   Only cache per-frame features when --feature-dir is provided, reducing
+                        cache size at the cost of needing to re-calculate window features.
+  --use-pose-hash       Include the pose file hash as a subdirectory level in the feature cache
+                        path (e.g. <feature-dir>/<video>/<pose-hash>/<identity>). Prevents
+                        collisions when multiple pipelines share a feature cache directory and
+                        different pose files happen to share the same video name.
 
 required arguments:
   --input-pose INPUT_POSE
@@ -45,6 +52,8 @@ Classifier Input (one of the following is required):
   --classifier CLASSIFIER
                         Classifier file produced from the `jabs-classify train` command
 ```
+
+When `--feature-dir` is provided, `jabs-classify` automatically detects the existing cache format (HDF5 or Parquet) and reads from it. New cache files are always written in Parquet format. If the directory already contains an HDF5 cache, it is read as-is and any new window features are added to the existing HDF5 file — no conversion takes place.
 
 ### Train Command
 
@@ -77,6 +86,7 @@ JABS includes a script called `jabs-features`, which can be used to generate a f
 usage: jabs-features [-h] --pose-file POSE_FILE --pose-version POSE_VERSION
                             --feature-dir FEATURE_DIR [--use-cm-distances]
                             [--window-size WINDOW_SIZE] [--fps FPS]
+                            [--use-pose-hash]
 
 options:
   -h, --help            show this help message and exit
@@ -90,7 +100,12 @@ options:
   --window-size WINDOW_SIZE
                         window size for features (default none)
   --fps FPS             frames per second to use for feature calculation
+  --use-pose-hash       Include the pose file hash as a subdirectory level in the feature cache
+                        path (e.g. <feature-dir>/<video>/<pose-hash>/<identity>). Prevents
+                        collisions when a shared cache directory is used across multiple pipelines.
 ```
+
+Features are always written in Parquet format. Use `--use-pose-hash` when building a shared feature cache for multiple pipelines where video filenames may collide.
 
 ## jabs-cli
 
@@ -138,20 +153,31 @@ The `jabs-init` command initializes a JABS project directory and computes featur
 
 ```bash
 jabs-init <project_dir> [--metadata <metadata.json>] [--force] [--processes <N>]
+          [-w WINDOW_SIZE] [--cache-format {hdf5,parquet}] [--skip-feature-generation]
 ```
 
 - `<project_dir>`: Path to the JABS project directory containing video and pose files.
 - `--metadata <metadata.json>`: Optional path to a JSON metadata file describing the project and videos.
-- `--force`: Overwrite existing features and settings if present.
+- `--force`: Recompute features even if cache files already exist.
 - `--processes <N>`: Number of parallel workers to use for feature computation. If omitted, this defaults to the logical CPU count.
+- `-w WINDOW_SIZE`: Window size(s) to pre-compute. Can be repeated (e.g. `-w 2 -w 5`). Defaults to 5 if omitted.
+- `--cache-format {hdf5,parquet}`: Feature cache storage format. Defaults to `parquet`. Use `hdf5` only for compatibility with older JABS versions.
+- `--skip-feature-generation`: Validate and initialize the project without computing features.
 
-**Example:**
+**Examples:**
 
 ```bash
-jabs-init /path/to/project --metadata project_metadata.json --processes 8
+# Initialize a project with default settings (Parquet cache, window size 5)
+jabs-init /path/to/project
+
+# Initialize with metadata, 8 workers, and explicit window sizes
+jabs-init /path/to/project --metadata project_metadata.json --processes 8 -w 2 -w 5
+
+# Migrate an existing HDF5 cache to Parquet (recomputes all features)
+jabs-init /path/to/project --cache-format parquet --force
 ```
 
-See the [Project Setup Guide](project-setup.md#initialization--jabs-init) for a brief overview.
+See the [Project Setup Guide](project-setup.md#initialization--jabs-init) for a brief overview and [Feature Cache Format](project-setup.md#feature-cache-format) for migration guidance.
 
 ## jabs-cli update-pose
 

--- a/docs/user-guide/project-setup.md
+++ b/docs/user-guide/project-setup.md
@@ -166,7 +166,19 @@ This directory contains trained classifiers. Currently, these are stored in Pyth
 
 ### jabs/features
 
-This directory contains the computed features. There is one directory per project video, and within each video directory there will be one feature subdirectory per identity. Feature files are portable between machines, but JABS may need to recompute the features if they were created with a different version of JABS. Feature files contain a version attribute that is incremented when features are added or changed, or the format of the features file is changed.
+This directory contains the computed features. There is one directory per project video, and within each video directory there will be one feature subdirectory per identity:
+
+```
+jabs/features/
+└── video_name/
+    ├── 0/          ← identity 0
+    ├── 1/          ← identity 1
+    └── ...
+```
+
+Feature files are portable between machines, but JABS may need to recompute them if the version of JABS that computed them is different from the one reading them. Each cache records a feature version number that is incremented whenever features are added, changed, or the cache format is updated.
+
+JABS supports two feature cache formats: **HDF5** (the original format) and **Parquet** (the current default). See [Feature Cache Format](#feature-cache-format) below for details and migration guidance.
 
 ### jabs/predictions
 
@@ -175,3 +187,44 @@ This directory contains one HDF5 prediction file per video (e.g., `VIDEO_1.h5`).
 ### jabs/training_logs
 
 This directory contains training reports generated each time a classifier is trained. Reports are saved as Markdown files with filenames in the format `<BehaviorName>_<timestamp>_training_report.md`. Each report includes training performance metrics, cross-validation results, and feature importance rankings. These reports provide a permanent record of training sessions for documentation and comparison purposes.
+
+## Feature Cache Format
+
+JABS supports two storage formats for the computed feature cache:
+
+| Format      | Description |
+|-------------|-------------|
+| **Parquet** | The current default. A columnar format that offers faster reads and smaller file sizes. Each identity directory contains `metadata.json`, `per_frame.parquet`, and one `window_<N>.parquet` file per cached window size. |
+| **HDF5**    | The original format. All features for an identity are stored in a single `features.h5` file. Supported by all versions of JABS. |
+
+New projects created with `jabs-init` or the GUI default to Parquet. JABS automatically detects the format of existing cache files on read, so HDF5 and Parquet projects both open correctly without any manual configuration.
+
+### Changing the cache format for a project (GUI)
+
+The cache format for a project is stored in `jabs/project.json` and can be changed from the GUI at any time via **Edit > Project Settings > Feature Cache Format**.
+
+Changing the setting alone does not convert existing cache files — JABS reads whatever format is already on disk. To force the cache to be regenerated in the new format:
+
+1. Open the project in JABS.
+2. Go to **Edit > Project Settings > Feature Cache Format** and select the desired format.
+3. Click **OK** to save.
+4. Use **File > Clear Feature Cache…** to delete all existing cache files.
+5. Trigger a training or classification run. JABS will recompute and write the cache in the new format on the next cache miss.
+
+### Migrating an existing project to Parquet (CLI)
+
+Use `jabs-init` with `--cache-format parquet` and `--force` to recompute all features and write them in Parquet format:
+
+```bash
+jabs-init /path/to/project --cache-format parquet --force
+```
+
+`--force` is required to overwrite existing HDF5 cache files. Without it, `jabs-init` skips identities that already have a valid cache. The `--cache-format parquet` flag is also written to `project.json` so the GUI and subsequent CLI runs use Parquet going forward.
+
+If the project has multiple window sizes, pass them explicitly so they are all pre-computed:
+
+```bash
+jabs-init /path/to/project --cache-format parquet --force -w 2 -w 5
+```
+
+To migrate back to HDF5, use `--cache-format hdf5 --force` in the same way.

--- a/packages/jabs-core/src/jabs/core/constants.py
+++ b/packages/jabs-core/src/jabs/core/constants.py
@@ -14,6 +14,7 @@ COMPRESSION_OPTS_DEFAULT = 6
 # settings keys for project settings stored in the project.json file
 CV_GROUPING_KEY = "cv_grouping"
 CLASSIFIER_MODE_KEY = "classifier_mode"
+CACHE_FORMAT_KEY = "cache_format"
 
 # reserved behavior name used in multi-class mode to store explicit negative labels
 MULTICLASS_NONE_BEHAVIOR = "None"

--- a/packages/jabs-core/src/jabs/core/enums/cache_format.py
+++ b/packages/jabs-core/src/jabs/core/enums/cache_format.py
@@ -3,8 +3,12 @@
 from enum import Enum
 
 
-class CacheFormat(Enum):
-    """Storage format for a project's feature cache."""
+class CacheFormat(str, Enum):
+    """Storage format for a project's feature cache.
+
+    Inheriting from str allows for easy serialization to/from JSON (the enum
+    will automatically be serialized using the enum value).
+    """
 
     HDF5 = "hdf5"
     PARQUET = "parquet"

--- a/packages/jabs-io/src/jabs/io/feature_cache/parquet.py
+++ b/packages/jabs-io/src/jabs/io/feature_cache/parquet.py
@@ -58,8 +58,12 @@ def _metadata_to_dict(metadata: FeatureCacheMetadata) -> dict[str, object]:
         "identity": metadata.identity,
         "num_frames": metadata.num_frames,
         "pose_hash": metadata.pose_hash,
-        "distance_scale_factor": metadata.distance_scale_factor,
-        "avg_wall_length": metadata.avg_wall_length,
+        "distance_scale_factor": float(metadata.distance_scale_factor)
+        if metadata.distance_scale_factor is not None
+        else None,
+        "avg_wall_length": float(metadata.avg_wall_length)
+        if metadata.avg_wall_length is not None
+        else None,
         "cached_window_sizes": sorted(metadata.cached_window_sizes),
     }
 

--- a/src/jabs/feature_extraction/features.py
+++ b/src/jabs/feature_extraction/features.py
@@ -123,7 +123,7 @@ class IdentityFeatures:
         self._identity_mask = pose_est.identity_mask(identity)
         self._op_settings = _normalize_op_settings(op_settings) if op_settings else None
         self._distance_scale_factor = (
-            pose_est.cm_per_pixel if op_settings.get("cm_units", False) else None
+            pose_est.cm_per_pixel if (op_settings or {}).get("cm_units", False) else None
         )
 
         if directory is None:

--- a/src/jabs/feature_extraction/features.py
+++ b/src/jabs/feature_extraction/features.py
@@ -40,11 +40,27 @@ _FEATURE_MODULES = [BaseFeatureGroup, SocialFeatureGroup, SegmentationFeatureGro
 
 _EXTENDED_FEATURE_MODULES = [LandmarkFeatureGroup]
 
-_BASE_FILTERS = {
-    "social": SocialFeatureGroup.module_names(),
-    "segmentation": SegmentationFeatureGroup.module_names(),
+_BASE_FILTERS: dict[str, dict[str, list[str]]] = {
+    "social": {"_all": SocialFeatureGroup.module_names()},
+    "segmentation": {"_all": SegmentationFeatureGroup.module_names()},
     "static_objects": LandmarkFeatureGroup.feature_map,
 }
+
+
+def _normalize_op_settings(settings: dict) -> dict:
+    """Normalize op_settings so all _BASE_FILTERS keys map to ``dict[str, bool]``.
+
+    project.json stores simple feature-group toggles (social, segmentation) as plain
+    booleans and compound settings (static_objects) as nested dicts.  Converting the
+    plain booleans to ``{"_all": value}`` at read time means downstream filter code
+    can always iterate uniformly without branching on the value type.
+    """
+    result = dict(settings)
+    for key in _BASE_FILTERS:
+        if key in result and not isinstance(result[key], dict):
+            result[key] = {"_all": result[key]}
+    return result
+
 
 _WINDOW_FILTERS = {
     "window": list(Feature._window_operations.keys()),
@@ -97,6 +113,7 @@ class IdentityFeatures:
         op_settings: dict | None = None,
         cache_window: bool = True,
         cache_format: CacheFormat = CacheFormat.HDF5,
+        include_pose_hash: bool = False,
     ) -> None:
         self._pose_version = pose_est.format_major_version
         self._num_frames = pose_est.num_frames
@@ -104,16 +121,18 @@ class IdentityFeatures:
         self._pose_hash = pose_est.hash
         self._identity = identity
         self._identity_mask = pose_est.identity_mask(identity)
-        self._op_settings = dict(op_settings) if op_settings else None
+        self._op_settings = _normalize_op_settings(op_settings) if op_settings else None
         self._distance_scale_factor = (
             pose_est.cm_per_pixel if op_settings.get("cm_units", False) else None
         )
 
-        self._identity_feature_dir = (
-            None
-            if directory is None
-            else (Path(directory) / Path(source_file).stem / str(self._identity))
-        )
+        if directory is None:
+            self._identity_feature_dir = None
+        else:
+            base = Path(directory) / Path(source_file).stem
+            if include_pose_hash:
+                base = base / self._pose_hash
+            self._identity_feature_dir = base / str(self._identity)
         self._cache_window = cache_window
         self._compute_social_features = pose_est.format_major_version >= 3
 
@@ -142,6 +161,12 @@ class IdentityFeatures:
 
         # will hold an array that indicates if each frame is valid for this identity
         self._frame_valid = None
+
+        # per-frame features: one of these will be set after __init__ completes.
+        # _per_frame_flat is set on cache-hit paths (avoids unflatten/re-flatten).
+        # _per_frame is set on cache-miss/compute paths and lazily from _per_frame_flat.
+        self._per_frame: PerFrameFeatureMap | None = None
+        self._per_frame_flat: FlatFeatureMap | None = None
 
         # per frame features
         point_mask = pose_est.get_identity_point_mask(identity)
@@ -285,7 +310,9 @@ class IdentityFeatures:
         cache_data = self._reader.read_per_frame(self._identity_feature_dir)
         self._frame_valid = cache_data.frame_valid
         assert len(self._frame_valid) == self._num_frames
-        self._per_frame = self._unflatten_per_frame(cache_data.features)
+        # Store the flat dict directly; skip unflatten here.
+        # _per_frame is built lazily by get_per_frame() if the nested format is needed.
+        self._per_frame_flat = cache_data.features
 
     def __save_per_frame(self) -> None:
         """Save per-frame features to the cache."""
@@ -465,6 +492,17 @@ class IdentityFeatures:
 
         return final_features
 
+    def _compute_base_filter_names(self) -> list[str]:
+        """Return the list of top-level module names to remove based on op_settings."""
+        names: list[str] = []
+        for setting_name, sub_settings in self._op_settings.items():
+            if setting_name not in _BASE_FILTERS:
+                continue
+            for sub_key, enabled in sub_settings.items():
+                if not enabled:
+                    names += _BASE_FILTERS[setting_name].get(sub_key, [])
+        return names
+
     def get_per_frame(self, labels: np.ndarray | None = None) -> PerFrameFeatureMap:
         """get per frame features
 
@@ -491,6 +529,9 @@ class IdentityFeatures:
 
             features are filtered by self.op_settings
         """
+        if self._per_frame is None:
+            self._per_frame = self._unflatten_per_frame(self._per_frame_flat)
+
         if labels is None:
             features = self._per_frame
 
@@ -512,6 +553,39 @@ class IdentityFeatures:
 
         return features
 
+    def get_per_frame_flat(self, labels: np.ndarray | None = None) -> FlatFeatureMap:
+        """Return per-frame features as a flat ``{module feature: array}`` dict.
+
+        When features were loaded from a cache file the flat representation stored
+        directly at load time is returned, skipping the unflatten→flatten round-trip
+        that ``get_per_frame()`` + ``merge_per_frame_features()`` would otherwise incur.
+
+        Args:
+            labels: If provided, only return features for frames where the label is
+                not NONE and the identity exists.
+
+        Returns:
+            Flat dict mapping ``"module_name feature_name"`` keys to 1-D arrays.
+        """
+        if self._per_frame_flat is not None:
+            if labels is not None:
+                mask = (labels != jabs.project.track_labels.TrackLabels.Label.NONE) & (
+                    self._identity_mask != 0
+                )
+                flat: FlatFeatureMap = {k: v[mask] for k, v in self._per_frame_flat.items()}
+            else:
+                flat = self._per_frame_flat
+
+            if self._op_settings is not None:
+                names_to_remove = self._compute_base_filter_names()
+                if names_to_remove:
+                    flat = {
+                        k: v for k, v in flat.items() if k.split(" ", 1)[0] not in names_to_remove
+                    }
+            return flat
+
+        return self.merge_per_frame_features(self.get_per_frame(labels))
+
     def get_features(self, window_size: int) -> dict:
         """get features and corresponding frame indexes for classification
 
@@ -524,15 +598,15 @@ class IdentityFeatures:
         Returns:
             dictionary with the following keys:
 
-            'per_frame': dict with feature name as keys, numpy array as values
-            'window': dict, see _compute_window_features
+            'per_frame': flat dict with ``"module feature"`` keys, numpy array values
+            'window': flat dict with ``"module op feature"`` keys, numpy array values
             'frame_indexes': 1D np array, maps elements of per frame and window
                feature arrays back to global frame indexes
 
             features are filtered by self.op_settings
         """
-        per_frame_features = self.get_per_frame()
-        window_features = self.get_window_features(window_size)
+        per_frame_features = self.get_per_frame_flat()
+        window_features = self.merge_window_features(self.get_window_features(window_size))
 
         indexes = np.arange(self._num_frames)[self._frame_valid == 1]
 
@@ -543,7 +617,7 @@ class IdentityFeatures:
         }
 
     def _filter_base_features_by_op(self, features: PerFrameFeatureMap) -> PerFrameFeatureMap:
-        """filter either per_frame or window features by the self._op_settings
+        """Filter per-frame or window features by op_settings.
 
         Args:
             features: dict of feature data
@@ -551,20 +625,7 @@ class IdentityFeatures:
         Returns:
             filtered features
         """
-        names_to_remove = []
-        for setting_name, setting_val in self._op_settings.items():
-            # skip if no filter assigned or we want to keep
-            if setting_name not in _BASE_FILTERS or setting_val is True:
-                continue
-            # special case for static objects, which are nested in a second dict
-            if isinstance(setting_val, dict):
-                for sub_setting, sub_val in setting_val.items():
-                    if not sub_val:
-                        names_to_remove = names_to_remove + _BASE_FILTERS[setting_name].get(
-                            sub_setting, []
-                        )
-            else:
-                names_to_remove = names_to_remove + _BASE_FILTERS[setting_name]
+        names_to_remove = self._compute_base_filter_names()
         return {k: v for k, v in features.items() if k not in names_to_remove}
 
     def _filter_window_features_by_op(self, features: WindowFeatureMap) -> WindowFeatureMap:

--- a/src/jabs/project/parallel_workers.py
+++ b/src/jabs/project/parallel_workers.py
@@ -6,6 +6,7 @@ be executed by ProcessPoolExecutor workers, managed by Project.get_labeled_featu
 """
 
 import json
+import logging
 import multiprocessing
 import sys
 from pathlib import Path
@@ -15,11 +16,14 @@ import numpy as np
 import pandas as pd
 
 import jabs.feature_extraction as fe
+from jabs.core.enums import CacheFormat
 from jabs.pose_estimation import open_pose_file
 from jabs.video_reader.utilities import get_fps
 
 from .track_labels import TrackLabels
 from .video_labels import VideoLabels
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from jabs.pose_estimation import PoseEstimation
@@ -40,6 +44,7 @@ class FeatureLoadJobSpec(TypedDict):
     cache_dir: Path | None
     behavior_settings: dict[str, object]
     behavior_name: str | None
+    cache_format: str
 
 
 class CollectFeatureLoadResult(TypedDict):
@@ -131,6 +136,14 @@ def collect_labeled_features(job: FeatureLoadJobSpec) -> CollectFeatureLoadResul
             continue
 
         # Feature extraction for this identity
+        try:
+            cache_format = CacheFormat(job["cache_format"])
+        except (KeyError, ValueError):
+            logger.error(
+                "Unknown cache_format %r in job spec; falling back to HDF5",
+                job.get("cache_format"),
+            )
+            cache_format = CacheFormat.HDF5
         features = fe.IdentityFeatures(
             video,
             identity,
@@ -138,11 +151,11 @@ def collect_labeled_features(job: FeatureLoadJobSpec) -> CollectFeatureLoadResul
             pose_est,
             fps=fps,
             op_settings=behavior_settings,
+            cache_format=cache_format,
         )
 
         # Per-frame features
-        per_frame = features.get_per_frame(labels)
-        per_frame = fe.IdentityFeatures.merge_per_frame_features(per_frame)
+        per_frame = features.get_per_frame_flat(labels)
 
         # Window features
         window_size: int = behavior_settings["window_size"]

--- a/src/jabs/project/parallel_workers.py
+++ b/src/jabs/project/parallel_workers.py
@@ -136,14 +136,7 @@ def collect_labeled_features(job: FeatureLoadJobSpec) -> CollectFeatureLoadResul
             continue
 
         # Feature extraction for this identity
-        try:
-            cache_format = CacheFormat(job["cache_format"])
-        except (KeyError, ValueError):
-            logger.error(
-                "Unknown cache_format %r in job spec; falling back to HDF5",
-                job.get("cache_format"),
-            )
-            cache_format = CacheFormat.HDF5
+        cache_format = CacheFormat(job["cache_format"])
         features = fe.IdentityFeatures(
             video,
             identity,

--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -2,6 +2,7 @@ import contextlib
 import getpass
 import gzip
 import json
+import logging
 import shutil
 import sys
 from collections.abc import Callable
@@ -28,6 +29,8 @@ from .session_tracker import SessionTracker
 from .settings_manager import SettingsManager
 from .video_labels import VideoLabels
 from .video_manager import VideoManager
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from jabs.classifier import Classifier
@@ -95,6 +98,11 @@ class Project:
         self._total_project_identities = 0
         self._enabled_extended_features = {}
 
+        # Capture whether project.json exists before SettingsManager loads it.
+        # Used below to choose the cache_format default: Parquet for brand-new projects,
+        # HDF5 for existing projects that predate the setting (conservative back-compat).
+        is_new_project = not self._paths.project_file.exists()
+
         self._settings_manager = SettingsManager(self._paths)
         self._video_manager = VideoManager(self._paths, self._settings_manager, enable_video_check)
         self._feature_manager = FeatureManager(
@@ -107,10 +115,12 @@ class Project:
         if self._settings_manager.project_settings.get("defaults") != self.get_project_defaults():
             self._settings_manager.save_project_file({"defaults": self.get_project_defaults()})
 
-        # Persist cache_format for projects that predate this setting (conservative HDF5 default).
+        # Persist cache_format. New projects default to Parquet; existing projects that
+        # predate this setting default to HDF5 to preserve backward compatibility.
         existing_settings = dict(self._settings_manager.project_settings.get("settings", {}))
         if CACHE_FORMAT_KEY not in existing_settings:
-            existing_settings[CACHE_FORMAT_KEY] = CacheFormat.HDF5.value
+            default_format = CacheFormat.PARQUET if is_new_project else CacheFormat.HDF5
+            existing_settings[CACHE_FORMAT_KEY] = default_format.value
             self._settings_manager.save_project_file({"settings": existing_settings})
 
         # Shared application-level process pool for feature extraction
@@ -195,8 +205,10 @@ class Project:
         """Get the feature cache format for this project.
 
         Returns:
-            The configured ``CacheFormat``. Defaults to ``CacheFormat.HDF5`` if
-            the setting is absent or contains an unrecognized value.
+            The configured ``CacheFormat``. The setting is always written to
+            ``project.json`` on first open, so this property should never read an
+            absent value in practice. Falls back to ``CacheFormat.HDF5`` for
+            unrecognized values.
         """
         raw = self._settings_manager.project_settings.get("settings", {}).get(
             CACHE_FORMAT_KEY, CacheFormat.HDF5.value
@@ -204,6 +216,9 @@ class Project:
         try:
             return CacheFormat(raw)
         except ValueError:
+            logger.error(
+                "Unrecognized cache_format value %r in project.json; falling back to HDF5", raw
+            )
             return CacheFormat.HDF5
 
     def clear_feature_cache(self) -> None:

--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -15,7 +15,8 @@ import numpy as np
 import pandas as pd
 
 import jabs.feature_extraction as fe
-from jabs.core.enums import CrossValidationGroupingStrategy, ProjectDistanceUnit
+from jabs.core.constants import CACHE_FORMAT_KEY
+from jabs.core.enums import CacheFormat, CrossValidationGroupingStrategy, ProjectDistanceUnit
 from jabs.pose_estimation import PoseEstimation, open_pose_file
 
 from .feature_manager import FeatureManager
@@ -106,6 +107,12 @@ class Project:
         if self._settings_manager.project_settings.get("defaults") != self.get_project_defaults():
             self._settings_manager.save_project_file({"defaults": self.get_project_defaults()})
 
+        # Persist cache_format for projects that predate this setting (conservative HDF5 default).
+        existing_settings = dict(self._settings_manager.project_settings.get("settings", {}))
+        if CACHE_FORMAT_KEY not in existing_settings:
+            existing_settings[CACHE_FORMAT_KEY] = CacheFormat.HDF5.value
+            self._settings_manager.save_project_file({"settings": existing_settings})
+
         # Shared application-level process pool for feature extraction
         self._process_pool = process_pool
 
@@ -182,6 +189,40 @@ class Project:
     def project_paths(self) -> ProjectPaths:
         """get the project paths object for this project"""
         return self._paths
+
+    @property
+    def cache_format(self) -> CacheFormat:
+        """Get the feature cache format for this project.
+
+        Returns:
+            The configured ``CacheFormat``. Defaults to ``CacheFormat.HDF5`` if
+            the setting is absent or contains an unrecognized value.
+        """
+        raw = self._settings_manager.project_settings.get("settings", {}).get(
+            CACHE_FORMAT_KEY, CacheFormat.HDF5.value
+        )
+        try:
+            return CacheFormat(raw)
+        except ValueError:
+            return CacheFormat.HDF5
+
+    def clear_feature_cache(self) -> None:
+        """Delete all feature cache files for every identity in the project.
+
+        Removes HDF5 and Parquet cache files from each per-identity directory
+        under the features directory. The directories themselves are preserved.
+        The new format will be written on the next cache miss.
+        """
+        from jabs.io.feature_cache import clear_cache
+
+        feature_dir = self._paths.feature_dir
+        if not feature_dir.exists():
+            return
+        for video_dir in feature_dir.iterdir():
+            if video_dir.is_dir():
+                for identity_dir in video_dir.iterdir():
+                    if identity_dir.is_dir():
+                        clear_cache(identity_dir)
 
     def get_derived_file_paths(self, video_name: str) -> list[Path]:
         """Return a list of paths for files derived from a given video.
@@ -639,6 +680,7 @@ class Project:
                 "cache_dir": self._paths.cache_dir,
                 "behavior_settings": behavior_settings,
                 "behavior_name": behavior,
+                "cache_format": self.cache_format.value,
             }
             jobs.append(job)
 

--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -234,10 +234,20 @@ class Project:
         if not feature_dir.exists():
             return
         for video_dir in feature_dir.iterdir():
-            if video_dir.is_dir():
-                for identity_dir in video_dir.iterdir():
-                    if identity_dir.is_dir():
-                        clear_cache(identity_dir)
+            if not video_dir.is_dir():
+                continue
+            for sub in video_dir.iterdir():
+                if not sub.is_dir():
+                    continue
+                try:
+                    int(sub.name)
+                    # sub is an identity directory (flat layout: features/<video>/<id>)
+                    clear_cache(sub)
+                except ValueError:
+                    # sub is a pose-hash directory (hash layout: features/<video>/<hash>/<id>)
+                    for identity_dir in sub.iterdir():
+                        if identity_dir.is_dir():
+                            clear_cache(identity_dir)
 
     def get_derived_file_paths(self, video_name: str) -> list[Path]:
         """Return a list of paths for files derived from a given video.

--- a/src/jabs/resources/docs/user_guide/cli-tools.md
+++ b/src/jabs/resources/docs/user_guide/cli-tools.md
@@ -161,7 +161,7 @@ jabs-init <project_dir> [--metadata <metadata.json>] [--force] [--processes <N>]
 - `--force`: Recompute features even if cache files already exist.
 - `--processes <N>`: Number of parallel workers to use for feature computation. If omitted, this defaults to the logical CPU count.
 - `-w WINDOW_SIZE`: Window size(s) to pre-compute. Can be repeated (e.g. `-w 2 -w 5`). Defaults to 5 if omitted.
-- `--cache-format {hdf5,parquet}`: Feature cache storage format. Defaults to `parquet`. Use `hdf5` only for compatibility with older JABS versions.
+- `--cache-format {hdf5,parquet}`: Feature cache storage format. If omitted, the existing project setting is preserved. New projects default to `parquet`; projects created before this option existed default to `hdf5`. Pass `--cache-format` explicitly only when you want to change or set the format — use `--force` alongside it to rewrite existing cache files in the new format.
 - `--skip-feature-generation`: Validate and initialize the project without computing features.
 
 **Examples:**

--- a/src/jabs/resources/docs/user_guide/cli-tools.md
+++ b/src/jabs/resources/docs/user_guide/cli-tools.md
@@ -20,7 +20,8 @@ See `jabs-classify COMMAND --help` for information on a specific command.
 usage: jabs-classify classify [-h] [--random-forest | --xgboost]
                             (--training TRAINING | --classifier CLASSIFIER) --input-pose
                             INPUT_POSE --out-dir OUT_DIR [--fps FPS]
-                            [--feature-dir FEATURE_DIR]
+                            [--feature-dir FEATURE_DIR] [--skip-window-cache]
+                            [--use-pose-hash]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -28,6 +29,12 @@ optional arguments:
   --feature-dir FEATURE_DIR
                         Feature cache dir. If present, look here for features before computing.
                         If features need to be computed, they will be saved here.
+  --skip-window-cache   Only cache per-frame features when --feature-dir is provided, reducing
+                        cache size at the cost of needing to re-calculate window features.
+  --use-pose-hash       Include the pose file hash as a subdirectory level in the feature cache
+                        path (e.g. <feature-dir>/<video>/<pose-hash>/<identity>). Prevents
+                        collisions when multiple pipelines share a feature cache directory and
+                        different pose files happen to share the same video name.
 
 required arguments:
   --input-pose INPUT_POSE
@@ -45,6 +52,8 @@ Classifier Input (one of the following is required):
   --classifier CLASSIFIER
                         Classifier file produced from the `jabs-classify train` command
 ```
+
+When `--feature-dir` is provided, `jabs-classify` automatically detects the existing cache format (HDF5 or Parquet) and reads from it. New cache files are always written in Parquet format. If the directory already contains an HDF5 cache, it is read as-is and any new window features are added to the existing HDF5 file — no conversion takes place.
 
 ### Train Command
 
@@ -77,6 +86,7 @@ JABS includes a script called `jabs-features`, which can be used to generate a f
 usage: jabs-features [-h] --pose-file POSE_FILE --pose-version POSE_VERSION
                             --feature-dir FEATURE_DIR [--use-cm-distances]
                             [--window-size WINDOW_SIZE] [--fps FPS]
+                            [--use-pose-hash]
 
 options:
   -h, --help            show this help message and exit
@@ -90,7 +100,12 @@ options:
   --window-size WINDOW_SIZE
                         window size for features (default none)
   --fps FPS             frames per second to use for feature calculation
+  --use-pose-hash       Include the pose file hash as a subdirectory level in the feature cache
+                        path (e.g. <feature-dir>/<video>/<pose-hash>/<identity>). Prevents
+                        collisions when a shared cache directory is used across multiple pipelines.
 ```
+
+Features are always written in Parquet format. Use `--use-pose-hash` when building a shared feature cache for multiple pipelines where video filenames may collide.
 
 ## jabs-cli
 
@@ -111,7 +126,7 @@ Options:
 
 Commands:
   postprocess           Apply a postprocessing pipeline to a JABS prediction HDF5 file.
-  convert-to-nwb        Convert a JABS pose estimation file to NWB format.
+  convert-to-nwb        Convert a JABS pose HDF5 file to NWB format.
   cross-validation      Run leave-one-group-out cross-validation for a JABS project.
   export-training       Export training data for a specified behavior and JABS project directory.
   prune                 Prune unused videos from a JABS project directory.
@@ -121,8 +136,8 @@ Commands:
   update-pose           Update a JABS project to use updated pose files while remapping labels.
 ```
 
-See [NWB Export](nwb-export.md) for full documentation of the `convert-to-nwb` command
-and NWB file structure.
+For full documentation of the `convert-to-nwb` command, including output modes, subjects
+and session metadata JSON formats, and NWB file structure, see [NWB Export](nwb-export.md).
 
 To get help for a specific command, run:
 
@@ -138,20 +153,31 @@ The `jabs-init` command initializes a JABS project directory and computes featur
 
 ```bash
 jabs-init <project_dir> [--metadata <metadata.json>] [--force] [--processes <N>]
+          [-w WINDOW_SIZE] [--cache-format {hdf5,parquet}] [--skip-feature-generation]
 ```
 
 - `<project_dir>`: Path to the JABS project directory containing video and pose files.
 - `--metadata <metadata.json>`: Optional path to a JSON metadata file describing the project and videos.
-- `--force`: Overwrite existing features and settings if present.
+- `--force`: Recompute features even if cache files already exist.
 - `--processes <N>`: Number of parallel workers to use for feature computation. If omitted, this defaults to the logical CPU count.
+- `-w WINDOW_SIZE`: Window size(s) to pre-compute. Can be repeated (e.g. `-w 2 -w 5`). Defaults to 5 if omitted.
+- `--cache-format {hdf5,parquet}`: Feature cache storage format. Defaults to `parquet`. Use `hdf5` only for compatibility with older JABS versions.
+- `--skip-feature-generation`: Validate and initialize the project without computing features.
 
-**Example:**
+**Examples:**
 
 ```bash
-jabs-init /path/to/project --metadata project_metadata.json --processes 8
+# Initialize a project with default settings (Parquet cache, window size 5)
+jabs-init /path/to/project
+
+# Initialize with metadata, 8 workers, and explicit window sizes
+jabs-init /path/to/project --metadata project_metadata.json --processes 8 -w 2 -w 5
+
+# Migrate an existing HDF5 cache to Parquet (recomputes all features)
+jabs-init /path/to/project --cache-format parquet --force
 ```
 
-See the [Project Setup Guide](project-setup.md#initialization--jabs-init) for a brief overview.
+See the [Project Setup Guide](project-setup.md#initialization--jabs-init) for a brief overview and [Feature Cache Format](project-setup.md#feature-cache-format) for migration guidance.
 
 ## jabs-cli update-pose
 
@@ -406,19 +432,19 @@ are replaced with underscores). Use `--list-behaviors` to check the names in a f
 
 Each stage entry has the following fields:
 
-| Field        | Required | Description                                                                                        |
-|--------------|----------|----------------------------------------------------------------------------------------------------|
-| `stage_name` | Yes      | Name of the postprocessing stage class (see [Available stages](#available-stages) below).          |
-| `parameters` | Yes      | Object of stage-specific parameters, or `null` if the stage takes no parameters.                   |
-| `enabled`    | No       | Boolean; defaults to `true`. Set to `false` to skip the stage without removing it from the config. |
+| Field | Required | Description |
+|---|---|---|
+| `stage_name` | Yes | Name of the postprocessing stage class (see [Available stages](#available-stages) below). |
+| `parameters` | Yes | Object of stage-specific parameters, or `null` if the stage takes no parameters. |
+| `enabled` | No | Boolean; defaults to `true`. Set to `false` to skip the stage without removing it from the config. |
 
 #### Available stages
 
-| Stage name                | Parameter                         | Description                                                                                                       |
-|---------------------------|-----------------------------------|-------------------------------------------------------------------------------------------------------------------|
-| `GapInterpolationStage`   | `max_interpolation_gap` (int > 0) | Fill short gaps of no-prediction frames between behavior bouts. Gaps up to this length (inclusive) are filled in. |
-| `BoutStitchingStage`      | `max_stitch_gap` (int > 0)        | Merge behavior bouts separated by short not-behavior gaps. Gaps up to this length (inclusive) are stitched over.  |
-| `BoutDurationFilterStage` | `min_duration` (int > 0)          | Remove behavior bouts shorter than the specified duration (in frames).                                            |
+| Stage name | Parameter | Description |
+|---|---|---|
+| `GapInterpolationStage` | `max_interpolation_gap` (int > 0) | Fill short gaps of no-prediction frames between behavior bouts. Gaps up to this length (inclusive) are filled in. |
+| `BoutStitchingStage` | `max_stitch_gap` (int > 0) | Merge behavior bouts separated by short not-behavior gaps. Gaps up to this length (inclusive) are stitched over. |
+| `BoutDurationFilterStage` | `min_duration` (int > 0) | Remove behavior bouts shorter than the specified duration (in frames). |
 
 Stages are applied in the order they appear in the list. A typical pipeline runs
 `GapInterpolationStage` or `BoutStitchingStage` before `BoutDurationFilterStage` so

--- a/src/jabs/resources/docs/user_guide/project-setup.md
+++ b/src/jabs/resources/docs/user_guide/project-setup.md
@@ -166,7 +166,19 @@ This directory contains trained classifiers. Currently, these are stored in Pyth
 
 ### jabs/features
 
-This directory contains the computed features. There is one directory per project video, and within each video directory there will be one feature subdirectory per identity. Feature files are portable between machines, but JABS may need to recompute the features if they were created with a different version of JABS. Feature files contain a version attribute that is incremented when features are added or changed, or the format of the features file is changed.
+This directory contains the computed features. There is one directory per project video, and within each video directory there will be one feature subdirectory per identity:
+
+```
+jabs/features/
+└── video_name/
+    ├── 0/          ← identity 0
+    ├── 1/          ← identity 1
+    └── ...
+```
+
+Feature files are portable between machines, but JABS may need to recompute them if the version of JABS that computed them is different from the one reading them. Each cache records a feature version number that is incremented whenever features are added, changed, or the cache format is updated.
+
+JABS supports two feature cache formats: **HDF5** (the original format) and **Parquet** (the current default). See [Feature Cache Format](#feature-cache-format) below for details and migration guidance.
 
 ### jabs/predictions
 
@@ -175,3 +187,44 @@ This directory contains one HDF5 prediction file per video (e.g., `VIDEO_1.h5`).
 ### jabs/training_logs
 
 This directory contains training reports generated each time a classifier is trained. Reports are saved as Markdown files with filenames in the format `<BehaviorName>_<timestamp>_training_report.md`. Each report includes training performance metrics, cross-validation results, and feature importance rankings. These reports provide a permanent record of training sessions for documentation and comparison purposes.
+
+## Feature Cache Format
+
+JABS supports two storage formats for the computed feature cache:
+
+| Format      | Description |
+|-------------|-------------|
+| **Parquet** | The current default. A columnar format that offers faster reads and smaller file sizes. Each identity directory contains `metadata.json`, `per_frame.parquet`, and one `window_<N>.parquet` file per cached window size. |
+| **HDF5**    | The original format. All features for an identity are stored in a single `features.h5` file. Supported by all versions of JABS. |
+
+New projects created with `jabs-init` or the GUI default to Parquet. JABS automatically detects the format of existing cache files on read, so HDF5 and Parquet projects both open correctly without any manual configuration.
+
+### Changing the cache format for a project (GUI)
+
+The cache format for a project is stored in `jabs/project.json` and can be changed from the GUI at any time via **Edit > Project Settings > Feature Cache Format**.
+
+Changing the setting alone does not convert existing cache files — JABS reads whatever format is already on disk. To force the cache to be regenerated in the new format:
+
+1. Open the project in JABS.
+2. Go to **Edit > Project Settings > Feature Cache Format** and select the desired format.
+3. Click **OK** to save.
+4. Use **File > Clear Feature Cache…** to delete all existing cache files.
+5. Trigger a training or classification run. JABS will recompute and write the cache in the new format on the next cache miss.
+
+### Migrating an existing project to Parquet (CLI)
+
+Use `jabs-init` with `--cache-format parquet` and `--force` to recompute all features and write them in Parquet format:
+
+```bash
+jabs-init /path/to/project --cache-format parquet --force
+```
+
+`--force` is required to overwrite existing HDF5 cache files. Without it, `jabs-init` skips identities that already have a valid cache. The `--cache-format parquet` flag is also written to `project.json` so the GUI and subsequent CLI runs use Parquet going forward.
+
+If the project has multiple window sizes, pass them explicitly so they are all pre-computed:
+
+```bash
+jabs-init /path/to/project --cache-format parquet --force -w 2 -w 5
+```
+
+To migrate back to HDF5, use `--cache-format hdf5 --force` in the same way.

--- a/src/jabs/scripts/classify.py
+++ b/src/jabs/scripts/classify.py
@@ -17,6 +17,7 @@ from rich.progress import BarColumn, Progress, TextColumn
 
 from jabs.classifier import Classifier
 from jabs.core.constants import APP_NAME
+from jabs.core.enums import CacheFormat
 from jabs.feature_extraction import IdentityFeatures
 from jabs.pose_estimation import open_pose_file
 from jabs.project.prediction_manager import PredictionManager
@@ -46,6 +47,7 @@ def train_and_classify(
     fps=DEFAULT_FPS,
     feature_dir: str | None = None,
     cache_window: bool = False,
+    use_pose_hash: bool = False,
 ):
     """Train a classifier using the provided training file and classify behaviors in a pose file.
 
@@ -59,6 +61,7 @@ def train_and_classify(
         fps (int, optional): Frames per second for feature extraction. Defaults to DEFAULT_FPS.
         feature_dir (str or None, optional): Directory for feature cache. If provided, features are cached here.
         cache_window (bool, optional): Whether to cache window features. Defaults to False.
+        use_pose_hash (bool, optional): Include pose file hash as a subdirectory in the cache path. Defaults to False.
     """
     if not training_file_path.exists():
         sys.exit("Unable to open training data\n")
@@ -72,6 +75,7 @@ def train_and_classify(
         fps,
         feature_dir,
         cache_window,
+        use_pose_hash=use_pose_hash,
     )
 
 
@@ -83,6 +87,7 @@ def classify_pose(
     fps=DEFAULT_FPS,
     feature_dir: str | None = None,
     cache_window: bool = False,
+    use_pose_hash: bool = False,
 ):
     """Classify behaviors in a pose file using a trained classifier.
 
@@ -97,6 +102,7 @@ def classify_pose(
         fps (int, optional): Frames per second for feature extraction. Defaults to DEFAULT_FPS.
         feature_dir (str or None, optional): Directory for feature cache. If provided, features are cached here.
         cache_window (bool, optional): Whether to cache window features. Defaults to False.
+        use_pose_hash (bool, optional): Include pose file hash as a subdirectory in the cache path. Defaults to False.
     """
     pose_est = open_pose_file(input_pose_file)
     pose_stem = get_pose_stem(input_pose_file)
@@ -125,14 +131,12 @@ def classify_pose(
                 fps=fps,
                 op_settings=classifier_settings,
                 cache_window=cache_window,
+                cache_format=CacheFormat.PARQUET,
+                include_pose_hash=use_pose_hash,
             ).get_features(classifier_settings["window_size"])
 
-            per_frame_features = pd.DataFrame(
-                IdentityFeatures.merge_per_frame_features(features["per_frame"])
-            )
-            window_features = pd.DataFrame(
-                IdentityFeatures.merge_window_features(features["window"])
-            )
+            per_frame_features = pd.DataFrame(features["per_frame"])
+            window_features = pd.DataFrame(features["window"])
 
             data = Classifier.combine_data(per_frame_features, window_features)
 
@@ -283,6 +287,17 @@ def classify_main():
         default=False,
         action="store_true",
     )
+    parser.add_argument(
+        "--use-pose-hash",
+        help=(
+            "Include the pose file hash as a subdirectory level in the feature cache path "
+            "(e.g. <feature-dir>/<video>/<pose-hash>/<identity>). "
+            "Prevents collisions when multiple pipelines share a feature cache directory "
+            "and different pose files happen to share the same video name."
+        ),
+        default=False,
+        action="store_true",
+    )
 
     args = parser.parse_args(classify_args)
 
@@ -297,6 +312,7 @@ def classify_main():
             fps=args.fps,
             feature_dir=args.feature_dir,
             cache_window=not args.skip_window_cache,
+            use_pose_hash=args.use_pose_hash,
         )
     elif args.classifier is not None:
         try:
@@ -327,6 +343,7 @@ def classify_main():
             fps=args.fps,
             feature_dir=args.feature_dir,
             cache_window=not args.skip_window_cache,
+            use_pose_hash=args.use_pose_hash,
         )
 
 

--- a/src/jabs/scripts/generate_features.py
+++ b/src/jabs/scripts/generate_features.py
@@ -9,7 +9,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from jabs.core.enums import ProjectDistanceUnit
+from jabs.core.enums import CacheFormat, ProjectDistanceUnit
 from jabs.feature_extraction.features import IdentityFeatures
 from jabs.pose_estimation import open_pose_file
 from jabs.project import Project
@@ -47,6 +47,8 @@ def generate_feature_cache(args):
             fps=args.fps,
             op_settings=settings,
             cache_window=cache_window,
+            cache_format=CacheFormat.PARQUET,
+            include_pose_hash=args.use_pose_hash,
         )
         # Window features are not automatically generated.
         if cache_window:
@@ -91,6 +93,17 @@ def main():
     )
     parser.add_argument(
         "--fps", default=30, help="frames per second to use for feature calculation"
+    )
+    parser.add_argument(
+        "--use-pose-hash",
+        action="store_true",
+        dest="use_pose_hash",
+        default=False,
+        help=(
+            "include the pose file hash as a subdirectory level in the feature cache path "
+            "(e.g. <feature-dir>/<video>/<pose-hash>/<identity>); "
+            "prevents collisions when a shared cache dir is used across multiple pipelines"
+        ),
     )
     args = parser.parse_args()
 

--- a/src/jabs/scripts/initialize_project.py
+++ b/src/jabs/scripts/initialize_project.py
@@ -35,14 +35,7 @@ def generate_files_worker(params: dict):
     """worker function used for generating project feature and cache files"""
     project = params["project"]
     pose_est = project.load_pose_est(project.video_manager.video_path(params["video"]))
-    try:
-        cache_format = CacheFormat(params.get("cache_format", CacheFormat.HDF5.value))
-    except ValueError:
-        logger.error(
-            "Unknown cache_format %r in job params; falling back to HDF5",
-            params.get("cache_format"),
-        )
-        cache_format = CacheFormat.HDF5
+    cache_format = CacheFormat(params["cache_format"])
 
     features = jabs.feature_extraction.IdentityFeatures(
         params["video"],
@@ -240,7 +233,7 @@ def run_initialize_project(
     metadata_path: Path | None,
     skip_feature_generation: bool,
     project_dir: Path,
-    cache_format: CacheFormat = CacheFormat.PARQUET,
+    cache_format: CacheFormat | None = None,
 ) -> None:
     """Run project initialization and optional feature generation."""
     pool = Pool(processes)
@@ -264,11 +257,16 @@ def run_initialize_project(
         distance_unit = project.feature_manager.distance_unit
         _apply_project_metadata(project, metadata)
 
-        # Write the requested cache format to project.json so subsequent opens
-        # (including subprocess workers that re-open the project) see it.
+        # Resolve the effective cache format. For new projects, Project.__init__ already
+        # wrote CACHE_FORMAT_KEY into project.json, so existing_settings always has the key
+        # (or it's an older HDf5 project that predates this setting key, which implies HDF5).
+        # We only override it when the user explicitly passes --cache-format.
         existing_settings = dict(project.settings_manager.project_settings.get("settings", {}))
-        existing_settings[CACHE_FORMAT_KEY] = cache_format.value
-        project.settings_manager.save_project_file({"settings": existing_settings})
+        if cache_format is None:
+            cache_format = CacheFormat(existing_settings[CACHE_FORMAT_KEY])
+        else:
+            existing_settings[CACHE_FORMAT_KEY] = cache_format.value
+            project.settings_manager.save_project_file({"settings": existing_settings})
 
         # iterate over each video and try to pair it with an h5 file
         # this test is quick, don't bother to parallelize
@@ -334,7 +332,7 @@ def run_initialize_project(
     "-f",
     "--force",
     is_flag=True,
-    help="recompute features even if file already exists",
+    help="Recompute features even if they already exist. Does not change the cache format; pass --cache-format explicitly to migrate.",
 )
 @click.option(
     "-p",
@@ -381,9 +379,12 @@ def run_initialize_project(
     "--cache-format",
     "cache_format",
     type=click.Choice([f.value for f in CacheFormat], case_sensitive=False),
-    default=CacheFormat.PARQUET.value,
-    show_default=True,
-    help="Feature cache storage format to use for this project",
+    default=None,
+    help=(
+        "Feature cache storage format. If omitted, the existing project setting is "
+        "preserved; new projects default to Parquet; projects created before this "
+        "option existed default to HDF5."
+    ),
 )
 @click.argument("project_dir", type=click.Path(path_type=Path))
 def main(
@@ -393,7 +394,7 @@ def main(
     force_pixel_distances: bool,
     metadata: Path | None,
     skip_feature_generation: bool,
-    cache_format: str,
+    cache_format: str | None,
     project_dir: Path,
 ) -> None:
     """jabs-init."""
@@ -405,7 +406,7 @@ def main(
         metadata_path=metadata,
         skip_feature_generation=skip_feature_generation,
         project_dir=project_dir,
-        cache_format=CacheFormat(cache_format),
+        cache_format=CacheFormat(cache_format) if cache_format is not None else None,
     )
 
 

--- a/src/jabs/scripts/initialize_project.py
+++ b/src/jabs/scripts/initialize_project.py
@@ -7,6 +7,7 @@ overwrite existing feature H5 files.
 """
 
 import json
+import logging
 import os
 from multiprocessing import Pool
 from pathlib import Path
@@ -18,10 +19,13 @@ from rich.progress import Progress
 import jabs.feature_extraction
 import jabs.pose_estimation
 import jabs.project
-from jabs.core.enums import ProjectDistanceUnit
+from jabs.core.constants import CACHE_FORMAT_KEY
+from jabs.core.enums import CacheFormat, ProjectDistanceUnit
 from jabs.project.video_manager import VideoManager
 from jabs.schema.metadata import validate_metadata
 from jabs.video_reader import VideoReader
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_WINDOW_SIZE = 5
 DEFAULT_PROCESSES = os.cpu_count() or 1
@@ -31,6 +35,14 @@ def generate_files_worker(params: dict):
     """worker function used for generating project feature and cache files"""
     project = params["project"]
     pose_est = project.load_pose_est(project.video_manager.video_path(params["video"]))
+    try:
+        cache_format = CacheFormat(params.get("cache_format", CacheFormat.HDF5.value))
+    except ValueError:
+        logger.error(
+            "Unknown cache_format %r in job params; falling back to HDF5",
+            params.get("cache_format"),
+        )
+        cache_format = CacheFormat.HDF5
 
     features = jabs.feature_extraction.IdentityFeatures(
         params["video"],
@@ -39,6 +51,7 @@ def generate_files_worker(params: dict):
         pose_est,
         force=params["force"],
         op_settings=project.get_project_defaults(),
+        cache_format=cache_format,
     )
 
     # unlike per frame features, window features are not automatically
@@ -132,6 +145,7 @@ def compute_project_features(
     window_sizes: list[int],
     force: bool,
     pool: Pool,
+    cache_format: CacheFormat = CacheFormat.PARQUET,
 ) -> None:
     """Compute features for all identities in the project."""
 
@@ -146,6 +160,7 @@ def compute_project_features(
                     "project": project,
                     "force": force,
                     "window_sizes": window_sizes,
+                    "cache_format": cache_format.value,
                 }
 
     total_identities = project.total_project_identities
@@ -225,6 +240,7 @@ def run_initialize_project(
     metadata_path: Path | None,
     skip_feature_generation: bool,
     project_dir: Path,
+    cache_format: CacheFormat = CacheFormat.PARQUET,
 ) -> None:
     """Run project initialization and optional feature generation."""
     pool = Pool(processes)
@@ -247,6 +263,12 @@ def run_initialize_project(
         project = jabs.project.Project(project_dir, enable_session_tracker=False)
         distance_unit = project.feature_manager.distance_unit
         _apply_project_metadata(project, metadata)
+
+        # Write the requested cache format to project.json so subsequent opens
+        # (including subprocess workers that re-open the project) see it.
+        existing_settings = dict(project.settings_manager.project_settings.get("settings", {}))
+        existing_settings[CACHE_FORMAT_KEY] = cache_format.value
+        project.settings_manager.save_project_file({"settings": existing_settings})
 
         # iterate over each video and try to pair it with an h5 file
         # this test is quick, don't bother to parallelize
@@ -279,7 +301,7 @@ def run_initialize_project(
 
         # compute features in parallel, this might take a while
         if not skip_feature_generation:
-            compute_project_features(project, resolved_window_sizes, force, pool)
+            compute_project_features(project, resolved_window_sizes, force, pool, cache_format)
 
         # save window sizes to project settings
         deduped_window_sizes = set(
@@ -355,6 +377,14 @@ def run_initialize_project(
     is_flag=True,
     help="Skip feature calculation and only initialize/validate the project",
 )
+@click.option(
+    "--cache-format",
+    "cache_format",
+    type=click.Choice([f.value for f in CacheFormat], case_sensitive=False),
+    default=CacheFormat.PARQUET.value,
+    show_default=True,
+    help="Feature cache storage format to use for this project",
+)
 @click.argument("project_dir", type=click.Path(path_type=Path))
 def main(
     force: bool,
@@ -363,6 +393,7 @@ def main(
     force_pixel_distances: bool,
     metadata: Path | None,
     skip_feature_generation: bool,
+    cache_format: str,
     project_dir: Path,
 ) -> None:
     """jabs-init."""
@@ -374,6 +405,7 @@ def main(
         metadata_path=metadata,
         skip_feature_generation=skip_feature_generation,
         project_dir=project_dir,
+        cache_format=CacheFormat(cache_format),
     )
 
 

--- a/src/jabs/ui/classification_thread.py
+++ b/src/jabs/ui/classification_thread.py
@@ -1,3 +1,5 @@
+import time
+
 import numpy as np
 import pandas as pd
 from PySide6.QtCore import QThread, Signal
@@ -43,7 +45,7 @@ class ClassifyThread(QThread):
         projects with many videos.
     """
 
-    classification_complete = Signal(dict)
+    classification_complete = Signal(dict, int)
     current_status = Signal(str)
     update_progress = Signal(int)
     error_callback = Signal(Exception)
@@ -86,6 +88,7 @@ class ClassifyThread(QThread):
         current_video_predictions = {}
         current_video_probabilities = {}
         current_video_predictions_postprocessed = {}
+        t0_ns = time.perf_counter_ns()
 
         def check_termination_requested() -> None:
             if self._should_terminate:
@@ -124,18 +127,15 @@ class ClassifyThread(QThread):
                         pose_est,
                         fps=fps,
                         op_settings=project_settings,
+                        cache_format=self._project.cache_format,
                     )
                     feature_values = features.get_features(
                         project_settings.get("window_size", DEFAULT_WINDOW_SIZE)
                     )
 
                     # reformat the data in a single 2D numpy array to pass to the classifier
-                    per_frame_features = pd.DataFrame(
-                        IdentityFeatures.merge_per_frame_features(feature_values["per_frame"])
-                    )
-                    window_features = pd.DataFrame(
-                        IdentityFeatures.merge_window_features(feature_values["window"])
-                    )
+                    per_frame_features = pd.DataFrame(feature_values["per_frame"])
+                    window_features = pd.DataFrame(feature_values["window"])
                     data = self._classifier.combine_data(per_frame_features, window_features)
 
                     check_termination_requested()
@@ -178,6 +178,7 @@ class ClassifyThread(QThread):
                 self._tasks_complete += 1
                 self.update_progress.emit(self._tasks_complete)
 
+            elapsed_ms = int((time.perf_counter_ns() - t0_ns) // 1_000_000)
             # emits the predictions, probabilities, and frame indexes for the video currently loaded in
             # the video player, so that it can update the UI accordingly to show the new predictions
             self.classification_complete.emit(
@@ -185,7 +186,8 @@ class ClassifyThread(QThread):
                     "predictions": current_video_predictions,
                     "probabilities": current_video_probabilities,
                     "predictions_postprocessed": current_video_predictions_postprocessed,
-                }
+                },
+                elapsed_ms,
             )
         except Exception as e:
             # if there was an exception, we'll emit the Exception as a signal so that

--- a/src/jabs/ui/main_window/central_widget.py
+++ b/src/jabs/ui/main_window/central_widget.py
@@ -918,7 +918,7 @@ class CentralWidget(QtWidgets.QWidget):
         # start classification thread
         self._classify_thread.start()
 
-    def _classify_thread_complete(self, output: dict) -> None:
+    def _classify_thread_complete(self, output: dict, elapsed_ms: int) -> None:
         """update the gui when the classification is complete"""
         # display the new predictions
         self._predictions = output["predictions"]
@@ -926,7 +926,9 @@ class CentralWidget(QtWidgets.QWidget):
         self._predictions_postprocessed = output["predictions_postprocessed"]
         self._cleanup_progress_dialog()
         self._cleanup_classify_thread()
-        self.status_message.emit("Classification Complete", 3000)
+        self.status_message.emit(
+            f"Classification Complete. Elapsed time: {elapsed_ms / 1000:.1f}s", 20000
+        )
         self._set_prediction_vis()
 
     def _update_classify_progress(self, step: int) -> None:

--- a/src/jabs/ui/main_window/main_window.py
+++ b/src/jabs/ui/main_window/main_window.py
@@ -325,6 +325,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self._project.feature_manager.can_use_segmentation_features
         )
         self._menu_refs.clear_cache.setEnabled(True)
+        self._menu_refs.clear_feature_cache.setEnabled(True)
         available_objects = self._project.feature_manager.static_objects
         for static_object, menu_item in self._menu_refs.enable_landmark_features.items():
             if static_object in available_objects:

--- a/src/jabs/ui/main_window/menu_builder.py
+++ b/src/jabs/ui/main_window/menu_builder.py
@@ -35,9 +35,10 @@ class MenuReferences:
 
     # App menu actions
     settings_action: QtGui.QAction
-    clear_cache: QtGui.QAction
 
     # File menu actions
+    clear_cache: QtGui.QAction
+    clear_feature_cache: QtGui.QAction
     export_frame: QtGui.QAction
     export_training: QtGui.QAction
     archive_behavior: QtGui.QAction
@@ -184,13 +185,6 @@ class MenuBuilder:
         license_action.triggered.connect(self.handlers.show_license_dialog)
         menu.addAction(license_action)
 
-        # Clear cache action (store as instance variable for later reference)
-        clear_cache = QtGui.QAction("Clear Project Cache", self.main_window)
-        clear_cache.setStatusTip("Clear Project Cache")
-        clear_cache.setEnabled(False)
-        clear_cache.triggered.connect(self.handlers.clear_cache)
-        menu.addAction(clear_cache)
-
         # Quit action
         exit_action = QtGui.QAction(f" &Quit {self.app_name}", self.main_window)
         exit_action.setShortcut(QtGui.QKeySequence("Ctrl+Q"))
@@ -199,7 +193,6 @@ class MenuBuilder:
         menu.addAction(exit_action)
 
         return {
-            "clear_cache": clear_cache,
             "settings_action": settings_action,
         }
 
@@ -257,12 +250,30 @@ class MenuBuilder:
         prune_action.triggered.connect(self.handlers.show_project_pruning_dialog)
         menu.addAction(prune_action)
 
+        menu.addSeparator()
+
+        # Clear pose cache action (was "Clear Project Cache" in the app menu)
+        clear_cache = QtGui.QAction("Clear Pose Cache", self.main_window)
+        clear_cache.setStatusTip("Clear the pose estimation cache for this project")
+        clear_cache.setEnabled(False)
+        clear_cache.triggered.connect(self.handlers.clear_cache)
+        menu.addAction(clear_cache)
+
+        # Clear feature cache action
+        clear_feature_cache = QtGui.QAction("Clear Feature Cache\u2026", self.main_window)
+        clear_feature_cache.setStatusTip("Delete all cached feature files for this project")
+        clear_feature_cache.setEnabled(False)
+        clear_feature_cache.triggered.connect(self.handlers.clear_feature_cache)
+        menu.addAction(clear_feature_cache)
+
         return {
             "open_recent_menu": open_recent_menu,
             "export_frame": export_frame,
             "export_training": export_training,
             "archive_behavior": archive_behavior,
             "prune_action": prune_action,
+            "clear_cache": clear_cache,
+            "clear_feature_cache": clear_feature_cache,
         }
 
     def _build_tool_menu(self, menu: QtWidgets.QMenu) -> dict:

--- a/src/jabs/ui/main_window/menu_handlers.py
+++ b/src/jabs/ui/main_window/menu_handlers.py
@@ -227,18 +227,39 @@ class MenuHandlers:
                 )
 
     def clear_cache(self) -> None:
-        """Clear the project's feature cache after user confirmation."""
+        """Clear the project's pose cache after user confirmation."""
         result = MessageDialog.confirm(
             self.window,
-            title="Clear Cache",
-            message="Are you sure you want to clear the project cache?",
+            title="Clear Pose Cache",
+            message="Are you sure you want to clear the project pose cache?",
         )
         if result:
             self.window._project.clear_cache()
             # need to reload the current video to force the pose file to reload
             if self.window._central_widget.loaded_video:
                 self.window._central_widget.load_video(self.window._central_widget.loaded_video)
-            self.window.display_status_message("Cache cleared", duration=3000)
+            self.window.display_status_message("Pose cache cleared", duration=3000)
+
+    def clear_feature_cache(self) -> None:
+        """Clear the project's feature cache after user confirmation."""
+        from jabs.core.enums import CacheFormat
+
+        project = self.window._project
+        hint = ""
+        if project.cache_format == CacheFormat.HDF5:
+            hint = (
+                "\n\nThis project is configured to use HDF5 feature cache. "
+                "To switch to the faster Parquet format, update Cache Format "
+                "in Project Settings before clearing."
+            )
+        result = MessageDialog.confirm(
+            self.window,
+            title="Clear Feature Cache",
+            message=f"Are you sure you want to delete all cached feature files?{hint}",
+        )
+        if result:
+            project.clear_feature_cache()
+            self.window.display_status_message("Feature cache cleared", duration=3000)
 
     # ========== App Menu Handlers ==========
 

--- a/src/jabs/ui/settings_dialog/cache_format_settings_group.py
+++ b/src/jabs/ui/settings_dialog/cache_format_settings_group.py
@@ -1,5 +1,7 @@
 """Cache format settings group for configuring the project's feature cache format."""
 
+import logging
+
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QComboBox, QLabel, QSizePolicy
 
@@ -8,7 +10,9 @@ from jabs.core.enums import CacheFormat
 
 from .settings_group import SettingsGroup
 
-_DEFAULT_CACHE_FORMAT = CacheFormat.HDF5
+logger = logging.getLogger(__name__)
+
+_DEFAULT_CACHE_FORMAT = CacheFormat.PARQUET
 
 _DISPLAY_NAMES: dict[CacheFormat, str] = {
     CacheFormat.HDF5: "HDF5",
@@ -90,4 +94,9 @@ class CacheFormatSettingsGroup(SettingsGroup):
         if index >= 0:
             self._format_combo.setCurrentIndex(index)
         else:
+            logger.error(
+                "Unrecognized cache_format value %r; defaulting to %s",
+                raw,
+                _DEFAULT_CACHE_FORMAT.value,
+            )
             self._format_combo.setCurrentIndex(self._format_combo.findData(_DEFAULT_CACHE_FORMAT))

--- a/src/jabs/ui/settings_dialog/cache_format_settings_group.py
+++ b/src/jabs/ui/settings_dialog/cache_format_settings_group.py
@@ -1,0 +1,93 @@
+"""Cache format settings group for configuring the project's feature cache format."""
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QComboBox, QLabel, QSizePolicy
+
+from jabs.core.constants import CACHE_FORMAT_KEY
+from jabs.core.enums import CacheFormat
+
+from .settings_group import SettingsGroup
+
+_DEFAULT_CACHE_FORMAT = CacheFormat.HDF5
+
+_DISPLAY_NAMES: dict[CacheFormat, str] = {
+    CacheFormat.HDF5: "HDF5",
+    CacheFormat.PARQUET: "Parquet",
+}
+
+
+class CacheFormatSettingsGroup(SettingsGroup):
+    """Settings group for feature cache format configuration.
+
+    Controls whether per-identity feature caches are written as HDF5 files or
+    as Parquet files. The new format takes effect on the next cache miss; use
+    *File > Clear Feature Cache* to force regeneration in the new format.
+    """
+
+    def __init__(self, parent=None):
+        """Initialize the cache format settings group."""
+        super().__init__("Feature Cache Format", parent)
+
+    def _create_controls(self) -> None:
+        """Create the cache format combo box control."""
+        self._format_combo = QComboBox()
+        for fmt in CacheFormat:
+            self._format_combo.addItem(_DISPLAY_NAMES[fmt], fmt)
+        self._format_combo.setCurrentIndex(self._format_combo.findData(_DEFAULT_CACHE_FORMAT))
+        self._format_combo.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
+        self.add_control_row("Cache Format:", self._format_combo)
+
+    def _create_documentation(self) -> QLabel:
+        """Create help text for the cache format setting."""
+        help_label = QLabel(self)
+        help_label.setTextFormat(Qt.TextFormat.RichText)
+        help_label.setWordWrap(True)
+        help_label.setText(
+            """
+            <h3>What is the Feature Cache Format?</h3>
+            <p>JABS pre-computes features and stores them on disk so that
+            subsequent training and classification runs can skip the computation step.
+            This setting controls the file format used for that cache.</p>
+
+            <ul>
+              <li><b>HDF5:</b> The original cache format. Compatible with all versions
+              of JABS.</li>
+              <li><b>Parquet:</b> A columnar storage format that offers faster reads
+              and smaller file sizes.</li>
+            </ul>
+
+            <p><b>Note:</b> Changing this setting takes effect on the next cache miss.
+            Existing cache files are not automatically converted. To regenerate the
+            cache in the new format, use <i>File &gt; Clear Feature Cache&hellip;</i>
+            before training or classifying.</p>
+            """
+        )
+        help_label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
+        return help_label
+
+    def get_values(self) -> dict:
+        """Return the currently selected cache format.
+
+        Returns:
+            Dict with ``CACHE_FORMAT_KEY`` mapped to the selected ``CacheFormat``.
+        """
+        return {CACHE_FORMAT_KEY: self._format_combo.currentData()}
+
+    def set_values(self, values: dict) -> None:
+        """Populate the combo box from a settings dict.
+
+        Args:
+            values: Dict that may contain ``CACHE_FORMAT_KEY``. Unrecognized
+                values fall back to ``_DEFAULT_CACHE_FORMAT``.
+        """
+        raw = values.get(CACHE_FORMAT_KEY, _DEFAULT_CACHE_FORMAT)
+        try:
+            enum_val = CacheFormat(raw) if not isinstance(raw, CacheFormat) else raw
+            index = self._format_combo.findData(enum_val)
+        except ValueError:
+            index = -1
+
+        if index >= 0:
+            self._format_combo.setCurrentIndex(index)
+        else:
+            self._format_combo.setCurrentIndex(self._format_combo.findData(_DEFAULT_CACHE_FORMAT))

--- a/src/jabs/ui/settings_dialog/settings_dialog.py
+++ b/src/jabs/ui/settings_dialog/settings_dialog.py
@@ -17,6 +17,7 @@ from PySide6.QtWidgets import (
 from jabs.core.constants import APP_NAME, ORG_NAME
 from jabs.project.settings_manager import SettingsManager
 
+from .cache_format_settings_group import CacheFormatSettingsGroup
 from .cross_validation_settings_group import CrossValidationSettingsGroup
 from .postprocessing_group import (
     DurationStageSettingsGroup,
@@ -238,6 +239,8 @@ class ProjectSettingsDialog(BaseSettingsDialog):
         """
         cv_group = CrossValidationSettingsGroup(parent)
         self._settings_groups.append(cv_group)
+        cache_format_group = CacheFormatSettingsGroup(parent)
+        self._settings_groups.append(cache_format_group)
 
 
 class PostprocessingSettingsDialog(BaseSettingsDialog):

--- a/tests/project/test_initialize_project.py
+++ b/tests/project/test_initialize_project.py
@@ -1,6 +1,7 @@
 from click.testing import CliRunner
 
 import jabs.scripts.initialize_project as initialize_project
+from jabs.core.enums import CacheFormat
 
 
 def test_jabs_init_click_parses_all_existing_options(tmp_path, monkeypatch):
@@ -20,6 +21,7 @@ def test_jabs_init_click_parses_all_existing_options(tmp_path, monkeypatch):
         metadata_path,
         skip_feature_generation,
         project_dir,
+        cache_format,
     ):
         captured.update(
             {
@@ -30,6 +32,7 @@ def test_jabs_init_click_parses_all_existing_options(tmp_path, monkeypatch):
                 "metadata_path": metadata_path,
                 "skip_feature_generation": skip_feature_generation,
                 "project_dir": project_dir,
+                "cache_format": cache_format,
             }
         )
 
@@ -54,6 +57,8 @@ def test_jabs_init_click_parses_all_existing_options(tmp_path, monkeypatch):
             "--metadata",
             str(metadata_path),
             "--skip-feature-generation",
+            "--cache-format",
+            "hdf5",
             str(project_dir),
         ],
     )
@@ -67,6 +72,7 @@ def test_jabs_init_click_parses_all_existing_options(tmp_path, monkeypatch):
         "metadata_path": metadata_path,
         "skip_feature_generation": True,
         "project_dir": project_dir,
+        "cache_format": CacheFormat.HDF5,
     }
 
 
@@ -85,6 +91,7 @@ def test_jabs_init_click_uses_existing_defaults(tmp_path, monkeypatch):
         metadata_path,
         skip_feature_generation,
         project_dir,
+        cache_format,
     ):
         captured.update(
             {
@@ -95,6 +102,7 @@ def test_jabs_init_click_uses_existing_defaults(tmp_path, monkeypatch):
                 "metadata_path": metadata_path,
                 "skip_feature_generation": skip_feature_generation,
                 "project_dir": project_dir,
+                "cache_format": cache_format,
             }
         )
 
@@ -116,6 +124,7 @@ def test_jabs_init_click_uses_existing_defaults(tmp_path, monkeypatch):
         "metadata_path": None,
         "skip_feature_generation": False,
         "project_dir": project_dir,
+        "cache_format": CacheFormat.PARQUET,
     }
 
 

--- a/tests/project/test_initialize_project.py
+++ b/tests/project/test_initialize_project.py
@@ -77,7 +77,7 @@ def test_jabs_init_click_parses_all_existing_options(tmp_path, monkeypatch):
 
 
 def test_jabs_init_click_uses_existing_defaults(tmp_path, monkeypatch):
-    """The Click entrypoint should keep the legacy default option values."""
+    """Check defaults passed by Click entrypoint."""
     project_dir = tmp_path / "project"
 
     captured = {}
@@ -124,7 +124,7 @@ def test_jabs_init_click_uses_existing_defaults(tmp_path, monkeypatch):
         "metadata_path": None,
         "skip_feature_generation": False,
         "project_dir": project_dir,
-        "cache_format": CacheFormat.PARQUET,
+        "cache_format": None,
     }
 
 

--- a/tests/project/test_project_cache_format.py
+++ b/tests/project/test_project_cache_format.py
@@ -41,12 +41,12 @@ def _project_settings(tmp_path: Path) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def test_new_project_defaults_to_hdf5(tmp_path: Path) -> None:
-    """A brand-new project gets cache_format=hdf5 written to project.json."""
+def test_new_project_defaults_to_parquet(tmp_path: Path) -> None:
+    """A brand-new project gets cache_format=parquet written to project.json."""
     project = _make_project(tmp_path)
 
-    assert project.cache_format == CacheFormat.HDF5
-    assert _project_settings(tmp_path).get(CACHE_FORMAT_KEY) == CacheFormat.HDF5.value
+    assert project.cache_format == CacheFormat.PARQUET
+    assert _project_settings(tmp_path).get(CACHE_FORMAT_KEY) == CacheFormat.PARQUET.value
 
 
 def test_existing_project_without_cache_format_migrates_to_hdf5(tmp_path: Path) -> None:
@@ -82,13 +82,12 @@ def test_existing_project_with_cache_format_parquet_is_preserved(tmp_path: Path)
 # ---------------------------------------------------------------------------
 
 
-def test_cache_format_returns_hdf5_enum(tmp_path: Path) -> None:
+def test_cache_format_returns_enum_instance(tmp_path: Path) -> None:
     """cache_format returns a CacheFormat instance, not a bare string."""
     project = _make_project(tmp_path)
 
     result = project.cache_format
     assert isinstance(result, CacheFormat)
-    assert result is CacheFormat.HDF5
 
 
 def test_cache_format_falls_back_to_hdf5_for_unknown_value(tmp_path: Path) -> None:
@@ -155,3 +154,24 @@ def test_clear_feature_cache_no_op_when_feature_dir_empty(tmp_path: Path) -> Non
     # feature_dir is created by Project.__init__; it just has no identity subdirs yet
     assert project.feature_dir.exists()
     project.clear_feature_cache()  # should not raise
+
+
+def test_clear_feature_cache_handles_pose_hash_layout(tmp_path: Path) -> None:
+    """clear_feature_cache removes cache files when pose-hash subdirectory is present.
+
+    Hash layout: features/<video>/<pose_hash>/<identity>/
+    """
+    project = _make_project(tmp_path)
+
+    pose_hash = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"  # 40-char hex
+    identity_dir = project.feature_dir / "video_stem" / pose_hash / "0"
+    identity_dir.mkdir(parents=True)
+    (identity_dir / "metadata.json").write_text("{}")
+    (identity_dir / "per_frame.parquet").write_bytes(b"stub")
+    (identity_dir / "window_5.parquet").write_bytes(b"stub")
+
+    project.clear_feature_cache()
+
+    assert not (identity_dir / "metadata.json").exists()
+    assert not any(identity_dir.glob("*.parquet"))
+    assert identity_dir.exists()  # directories preserved

--- a/tests/project/test_project_cache_format.py
+++ b/tests/project/test_project_cache_format.py
@@ -1,0 +1,157 @@
+"""Tests for Project.cache_format property and related feature cache integration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from jabs.core.constants import CACHE_FORMAT_KEY
+from jabs.core.enums import CacheFormat
+from jabs.project import Project
+
+
+@pytest.fixture(autouse=True, scope="module")
+def patch_session_tracker():
+    """Suppress SessionTracker side effects."""
+    with patch("jabs.project.session_tracker.SessionTracker.__del__", return_value=None):
+        yield
+
+
+def _make_project(tmp_path: Path) -> Project:
+    """Create a minimal Project in tmp_path with no videos or pose files."""
+    return Project(
+        tmp_path,
+        enable_video_check=False,
+        enable_session_tracker=False,
+        validate_project_dir=False,
+    )
+
+
+def _project_settings(tmp_path: Path) -> dict:
+    """Read the settings dict from the project.json on disk."""
+    project_file = tmp_path / "jabs" / "project.json"
+    return json.loads(project_file.read_text()).get("settings", {})
+
+
+# ---------------------------------------------------------------------------
+# Default / migration behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_new_project_defaults_to_hdf5(tmp_path: Path) -> None:
+    """A brand-new project gets cache_format=hdf5 written to project.json."""
+    project = _make_project(tmp_path)
+
+    assert project.cache_format == CacheFormat.HDF5
+    assert _project_settings(tmp_path).get(CACHE_FORMAT_KEY) == CacheFormat.HDF5.value
+
+
+def test_existing_project_without_cache_format_migrates_to_hdf5(tmp_path: Path) -> None:
+    """A project.json that predates cache_format gets hdf5 written on open."""
+    jabs_dir = tmp_path / "jabs"
+    jabs_dir.mkdir(parents=True)
+    project_file = jabs_dir / "project.json"
+    # Write a project.json that has no cache_format key at all.
+    project_file.write_text(json.dumps({"behavior": {}, "window_sizes": [5]}))
+
+    project = _make_project(tmp_path)
+
+    assert project.cache_format == CacheFormat.HDF5
+    assert _project_settings(tmp_path).get(CACHE_FORMAT_KEY) == CacheFormat.HDF5.value
+
+
+def test_existing_project_with_cache_format_parquet_is_preserved(tmp_path: Path) -> None:
+    """Opening a project that already has cache_format=parquet preserves it."""
+    jabs_dir = tmp_path / "jabs"
+    jabs_dir.mkdir(parents=True)
+    project_file = jabs_dir / "project.json"
+    project_file.write_text(
+        json.dumps({"behavior": {}, "settings": {CACHE_FORMAT_KEY: "parquet"}})
+    )
+
+    project = _make_project(tmp_path)
+
+    assert project.cache_format == CacheFormat.PARQUET
+
+
+# ---------------------------------------------------------------------------
+# cache_format property — value handling
+# ---------------------------------------------------------------------------
+
+
+def test_cache_format_returns_hdf5_enum(tmp_path: Path) -> None:
+    """cache_format returns a CacheFormat instance, not a bare string."""
+    project = _make_project(tmp_path)
+
+    result = project.cache_format
+    assert isinstance(result, CacheFormat)
+    assert result is CacheFormat.HDF5
+
+
+def test_cache_format_falls_back_to_hdf5_for_unknown_value(tmp_path: Path) -> None:
+    """An unrecognised cache_format value in project.json falls back to HDF5."""
+    jabs_dir = tmp_path / "jabs"
+    jabs_dir.mkdir(parents=True)
+    project_file = jabs_dir / "project.json"
+    project_file.write_text(
+        json.dumps({"behavior": {}, "settings": {CACHE_FORMAT_KEY: "unknown_format"}})
+    )
+
+    project = _make_project(tmp_path)
+
+    assert project.cache_format == CacheFormat.HDF5
+
+
+def test_clear_feature_cache_removes_hdf5_files(tmp_path: Path) -> None:
+    """clear_feature_cache removes features.h5 from all identity dirs."""
+    project = _make_project(tmp_path)
+
+    identity_dir = project.feature_dir / "video_stem" / "0"
+    identity_dir.mkdir(parents=True)
+    (identity_dir / "features.h5").write_bytes(b"stub")
+
+    project.clear_feature_cache()
+
+    assert not (identity_dir / "features.h5").exists()
+
+
+def test_clear_feature_cache_removes_parquet_files(tmp_path: Path) -> None:
+    """clear_feature_cache removes Parquet cache files from all identity dirs."""
+    project = _make_project(tmp_path)
+
+    identity_dir = project.feature_dir / "video_stem" / "0"
+    identity_dir.mkdir(parents=True)
+    (identity_dir / "metadata.json").write_text("{}")
+    (identity_dir / "per_frame.parquet").write_bytes(b"stub")
+    (identity_dir / "window_5.parquet").write_bytes(b"stub")
+
+    project.clear_feature_cache()
+
+    assert not (identity_dir / "metadata.json").exists()
+    assert not any(identity_dir.glob("*.parquet"))
+
+
+def test_clear_feature_cache_preserves_directory_structure(tmp_path: Path) -> None:
+    """clear_feature_cache removes files but leaves directories intact."""
+    project = _make_project(tmp_path)
+
+    identity_dir = project.feature_dir / "video_stem" / "0"
+    identity_dir.mkdir(parents=True)
+    (identity_dir / "features.h5").write_bytes(b"stub")
+
+    project.clear_feature_cache()
+
+    assert identity_dir.exists()
+    assert (project.feature_dir / "video_stem").exists()
+
+
+def test_clear_feature_cache_no_op_when_feature_dir_empty(tmp_path: Path) -> None:
+    """clear_feature_cache does not raise when the features directory has no cache files."""
+    project = _make_project(tmp_path)
+
+    # feature_dir is created by Project.__init__; it just has no identity subdirs yet
+    assert project.feature_dir.exists()
+    project.clear_feature_cache()  # should not raise


### PR DESCRIPTION
This pull request adds support for Parquet as the default cache format, and enhance cache directory structure options. The changes clarify and expand documentation for feature cache formats and migration, add new CLI options for cache management.

For large projects, testing shows that by using the more efficient Parquet feature cache format, the classification loop in the GUI can see a ~40% speedup.

**Documentation improvements:**

* Expanded user and project setup guides to document both HDF5 and Parquet feature cache formats, migration steps, and cache directory structure, including new CLI options like `--use-pose-hash`, `--skip-window-cache`, and `--cache-format`. 

**Feature cache and CLI enhancements:**

* Added `--use-pose-hash` option to CLI tools and feature extraction to support more robust cache directory layouts and avoid filename collisions in shared caches. 
* Updated `jabs-init` to support explicit cache format selection (`--cache-format {hdf5,parquet}`).

**Core code and serialization updates:**

* Changed `CacheFormat` enum to inherit from `str` for easier JSON serialization and added `CACHE_FORMAT_KEY` constant for project settings. 
* Improved Parquet cache metadata serialization to ensure values are always stored as floats or None.

**Feature extraction and performance improvements:**

* Refactored feature extraction code to normalize operation settings, optimize per-frame feature handling, and add efficient flat feature access methods, reducing unnecessary data transformations. 
* Consolidated and simplified feature filtering logic for both per-frame and window features based on operation settings. 