### PR TITLE
Change button label to 'None' in multi-class mode

### DIFF
--- a/src/jabs/project/video_labels.py
+++ b/src/jabs/project/video_labels.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any
 
 from jabs.pose_estimation import PoseEstimation
@@ -91,6 +92,17 @@ class VideoLabels:
         for identity, behaviors in self._identity_labels.items():
             for behavior, track_labels in behaviors.items():
                 yield identity, behavior, track_labels
+
+    def iter_behavior_labels(self, identity: str) -> Iterator[tuple[str, TrackLabels]]:
+        """Yield ``(behavior, TrackLabels)`` for every labeled track belonging to an identity.
+
+        Args:
+            identity: String representation of the identity to iterate over.
+
+        Yields:
+            Tuples of (behavior name, TrackLabels) for each labeled track.
+        """
+        yield from self._identity_labels.get(identity, {}).items()
 
     def counts(self, behavior):
         """get the count of labeled frames and bouts for each identity in this video for a specified behavior

--- a/src/jabs/ui/main_control_widget/main_control_widget.py
+++ b/src/jabs/ui/main_control_widget/main_control_widget.py
@@ -16,7 +16,7 @@ from PySide6 import QtCore, QtWidgets
 from PySide6.QtGui import QIcon, QPainter, QPixmap
 
 from jabs.classifier import Classifier
-from jabs.core.enums import ClassifierType
+from jabs.core.enums import ClassifierMode, ClassifierType
 
 from ..colors import (
     BEHAVIOR_BUTTON_COLOR_BRIGHT,
@@ -86,6 +86,7 @@ class MainControlWidget(QtWidgets.QWidget):
 
         # initial behavior labels to list in the drop-down selection
         self._behaviors = []
+        self._classifier_mode: ClassifierMode = ClassifierMode.BINARY
 
         # behavior selection form components
         self.behavior_selection = QtWidgets.QComboBox()
@@ -671,11 +672,29 @@ class MainControlWidget(QtWidgets.QWidget):
         # send a signal that we have an updated list of window sizes
         self.new_window_sizes.emit(sizes)
 
+    def set_classifier_mode(self, mode: ClassifierMode) -> None:
+        """Update the labeling UI to reflect the current classifier mode.
+
+        In multi-class mode the not-behavior button is repurposed as a "None"
+        label button; in binary mode it shows the normal "Not {behavior}" text.
+
+        Args:
+            mode: The classifier mode to apply.
+        """
+        self._classifier_mode = mode
+        self._behavior_changed()
+
     def _behavior_changed(self):
         self._label_behavior_button.setText(self.current_behavior)
         self._label_behavior_button.setToolTip(f"Label frames {self.current_behavior} [z]")
-        self._label_not_behavior_button.setText(f"Not {self.current_behavior}")
-        self._label_not_behavior_button.setToolTip(f"Label frames Not {self.current_behavior} [c]")
+        if self._classifier_mode == ClassifierMode.MULTICLASS:
+            self._label_not_behavior_button.setText("None")
+            self._label_not_behavior_button.setToolTip("Label frames as None [c]")
+        else:
+            self._label_not_behavior_button.setText(f"Not {self.current_behavior}")
+            self._label_not_behavior_button.setToolTip(
+                f"Label frames Not {self.current_behavior} [c]"
+            )
         self.behavior_changed.emit(self.current_behavior)
 
     def _window_size_changed(self):

--- a/src/jabs/ui/main_window/central_widget.py
+++ b/src/jabs/ui/main_window/central_widget.py
@@ -12,7 +12,8 @@ from shapely.geometry import Point
 import jabs.feature_extraction
 from jabs.behavior_search import SearchHit
 from jabs.classifier import Classifier
-from jabs.core.enums import ClassifierType, PredictionType
+from jabs.core.constants import MULTICLASS_NONE_BEHAVIOR
+from jabs.core.enums import ClassifierMode, ClassifierType, PredictionType
 from jabs.pose_estimation import PoseEstimation, PoseEstimationV8
 from jabs.project import Project, TimelineAnnotations, TrackLabels, VideoLabels
 
@@ -315,6 +316,7 @@ class CentralWidget(QtWidgets.QWidget):
         self._loaded_video = None
 
         self._controls.update_project_settings(project.settings)
+        self._controls.set_classifier_mode(project.settings_manager.classifier_mode)
         self._search_bar_widget.update_project(project)
         self._update_timeline_search_results()
 
@@ -586,17 +588,24 @@ class CentralWidget(QtWidgets.QWidget):
         self._label_button_common()
 
     def _label_not_behavior(self) -> None:
-        """apply _not_ behavior label to currently selected range of frames"""
+        """Apply not-behavior label (binary) or None label (multi-class) to selected frames."""
         start, end = sorted([self._selection_start, self._curr_selection_end])
-        self._project.session_tracker.label_created(
-            self._loaded_video,
-            self._controls.current_identity_index,
-            self._controls.current_behavior,
-            False,
-            start,
-            end,
-        )
-        self._get_label_track().label_not_behavior(start, end)
+        if self._project.settings_manager.classifier_mode == ClassifierMode.MULTICLASS:
+            identity_str = str(self._controls.current_identity_index)
+            self._labels.get_track_labels(identity_str, MULTICLASS_NONE_BEHAVIOR).label_behavior(
+                start, end
+            )
+            self._get_label_track().clear_labels(start, end)
+        else:
+            self._project.session_tracker.label_created(
+                self._loaded_video,
+                self._controls.current_identity_index,
+                self._controls.current_behavior,
+                False,
+                start,
+                end,
+            )
+            self._get_label_track().label_not_behavior(start, end)
         self._label_button_common()
 
     def _clear_behavior_label(self) -> None:

--- a/src/jabs/ui/main_window/central_widget.py
+++ b/src/jabs/ui/main_window/central_widget.py
@@ -592,10 +592,12 @@ class CentralWidget(QtWidgets.QWidget):
         start, end = sorted([self._selection_start, self._curr_selection_end])
         if self._project.settings_manager.classifier_mode == ClassifierMode.MULTICLASS:
             identity_str = str(self._controls.current_identity_index)
+            for ident, behavior, track in self._labels.iter_identity_behavior_labels():
+                if ident == identity_str and behavior != MULTICLASS_NONE_BEHAVIOR:
+                    track.clear_labels(start, end)
             self._labels.get_track_labels(identity_str, MULTICLASS_NONE_BEHAVIOR).label_behavior(
                 start, end
             )
-            self._get_label_track().clear_labels(start, end)
         else:
             self._project.session_tracker.label_created(
                 self._loaded_video,

--- a/src/jabs/ui/main_window/central_widget.py
+++ b/src/jabs/ui/main_window/central_widget.py
@@ -574,16 +574,23 @@ class CentralWidget(QtWidgets.QWidget):
         )
 
     def _label_behavior(self) -> None:
-        """Apply behavior label to currently selected range of frames"""
+        """Apply behavior label to currently selected range of frames."""
         start, end = sorted([self._selection_start, self._curr_selection_end])
-        self._project.session_tracker.label_created(
-            self._loaded_video,
-            self._controls.current_identity_index,
-            self._controls.current_behavior,
-            True,
-            start,
-            end,
-        )
+        if self._project.settings_manager.classifier_mode == ClassifierMode.MULTICLASS:
+            identity_str = str(self._controls.current_identity_index)
+            current_behavior = self._controls.current_behavior
+            for behavior, track in self._labels.iter_behavior_labels(identity_str):
+                if behavior != current_behavior:
+                    track.clear_labels(start, end)
+        else:
+            self._project.session_tracker.label_created(
+                self._loaded_video,
+                self._controls.current_identity_index,
+                self._controls.current_behavior,
+                True,
+                start,
+                end,
+            )
         self._get_label_track().label_behavior(start, end)
         self._label_button_common()
 
@@ -592,8 +599,8 @@ class CentralWidget(QtWidgets.QWidget):
         start, end = sorted([self._selection_start, self._curr_selection_end])
         if self._project.settings_manager.classifier_mode == ClassifierMode.MULTICLASS:
             identity_str = str(self._controls.current_identity_index)
-            for ident, behavior, track in self._labels.iter_identity_behavior_labels():
-                if ident == identity_str and behavior != MULTICLASS_NONE_BEHAVIOR:
+            for behavior, track in self._labels.iter_behavior_labels(identity_str):
+                if behavior != MULTICLASS_NONE_BEHAVIOR:
                     track.clear_labels(start, end)
             self._labels.get_track_labels(identity_str, MULTICLASS_NONE_BEHAVIOR).label_behavior(
                 start, end

--- a/src/jabs/ui/main_window/central_widget.py
+++ b/src/jabs/ui/main_window/central_widget.py
@@ -582,15 +582,14 @@ class CentralWidget(QtWidgets.QWidget):
             for behavior, track in self._labels.iter_behavior_labels(identity_str):
                 if behavior != current_behavior:
                     track.clear_labels(start, end)
-        else:
-            self._project.session_tracker.label_created(
-                self._loaded_video,
-                self._controls.current_identity_index,
-                self._controls.current_behavior,
-                True,
-                start,
-                end,
-            )
+        self._project.session_tracker.label_created(
+            self._loaded_video,
+            self._controls.current_identity_index,
+            self._controls.current_behavior,
+            True,
+            start,
+            end,
+        )
         self._get_label_track().label_behavior(start, end)
         self._label_button_common()
 
@@ -602,6 +601,14 @@ class CentralWidget(QtWidgets.QWidget):
             for behavior, track in self._labels.iter_behavior_labels(identity_str):
                 if behavior != MULTICLASS_NONE_BEHAVIOR:
                     track.clear_labels(start, end)
+            self._project.session_tracker.label_created(
+                self._loaded_video,
+                self._controls.current_identity_index,
+                MULTICLASS_NONE_BEHAVIOR,
+                True,
+                start,
+                end,
+            )
             self._labels.get_track_labels(identity_str, MULTICLASS_NONE_BEHAVIOR).label_behavior(
                 start, end
             )

--- a/src/jabs/ui/main_window/main_window.py
+++ b/src/jabs/ui/main_window/main_window.py
@@ -456,6 +456,10 @@ class MainWindow(QtWidgets.QMainWindow):
         """
         # changing the settings can affect training thresholds, so the train button state needs to be updated
         self._central_widget.set_train_button_enabled_state()
+        # classifier mode change is reflected immediately on the labeling buttons
+        self._central_widget.controls.set_classifier_mode(
+            self._project.settings_manager.classifier_mode
+        )
 
     def on_app_settings_changed(self) -> None:
         """Slot called when application settings are changed via JabsSettingsDialog.


### PR DESCRIPTION
This pull request introduces improved support for handling both binary and multi-class classifier modes in the labeling UI and logic. The main changes ensure that the UI and labeling behavior adapt dynamically based on the selected classifier mode, especially by updating button labels and label assignment logic.

Classifier mode support and UI updates:

* Added a `set_classifier_mode` method to `MainControlWidget` to update the UI based on the current classifier mode. In multi-class mode, the "Not {behavior}" button is relabeled as "None" and its tooltip is updated accordingly.
* The `MainControlWidget` now initializes with a default classifier mode (`ClassifierMode.BINARY`).
* The `CentralWidget` calls `set_classifier_mode` on controls when a new project is set, ensuring the UI reflects the project's classifier mode.
* The main window updates the classifier mode on the control widget immediately when project settings change, keeping the UI in sync with settings.

Labeling logic improvements:

* The `_label_not_behavior` method in `CentralWidget` now applies a "None" label in multi-class mode (using `MULTICLASS_NONE_BEHAVIOR`), and maintains the previous behavior in binary mode.

