### PR TITLE
Add shortcut to select all frames in current behavior bout

### DIFF
--- a/docs/user-guide/keyboard-shortcuts.md
+++ b/docs/user-guide/keyboard-shortcuts.md
@@ -13,7 +13,8 @@
 
 | Action                        | Shortcut   |
 |-------------------------------|------------|
-| Play / Pause video            | Space bar  |
+| Play / Pause video            | Space bar        |
+| Play current bout             | Shift+Space bar  |
 | Previous / Next frame         | ← / →      |
 | Move forward / back 10 frames | ↑ / ↓      |
 | Previous / Next video         | , / .      |

--- a/docs/user-guide/keyboard-shortcuts.md
+++ b/docs/user-guide/keyboard-shortcuts.md
@@ -2,41 +2,42 @@
 
 ## Application
 
-| Action                      | Shortcut      |
-| --------------------------- | ------------- |
-| Quit JABS                   | Ctrl+Q / ⌘Q   |
-| Export current frame        | Ctrl+E / ⌘E   |
-| Export training data        | Ctrl+T / ⌘T   |
-| Open behavior search dialog | Ctrl+F / ⌘F   |
+| Action                      | Shortcut    |
+|-----------------------------|-------------|
+| Quit JABS                   | Ctrl+Q / ⌘Q |
+| Export current frame        | Ctrl+E / ⌘E |
+| Export training data        | Ctrl+T / ⌘T |
+| Open behavior search dialog | Ctrl+F / ⌘F |
 
 ## Video Navigation
 
-| Action                        | Shortcut  |
-| ----------------------------- | --------- |
-| Play / Pause video            | Space bar |
-| Previous / Next frame         | ← / →     |
-| Move forward / back 10 frames | ↑ / ↓     |
-| Previous / Next video         | , / .     |
+| Action                        | Shortcut   |
+|-------------------------------|------------|
+| Play / Pause video            | Space bar  |
+| Previous / Next frame         | ← / →      |
+| Move forward / back 10 frames | ↑ / ↓      |
+| Previous / Next video         | , / .      |
 
 ## Labeling
 
-| Action                                   | Shortcut       |
-| ---------------------------------------- | -------------- |
-| Start select mode                        | z, x, c        |
-| Label selection as behavior              | z              |
-| Clear labels from selection              | x              |
-| Label selection as not behavior          | c              |
-| Exit select mode without making a change | Esc            |
-| Select all frames                        | Ctrl+A / ⌘A   |
+| Action                                   | Shortcut           |
+|------------------------------------------|--------------------|
+| Start select mode                        | z, x, c            |
+| Label selection as behavior              | z                  |
+| Clear labels from selection              | x                  |
+| Label selection as not behavior          | c                  |
+| Exit select mode without making a change | Esc                |
+| Select all frames                        | Ctrl+A / ⌘A        |
+| Select current bout                      | Ctrl+Shift+A / ⌘⇧A |
 
 ## Identity & Overlays
 
 | Action                            | Shortcut          |
-| --------------------------------- | ----------------- |
+|-----------------------------------|-------------------|
 | Switch to next / previous subject | Shift+↑ / Shift+↓ |
 | Toggle track overlay              | t                 |
 | Toggle pose overlay               | p                 |
 | Toggle landmark overlay           | l                 |
-| Toggle Minimalist Identity Labels | Ctrl+I / ⌘I   |
+| Toggle Minimalist Identity Labels | Ctrl+I / ⌘I       |
 
 > **Note:** Next/previous subject order follows the "Identity Selection" dropdown ordering.

--- a/src/jabs/resources/docs/user_guide/keyboard-shortcuts.md
+++ b/src/jabs/resources/docs/user_guide/keyboard-shortcuts.md
@@ -3,7 +3,7 @@
 ## Application
 
 | Action                      | Shortcut      |
-| --------------------------- | ------------- |
+|-----------------------------|---------------|
 | Quit JABS                   | Ctrl+Q / ⌘Q   |
 | Export current frame        | Ctrl+E / ⌘E   |
 | Export training data        | Ctrl+T / ⌘T   |
@@ -11,32 +11,33 @@
 
 ## Video Navigation
 
-| Action                        | Shortcut  |
-| ----------------------------- | --------- |
-| Play / Pause video            | Space bar |
-| Previous / Next frame         | ← / →     |
-| Move forward / back 10 frames | ↑ / ↓     |
-| Previous / Next video         | , / .     |
+| Action                        | Shortcut    |
+|-------------------------------|-------------|
+| Play / Pause video            | Space bar   |
+| Previous / Next frame         | ← / →       |
+| Move forward / back 10 frames | ↑ / ↓       |
+| Previous / Next video         | , / .       |
 
 ## Labeling
 
-| Action                                   | Shortcut       |
-| ---------------------------------------- | -------------- |
-| Start select mode                        | z, x, c        |
-| Label selection as behavior              | z              |
-| Clear labels from selection              | x              |
-| Label selection as not behavior          | c              |
-| Exit select mode without making a change | Esc            |
-| Select all frames                        | Ctrl+A / ⌘A   |
+| Action                                   | Shortcut           |
+|------------------------------------------|--------------------|
+| Start select mode                        | z, x, c            |
+| Label selection as behavior              | z                  |
+| Clear labels from selection              | x                  |
+| Label selection as not behavior          | c                  |
+| Exit select mode without making a change | Esc                |
+| Select all frames                        | Ctrl+A / ⌘A        |
+| Select current bout                      | Ctrl+Shift+A / ⌘⇧A |
 
 ## Identity & Overlays
 
 | Action                            | Shortcut          |
-| --------------------------------- | ----------------- |
+|-----------------------------------|-------------------|
 | Switch to next / previous subject | Shift+↑ / Shift+↓ |
 | Toggle track overlay              | t                 |
 | Toggle pose overlay               | p                 |
 | Toggle landmark overlay           | l                 |
-| Toggle Minimalist Identity Labels | Ctrl+I / ⌘I   |
+| Toggle Minimalist Identity Labels | Ctrl+I / ⌘I       |
 
 > **Note:** Next/previous subject order follows the "Identity Selection" dropdown ordering.

--- a/src/jabs/resources/docs/user_guide/keyboard-shortcuts.md
+++ b/src/jabs/resources/docs/user_guide/keyboard-shortcuts.md
@@ -13,7 +13,8 @@
 
 | Action                        | Shortcut    |
 |-------------------------------|-------------|
-| Play / Pause video            | Space bar   |
+| Play / Pause video            | Space bar        |
+| Play current bout             | Shift+Space bar  |
 | Previous / Next frame         | ← / →       |
 | Move forward / back 10 frames | ↑ / ↓       |
 | Previous / Next video         | , / .       |

--- a/src/jabs/ui/main_window/central_widget.py
+++ b/src/jabs/ui/main_window/central_widget.py
@@ -571,7 +571,6 @@ class CentralWidget(QtWidgets.QWidget):
         ):
             return
 
-        current_frame = self._player_widget.current_frame
         identity = self._controls.current_identity_index
         behavior = self._controls.current_behavior
 
@@ -583,22 +582,11 @@ class CentralWidget(QtWidgets.QWidget):
         if labels is None or len(labels) == 0:
             return
 
-        current_label = labels[current_frame]
-        if current_label not in (
-            TrackLabels.Label.BEHAVIOR.value,
-            TrackLabels.Label.NOT_BEHAVIOR.value,
-        ):
+        bout = self._get_bout_range(labels, self._player_widget.current_frame)
+        if bout is None:
             return
 
-        start = current_frame
-        while start > 0 and labels[start - 1] == current_label:
-            start -= 1
-
-        num_frames = len(labels)
-        end = current_frame
-        while end < num_frames and labels[end] == current_label:
-            end += 1
-        end -= 1
+        start, end = bout
 
         if not self._controls.select_button_is_checked:
             self._controls.toggle_select_button()
@@ -607,6 +595,36 @@ class CentralWidget(QtWidgets.QWidget):
         self._selection_start = start
         self._selection_end = end
         self._stacked_timeline.start_selection(start, end)
+
+    @staticmethod
+    def _get_bout_range(labels: np.ndarray, current_frame: int) -> tuple[int, int] | None:
+        """Return the (start, end) frame indices of the labeled bout at current_frame.
+
+        Args:
+            labels: Per-frame label array for a single identity/behavior track.
+            current_frame: Index of the current frame.
+
+        Returns:
+            Inclusive (start, end) frame indices, or None if the current frame is
+            not labeled BEHAVIOR or NOT_BEHAVIOR.
+        """
+        current_label = labels[current_frame]
+        if current_label not in (
+            TrackLabels.Label.BEHAVIOR.value,
+            TrackLabels.Label.NOT_BEHAVIOR.value,
+        ):
+            return None
+
+        start = current_frame
+        while start > 0 and labels[start - 1] == current_label:
+            start -= 1
+
+        end = current_frame
+        while end < len(labels) and labels[end] == current_label:
+            end += 1
+        end -= 1
+
+        return start, end
 
     @property
     def _curr_selection_end(self) -> int:
@@ -1331,27 +1349,11 @@ class CentralWidget(QtWidgets.QWidget):
         if labels is None or len(labels) == 0:
             return
 
-        current_label = labels[current_frame]
-        # Only play if current label is BEHAVIOR or NOT_BEHAVIOR
-        if current_label not in (
-            TrackLabels.Label.BEHAVIOR.value,
-            TrackLabels.Label.NOT_BEHAVIOR.value,
-        ):
+        bout = self._get_bout_range(labels, current_frame)
+        if bout is None:
             return
 
-        # Find start of bout
-        start = current_frame
-        while start > 0 and labels[start - 1] == current_label:
-            start -= 1
-
-        # Find end of bout (inclusive)
-        num_frames = len(labels)
-        end = current_frame
-        while end < num_frames and labels[end] == current_label:
-            end += 1
-        end -= 1
-
-        self._player_widget.play_range(start, end)
+        self._player_widget.play_range(*bout)
 
     def _on_timeline_annotation_button_clicked(self) -> None:
         """Handle the event when the button to create a new timeline annotation is clicked.

--- a/src/jabs/ui/main_window/central_widget.py
+++ b/src/jabs/ui/main_window/central_widget.py
@@ -559,6 +559,55 @@ class CentralWidget(QtWidgets.QWidget):
                 self._selection_end = num_frames - 1
                 self._stacked_timeline.start_selection(self._selection_start, self._selection_end)
 
+    def select_current_bout(self) -> None:
+        """Select all frames in the current bout (contiguous labeled run at the current frame).
+
+        Only activates when the current frame has a BEHAVIOR or NOT_BEHAVIOR label.
+        """
+        if (
+            not self._controls.select_button_enabled
+            or self._labels is None
+            or self._pose_est is None
+        ):
+            return
+
+        current_frame = self._player_widget.current_frame
+        identity = self._controls.current_identity_index
+        behavior = self._controls.current_behavior
+
+        if identity == -1 or behavior == "":
+            return
+
+        labels = self._labels.get_track_labels(str(identity), behavior).get_labels()
+
+        if labels is None or len(labels) == 0:
+            return
+
+        current_label = labels[current_frame]
+        if current_label not in (
+            TrackLabels.Label.BEHAVIOR.value,
+            TrackLabels.Label.NOT_BEHAVIOR.value,
+        ):
+            return
+
+        start = current_frame
+        while start > 0 and labels[start - 1] == current_label:
+            start -= 1
+
+        num_frames = len(labels)
+        end = current_frame
+        while end < num_frames and labels[end] == current_label:
+            end += 1
+        end -= 1
+
+        if not self._controls.select_button_is_checked:
+            self._controls.toggle_select_button()
+
+        self._controls.enable_label_buttons()
+        self._selection_start = start
+        self._selection_end = end
+        self._stacked_timeline.start_selection(start, end)
+
     @property
     def _curr_selection_end(self) -> int:
         """Get the end of the current selection.

--- a/src/jabs/ui/main_window/menu_builder.py
+++ b/src/jabs/ui/main_window/menu_builder.py
@@ -661,3 +661,8 @@ class MenuBuilder:
         select_all_action.setShortcut(QtGui.QKeySequence.StandardKey.SelectAll)
         select_all_action.triggered.connect(self.handlers.handle_select_all)
         self.main_window.addAction(select_all_action)
+
+        select_bout_action = QtGui.QAction(self.main_window)
+        select_bout_action.setShortcut(QtGui.QKeySequence("Ctrl+Shift+A"))
+        select_bout_action.triggered.connect(self.handlers.handle_select_current_bout)
+        self.main_window.addAction(select_bout_action)

--- a/src/jabs/ui/main_window/menu_handlers.py
+++ b/src/jabs/ui/main_window/menu_handlers.py
@@ -562,6 +562,10 @@ class MenuHandlers:
         """Handle Ctrl+A / Cmd+A keyboard shortcut."""
         self.window._central_widget.select_all()
 
+    def handle_select_current_bout(self) -> None:
+        """Handle Ctrl+Shift+A / Cmd+Shift+A keyboard shortcut."""
+        self.window._central_widget.select_current_bout()
+
     def on_bbox_overlay_support_changed(self, supported: bool) -> None:
         """Enable/disable the bounding box overlay menu item based on whether the current pose supports it.
 

--- a/tests/ui/test_menu_handlers.py
+++ b/tests/ui/test_menu_handlers.py
@@ -194,6 +194,24 @@ def test_export_frame_restores_existing_directory(monkeypatch, tmp_path, handler
     assert captured["initial_path"] == str(tmp_path / "video_frame000042.png")
 
 
+def test_handle_select_all_delegates_to_central_widget():
+    """handle_select_all() calls select_all() on the central widget."""
+    central = SimpleNamespace(select_all=MagicMock())
+    window = SimpleNamespace(_central_widget=central)
+    handler = MenuHandlers(window)
+    handler.handle_select_all()
+    central.select_all.assert_called_once_with()
+
+
+def test_handle_select_current_bout_delegates_to_central_widget():
+    """handle_select_current_bout() calls select_current_bout() on the central widget."""
+    central = SimpleNamespace(select_current_bout=MagicMock())
+    window = SimpleNamespace(_central_widget=central)
+    handler = MenuHandlers(window)
+    handler.handle_select_current_bout()
+    central.select_current_bout.assert_called_once_with()
+
+
 def test_export_frame_missing_directory_falls_back(monkeypatch, handler_setup):
     """A missing saved directory falls back to the bare suggested filename."""
     handler, window, player = handler_setup


### PR DESCRIPTION
This pull request adds a new "Select current bout" feature, which allows users to quickly select all frames in the current labeled bout (a contiguous run of BEHAVIOR or NOT_BEHAVIOR labels) using a keyboard shortcut. (current bout means a behavior or not behavior bout overlapping the current frame for the currently selected mouse) It also updates documentation and UI to reflect this new functionality and improves the formatting of the keyboard shortcuts documentation tables.

Feature addition:

* Added a `select_current_bout` method to `CentralWidget` that selects all frames in the current labeled bout at the current frame, and only activates when the frame has a BEHAVIOR or NOT_BEHAVIOR label.
* Introduced a new keyboard shortcut (Ctrl+Shift+A / ⌘⇧A) to trigger the "Select current bout" action, and connected it to the new handler in the menu system.

Documentation updates:

* Added the "Select current bout" shortcut to both `docs/user-guide/keyboard-shortcuts.md` and `src/jabs/resources/docs/user_guide/keyboard-shortcuts.md`. 
* Improved table formatting in the keyboard shortcuts documentation for better readability and consistency. 