### PR TITLE
Improve resize handling of stacked timeline widget

### DIFF
--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/label_overview_util.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/label_overview_util.py
@@ -2,8 +2,8 @@ from random import Random
 
 import numpy as np
 import numpy.typing as npt
-from PySide6.QtCore import QPoint, Qt
-from PySide6.QtGui import QBrush, QPen, QPolygon
+from PySide6.QtCore import QPointF, Qt
+from PySide6.QtGui import QBrush, QPen, QPolygonF
 
 from jabs.project import TrackLabels
 
@@ -43,7 +43,7 @@ def binary_predictions_to_lut_indices(
     return (predictions + 1).astype(np.int16)
 
 
-def diamond_at(x: float, y: float, w: float, h: float) -> QPolygon:
+def diamond_at(x: float, y: float, w: float, h: float) -> QPolygonF:
     """Create a diamond shape polygon centered at (x, y) with width w and height h.
 
     Args:
@@ -53,29 +53,35 @@ def diamond_at(x: float, y: float, w: float, h: float) -> QPolygon:
         h (float): The height of the diamond.
 
     Returns:
-        QPolygon: A polygon representing the diamond shape.
+        QPolygonF: A polygon representing the diamond shape.
     """
-    return QPolygon(
+    return QPolygonF(
         [
-            QPoint(x, y - h),  # top
-            QPoint(x + w, y),  # right
-            QPoint(x, y + h),  # bottom
-            QPoint(x - w, y),  # left
+            QPointF(x, y - h),  # top
+            QPointF(x + w, y),  # right
+            QPointF(x, y + h),  # bottom
+            QPointF(x - w, y),  # left
         ]
     )
 
 
 def render_search_hits(
-    qp, search_results, offset, start, frame_width, bar_height, window_frames_total
-):
+    qp,
+    search_results: list,
+    offset: float,
+    start: int,
+    frame_width: float,
+    bar_height: int,
+    window_frames_total: int,
+) -> None:
     """Render search hits on the given QPainter.
 
     Args:
         qp (QPainter): The QPainter to draw on.
         search_results (list): List of search hit results.
-        offset (int): The offset for drawing.
+        offset (float): The x offset for drawing (0 when content fills the full widget).
         start (int): The starting frame index for the current view.
-        frame_width (int): The width of each frame.
+        frame_width (float): Pixels per frame (may be fractional).
         bar_height (int): The height of the bar.
         window_frames_total (int): Total number of frames in the window.
     """
@@ -115,8 +121,8 @@ def render_search_hits(
             # skip search hits that are completely out of bounds
             continue
 
-        start_pos = offset + (bounded_rel_start * frame_width)
-        end_pos = offset + (bounded_rel_end * frame_width)
+        start_pos = offset + bounded_rel_start * frame_width
+        end_pos = offset + bounded_rel_end * frame_width
         qp.drawLine(start_pos, y_pos, end_pos, y_pos)
 
         if bounded_rel_start == rel_start_frame:

--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/label_overview_util.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/label_overview_util.py
@@ -1,3 +1,4 @@
+import math
 from random import Random
 
 import numpy as np
@@ -121,8 +122,11 @@ def render_search_hits(
             # skip search hits that are completely out of bounds
             continue
 
-        start_pos = offset + bounded_rel_start * frame_width
-        end_pos = offset + bounded_rel_end * frame_width
+        start_pos = math.floor(offset + bounded_rel_start * frame_width)
+        end_pos = math.floor(offset + bounded_rel_end * frame_width)
+        # ensure at least 1px span so single-frame hits remain visible
+        if end_pos <= start_pos:
+            end_pos = start_pos + 1
         qp.drawLine(start_pos, y_pos, end_pos, y_pos)
 
         if bounded_rel_start == rel_start_frame:

--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/manual_label_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/manual_label_widget.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 import numpy as np
 import numpy.typing as npt
 from PySide6.QtCore import QSize, Qt, Slot
@@ -85,10 +87,8 @@ class ManualLabelWidget(QWidget):
 
         self._bar_height = self._BAR_HEIGHT
 
-        # size each frame takes up in the bar in pixels
-        self._frame_width = self.size().width() // self._window_frames_total
-        self._adjusted_width = self._window_frames_total * self._frame_width
-        self._offset = (self.size().width() - self._adjusted_width) // 2
+        # float pixels per frame; set in resizeEvent
+        self._frame_width: float = 0.0
 
         # initialize some brushes and pens once rather than every paintEvent
         self._position_marker_pen = QPen(POSITION_MARKER_COLOR, 1, Qt.PenStyle.SolidLine)
@@ -123,15 +123,14 @@ class ManualLabelWidget(QWidget):
     def resizeEvent(self, event: QResizeEvent) -> None:
         """Handle widget resize events.
 
-        Updates internal frame width, adjusted width, and offset values based on the new widget size.
-        This ensures that the label bar and its elements are correctly scaled and centered after resizing.
+        Updates the floating-point pixels-per-frame value based on the new widget width.
+        Content expands to fill the full width with no padding.
 
         Args:
             event: QResizeEvent containing the new and old size of the widget.
         """
-        self._frame_width = self.size().width() // self._window_frames_total
-        self._adjusted_width = self._window_frames_total * self._frame_width
-        self._offset = (self.size().width() - self._adjusted_width) // 2
+        w = self.size().width()
+        self._frame_width = w / self._window_frames_total if w > 0 else 0.0
 
     def paintEvent(self, event: QPaintEvent) -> None:
         """Handle widget paint events.
@@ -143,6 +142,12 @@ class ManualLabelWidget(QWidget):
         Args:
             event: QPaintEvent containing the region to be redrawn.
         """
+        fw = self._frame_width
+        if fw == 0.0:
+            return
+
+        widget_width = self.size().width()
+
         # starting and ending frames of the current view
         # since the current frame is centered start might be negative and end might be > num_frames
         # out of bounds frames will be padded with a pattern
@@ -152,19 +157,25 @@ class ManualLabelWidget(QWidget):
         # slice size for grabbing label blocks
         slice_start = max(start, 0)
         slice_end = min(end, self._num_frames - 1)
+        n_in_bounds = slice_end - slice_start + 1
+
+        # Number of padding frames before the in-bounds content
+        n_start_pad = max(0, -start)
+
+        # Pixel edges of the in-bounds region using floating-point frame positions
+        in_bounds_x0 = math.floor(n_start_pad * fw)
+        in_bounds_x1 = math.floor((n_start_pad + n_in_bounds) * fw)
+        in_bounds_px = in_bounds_x1 - in_bounds_x0
 
         qp = QPainter(self)
         qp.setPen(Qt.PenStyle.NoPen)
 
-        # Calculate padding in pixels
-        start_padding = max(0, -start) * self._frame_width
-
-        # Use QPainter to fill drawing area with the padding pattern
+        # Fill entire bar with the padding pattern, then overdraw in-bounds content
         qp.setBrush(self._padding_brush)
-        qp.drawRect(self._offset, 0, self._adjusted_width, self._bar_height)
+        qp.drawRect(0, 0, widget_width, self._bar_height)
 
         # Draw the main bar image
-        if self._labels is not None:
+        if self._labels is not None and n_in_bounds > 0 and in_bounds_px > 0:
             # _labels stores direct LUT indices (binary labels are pre-offset on set_labels)
             color_indices = self._labels[slice_start : slice_end + 1]
 
@@ -175,22 +186,23 @@ class ManualLabelWidget(QWidget):
             gap_mask = self._identity_mask[slice_start : slice_end + 1] == 0
             colors[gap_mask, 3] = self.GAP_ALPHA
 
-            # expand color array to bar height
-            # shape (bar_height, frames in view, 4)
+            # Per-frame pixel widths: floor((i+1)*fw) - floor(i*fw) for each frame
+            win_indices = np.arange(n_start_pad, n_start_pad + n_in_bounds + 1, dtype=np.float64)
+            frame_px_widths = np.diff(np.floor(win_indices * fw)).astype(int)
+
+            # expand color array to bar height: shape (bar_height, n_in_bounds, 4)
             colors_bar = np.repeat(colors[np.newaxis, :, :], self._bar_height, axis=0)
 
-            # Repeat each column (frame) by self._frame_width pixels
-            # shape: (bar_height, frames in view * frame_width, 4)
-            colors_bar = np.repeat(colors_bar, self._frame_width, axis=1)
+            # Expand each frame to its pixel width: shape (bar_height, in_bounds_px, 4)
+            colors_bar = np.repeat(colors_bar, frame_px_widths, axis=1)
 
-            # Draw the main bar image accounting for start padding
             img = QImage(
                 colors_bar.data,
                 colors_bar.shape[1],
                 colors_bar.shape[0],
                 QImage.Format.Format_RGBA8888,
             )
-            qp.drawImage(self._offset + start_padding, 0, img)
+            qp.drawImage(in_bounds_x0, 0, img)
 
         # Draw selection overlay if in select mode
         if self._selection_start is not None:
@@ -199,7 +211,7 @@ class ManualLabelWidget(QWidget):
         render_search_hits(
             qp,
             self._search_results,
-            self._offset,
+            0,
             start,
             self._frame_width,
             self._bar_height,
@@ -223,7 +235,7 @@ class ManualLabelWidget(QWidget):
             painter: The active QPainter used for drawing.
         """
         painter.setPen(self._position_marker_pen)
-        position_offset = self._offset + self._adjusted_width // 2
+        position_offset = self.size().width() // 2
         painter.drawLine(position_offset, 0, position_offset, self._bar_height - 1)
 
     def _draw_bounding_box(self, painter: QPainter) -> None:
@@ -236,7 +248,7 @@ class ManualLabelWidget(QWidget):
         """
         painter.setPen(self._BORDER_COLOR)
         painter.setBrush(Qt.BrushStyle.NoBrush)
-        painter.drawRect(self._offset, 0, self._adjusted_width - 1, self._bar_height - 1)
+        painter.drawRect(0, 0, self.size().width() - 1, self._bar_height - 1)
 
     def _draw_selection_overlay(self, painter: QPainter) -> None:
         """Draw the selection overlay on the label bar.
@@ -247,44 +259,28 @@ class ManualLabelWidget(QWidget):
         Args:
             painter: The active QPainter used for drawing.
         """
-        # starting and ending frames of the current view
+        fw = self._frame_width
         start = self._current_frame - self._window_size
-        end = self._current_frame + self._window_size
+
+        if self._selection_end is not None:
+            true_start, true_end = self._selection_start, self._selection_end
+        else:
+            true_start = min(self._selection_start, self._current_frame)
+            true_end = max(self._selection_start, self._current_frame)
+
+        # Clamp to the visible window (in window-relative frame indices)
+        vis_start = max(true_start - start, 0)
+        vis_end = min(true_end - start + 1, self._window_frames_total)
+
+        if vis_end <= vis_start:
+            return
+
+        x0 = math.floor(vis_start * fw)
+        x1 = math.floor(vis_end * fw)
 
         painter.setPen(Qt.PenStyle.NoPen)
         painter.setBrush(self._selection_brush)
-
-        # figure out the start and width of the selection rectangle
-        if self._selection_end is not None:
-            # we have an explicit end frame for the selection
-            selection_start = max(self._selection_start - start, 0)
-            selection_width = (
-                min(end, self._selection_end) - max(start, self._selection_start) + 1
-            ) * self._frame_width
-        elif self._selection_start < self._current_frame:
-            # normal selection, start is lower than current frame
-            selection_start = max(self._selection_start - start, 0)
-            selection_width = (
-                self._current_frame - max(start, self._selection_start) + 1
-            ) * self._frame_width
-        elif self._selection_start > self._current_frame:
-            # user started selecting and then scanned backwards, start is greater than current frame
-            selection_start = self._current_frame - start
-            selection_width = (
-                min(end, self._selection_start) - self._current_frame + 1
-            ) * self._frame_width
-        else:
-            # single frame selected
-            selection_start = self._current_frame - start
-            selection_width = self._frame_width
-
-        # draw the selection overlay rectangle
-        painter.drawRect(
-            self._offset + (selection_start * self._frame_width),
-            0,
-            selection_width,
-            self._bar_height,
-        )
+        painter.drawRect(x0, 0, max(x1 - x0, 1), self._bar_height)
 
     def _draw_second_ticks(self, painter: QPainter, start: int, end: int) -> None:
         """Draw vertical tick marks at one-second intervals along the label bar.
@@ -297,17 +293,17 @@ class ManualLabelWidget(QWidget):
             start: The starting frame number of the current view.
             end: The ending frame number of the current view.
         """
-        # can't draw if we don't know the frame rate yet
         if self._framerate == 0:
             return
 
+        fw = self._frame_width
         painter.setBrush(self._BORDER_COLOR)
         for i in range(start, end + 1):
-            # we could add i > 0 and i < num_frames to this if test to avoid
-            # drawing ticks in the 'padding' at the start and end of the video
             if i % self._framerate == 0:
-                offset = (i - start) * self._frame_width + self._offset
-                painter.drawRect(offset, 0, self._frame_width - 1, self._TICK_HEIGHT)
+                win_i = i - start
+                x0 = math.floor(win_i * fw)
+                x1 = math.floor((win_i + 1) * fw)
+                painter.drawRect(x0, 0, max(x1 - x0, 1), self._TICK_HEIGHT)
 
     def set_labels(self, labels: npt.NDArray[np.int16], mask: npt.NDArray[np.int16]) -> None:
         """Load and display the label track and identity mask.

--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/manual_label_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/manual_label_widget.py
@@ -129,6 +129,7 @@ class ManualLabelWidget(QWidget):
         Args:
             event: QResizeEvent containing the new and old size of the widget.
         """
+        super().resizeEvent(event)
         w = self.size().width()
         self._frame_width = w / self._window_frames_total if w > 0 else 0.0
 
@@ -142,11 +143,11 @@ class ManualLabelWidget(QWidget):
         Args:
             event: QPaintEvent containing the region to be redrawn.
         """
-        fw = self._frame_width
-        if fw == 0.0:
-            return
-
         widget_width = self.size().width()
+        if widget_width == 0 or self._window_frames_total == 0:
+            return
+        self._frame_width = widget_width / self._window_frames_total
+        fw = self._frame_width
 
         # starting and ending frames of the current view
         # since the current frame is centered start might be negative and end might be > num_frames
@@ -321,6 +322,21 @@ class ManualLabelWidget(QWidget):
             labels: Class-index array of shape ``(n_frames,)`` with dtype ``int16``.
             mask: Integer array indicating valid identity frames (1 = present, 0 = gap).
         """
+        if labels.ndim != 1:
+            raise ValueError("labels must be a 1D array")
+        if mask.ndim != 1:
+            raise ValueError("mask must be a 1D array")
+        if labels.shape[0] != mask.shape[0]:
+            raise ValueError(
+                f"labels and mask must have the same length: {labels.shape[0]} != {mask.shape[0]}"
+            )
+        if self._num_frames and labels.shape[0] != self._num_frames:
+            raise ValueError(
+                f"labels length must match num_frames: {labels.shape[0]} != {self._num_frames}"
+            )
+        if np.any(labels < 0) or np.any(labels >= len(self._color_lut)):
+            raise ValueError("labels contain indices outside the active color LUT range")
+
         self._labels = labels
         self._identity_mask = mask
         self.update()

--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/manual_label_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/manual_label_widget.py
@@ -330,7 +330,7 @@ class ManualLabelWidget(QWidget):
             raise ValueError(
                 f"labels and mask must have the same length: {labels.shape[0]} != {mask.shape[0]}"
             )
-        if self._num_frames and labels.shape[0] != self._num_frames:
+        if labels.shape[0] != self._num_frames:
             raise ValueError(
                 f"labels length must match num_frames: {labels.shape[0]} != {self._num_frames}"
             )

--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/predicted_label_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/predicted_label_widget.py
@@ -37,11 +37,11 @@ class PredictedLabelWidget(ManualLabelWidget):
         Args:
             event (QPaintEvent): The paint event containing region to update.
         """
-        fw = self._frame_width
-        if fw == 0.0:
-            return
-
         widget_width = self.size().width()
+        if widget_width == 0 or self._window_frames_total == 0:
+            return
+        self._frame_width = widget_width / self._window_frames_total
+        fw = self._frame_width
 
         start = self._current_frame - self._window_size
         end = self._current_frame + self._window_size
@@ -76,7 +76,8 @@ class PredictedLabelWidget(ManualLabelWidget):
 
             # Set alpha from probabilities if available
             if self._probabilities is not None:
-                alphas = (self._probabilities[slice_start : slice_end + 1] * 255).astype(np.uint8)
+                probs = np.clip(self._probabilities[slice_start : slice_end + 1], 0.0, 1.0)
+                alphas = (probs * 255).astype(np.uint8)
 
                 # some post-processed predictions may have zero probability, specifically the interpolation stage
                 # which fills in short gaps where there was no prediction. To ensure these interpolated classes
@@ -131,8 +132,34 @@ class PredictedLabelWidget(ManualLabelWidget):
             predictions: Class-index array of shape ``(n_frames,)`` with dtype ``int16``, or ``None``.
             probabilities: Per-frame prediction confidence of shape ``(n_frames,)``, or ``None``.
         """
+        if predictions is None:
+            if probabilities is not None:
+                raise ValueError("probabilities must be None when predictions is None")
+            self._predictions = None
+            self._probabilities = None
+            self.update()
+            return
+
+        if predictions.ndim != 1:
+            raise ValueError("predictions must be a 1D array")
+        if self._num_frames and predictions.shape[0] != self._num_frames:
+            raise ValueError(
+                "predictions length must match num_frames: "
+                f"{predictions.shape[0]} != {self._num_frames}"
+            )
+        if np.any(predictions < 0) or np.any(predictions >= len(self._color_lut)):
+            raise ValueError("predictions contain indices outside the active color LUT range")
+
+        if probabilities is not None:
+            if probabilities.ndim != 1 or probabilities.shape[0] != predictions.shape[0]:
+                raise ValueError(
+                    "probabilities must be a 1D array with same length as predictions"
+                )
+            self._probabilities = np.clip(probabilities, 0.0, 1.0).astype(np.float32, copy=False)
+        else:
+            self._probabilities = None
+
         self._predictions = predictions
-        self._probabilities = probabilities
         self.update()
 
     def start_selection(self, start_frame: int, end_frame: int | None = None) -> None:

--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/predicted_label_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/predicted_label_widget.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy as np
 import numpy.typing as npt
 from PySide6.QtCore import Qt
@@ -35,46 +37,38 @@ class PredictedLabelWidget(ManualLabelWidget):
         Args:
             event (QPaintEvent): The paint event containing region to update.
         """
-        # starting and ending frames of the current view
-        # since the current frame is centered start might be negative and end might be > num_frames
-        # out of bounds frames will be padded with a pattern
+        fw = self._frame_width
+        if fw == 0.0:
+            return
+
+        widget_width = self.size().width()
+
         start = self._current_frame - self._window_size
         end = self._current_frame + self._window_size
 
-        # calculate the start and end of the slice to draw
         slice_start = max(start, 0)
         slice_end = min(end, self._num_frames - 1)
+        n_in_bounds = slice_end - slice_start + 1
+        n_start_pad = max(0, -start)
 
-        start_padding = max(0, -start) * self._frame_width
-        in_bounds_frames = slice_end - slice_start + 1
-        in_bounds_width = in_bounds_frames * self._frame_width
-        end_padding_frames = max(0, end - (self._num_frames - 1))
-        end_padding_width = end_padding_frames * self._frame_width
+        in_bounds_x0 = math.floor(n_start_pad * fw)
+        in_bounds_x1 = math.floor((n_start_pad + n_in_bounds) * fw)
+        in_bounds_px = in_bounds_x1 - in_bounds_x0
 
         qp = QPainter(self)
         qp.setPen(Qt.PenStyle.NoPen)
 
-        # Draw start padding
-        if start_padding > 0:
-            qp.setBrush(self._padding_brush)
-            qp.drawRect(self._offset, 0, start_padding, self._bar_height)
+        # Fill entire bar with padding pattern, then overdraw in-bounds region
+        qp.setBrush(self._padding_brush)
+        qp.drawRect(0, 0, widget_width, self._bar_height)
 
-        # Draw in-bounds white background
-        qp.setBrush(Qt.GlobalColor.white)
-        qp.drawRect(self._offset + start_padding, 0, in_bounds_width, self._bar_height)
-
-        # Draw end padding
-        if end_padding_width > 0:
-            qp.setBrush(self._padding_brush)
-            qp.drawRect(
-                self._offset + start_padding + in_bounds_width,
-                0,
-                end_padding_width,
-                self._bar_height,
-            )
+        if n_in_bounds > 0 and in_bounds_px > 0:
+            # White background for the in-bounds region; predictions are overlaid with alpha
+            qp.setBrush(Qt.GlobalColor.white)
+            qp.drawRect(in_bounds_x0, 0, in_bounds_px, self._bar_height)
 
         # Draw predictions overlaid on the white background; lower probability = more transparent.
-        if self._predictions is not None:
+        if self._predictions is not None and n_in_bounds > 0 and in_bounds_px > 0:
             color_indices = self._predictions[slice_start : slice_end + 1]
 
             # Map to RGBA colors
@@ -93,25 +87,26 @@ class PredictedLabelWidget(ManualLabelWidget):
 
                 colors[:, 3] = alphas
 
-            # Expand to bar height: shape = (bar_height, frames in view, 4)
+            # Per-frame pixel widths using floating-point positions
+            win_indices = np.arange(n_start_pad, n_start_pad + n_in_bounds + 1, dtype=np.float64)
+            frame_px_widths = np.diff(np.floor(win_indices * fw)).astype(int)
+
+            # Expand to bar height and per-frame pixel widths
             colors_bar = np.repeat(colors[np.newaxis, :, :], self._bar_height, axis=0)
+            colors_bar = np.repeat(colors_bar, frame_px_widths, axis=1)
 
-            # Expand each frame horizontally: shape = (bar_height, frames in view * frame pixel width, 4)
-            colors_bar = np.repeat(colors_bar, self._frame_width, axis=1)
-
-            # Draw the bar
             img = QImage(
                 colors_bar.data,
                 colors_bar.shape[1],
                 colors_bar.shape[0],
                 QImage.Format.Format_RGBA8888,
             )
-            qp.drawImage(self._offset + start_padding, 0, img)
+            qp.drawImage(in_bounds_x0, 0, img)
 
         render_search_hits(
             qp,
             self._search_results,
-            self._offset,
+            0,
             start,
             self._frame_width,
             self._bar_height,

--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/timeline_label_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/timeline_label_widget.py
@@ -116,9 +116,8 @@ class TimelineLabelWidget(QWidget):
 
         self._search_results: list[SearchHit] = []
 
-        self._bin_size = 0
+        self._float_bin_size: float = 0.0
         self._pixmap: QPixmap | None = None
-        self._pixmap_offset = 0
 
         self._current_frame = 0
         self._num_frames = 0
@@ -166,23 +165,25 @@ class TimelineLabelWidget(QWidget):
         Args:
             event (QPaintEvent): The paint event.
         """
-        # make sure we have something to draw
-        if self._pixmap is None or self._bin_size == 0:
+        if self._pixmap is None or self._float_bin_size == 0.0:
             return
+
+        fbs = self._float_bin_size
 
         qp = QPainter(self)
 
-        # get the current position
-        mapped_position = self._current_frame // self._bin_size
-        start = mapped_position - (self._window_size // self._bin_size) + self._pixmap_offset
+        # Highlight the window around the current position
+        mapped_position = int(self._current_frame / fbs)
+        window_px = int(self._frames_in_view / fbs)
+        window_half_px = int(self._window_size / fbs)
+        highlight_start = mapped_position - window_half_px
 
-        # highlight the current position
         qp.setPen(QPen(POSITION_MARKER_COLOR, 1, Qt.PenStyle.SolidLine))
         qp.setBrush(QBrush(POSITION_MARKER_COLOR, Qt.BrushStyle.Dense4Pattern))
-        qp.drawRect(start, 0, self._frames_in_view // self._bin_size, self.size().height() - 1)
+        qp.drawRect(highlight_start, 0, window_px, self.size().height() - 1)
 
-        # draw the actual bar
-        qp.drawPixmap(0 + self._pixmap_offset, 0, self._pixmap)
+        # Draw the label bar (fills the full widget width)
+        qp.drawPixmap(0, 0, self._pixmap)
 
         qp.setPen(QPen(Qt.GlobalColor.green, 1, Qt.PenStyle.SolidLine))
         qp.setBrush(QBrush(Qt.GlobalColor.green, Qt.BrushStyle.SolidPattern))
@@ -190,8 +191,8 @@ class TimelineLabelWidget(QWidget):
         diamond_w = self.size().height() // 8
         diamond_h = self.size().height() // 8
         for hit in self._search_results:
-            start_pos = hit.start_frame // self._bin_size + self._pixmap_offset
-            end_pos = (hit.end_frame + 1) // self._bin_size + self._pixmap_offset
+            start_pos = int(hit.start_frame / fbs)
+            end_pos = int((hit.end_frame + 1) / fbs)
             qp.drawLine(start_pos, center_y, end_pos, center_y)
             qp.drawPolygon(diamond_at(start_pos, center_y, diamond_w, diamond_h))
             qp.drawPolygon(diamond_at(end_pos, center_y, diamond_w, diamond_h))
@@ -259,9 +260,9 @@ class TimelineLabelWidget(QWidget):
     def _update_bar(self) -> None:
         """Downsample the label array and update the bar pixmap for display.
 
-        Converts the current labels into a color bar, downsampling as needed to fit the widget width,
-        and updates the internal pixmap for efficient rendering. The internal pixmap is reused by paintEvent
-        and only updated when the labels change or the widget is resized.
+        Converts the current labels into a color bar using proportional color blending,
+        then updates the internal pixmap for efficient rendering. The pixmap fills the
+        full widget width with no padding.
         """
         if self._labels is None:
             return
@@ -269,21 +270,13 @@ class TimelineLabelWidget(QWidget):
         width = self.size().width()
         height = self.size().height()
 
-        # create a pixmap with a width that evenly divides the total number of
-        # frames so that each pixel along the width represents a bin of frames
-        # (_update_scale() has done this, we can use pixmap_offset to figure
-        # out how many pixels of padding will be on each side of the final
-        # pixmap)
-        pixmap_width = width - 2 * self._pixmap_offset
-
-        self._pixmap = QPixmap(pixmap_width, height)
+        self._pixmap = QPixmap(width, height)
         self._pixmap.fill(Qt.GlobalColor.transparent)
 
-        colors = _downsample_to_size(self._labels, self._color_lut, pixmap_width)
+        colors = _downsample_to_size(self._labels, self._color_lut, width)
 
         color_bar = np.repeat(colors[np.newaxis, :, :], self._bar_height, axis=0)
 
-        # convert bar to QImage and draw it to the pixmap
         img = QImage(
             color_bar.data,
             color_bar.shape[1],
@@ -295,16 +288,12 @@ class TimelineLabelWidget(QWidget):
         painter.end()
 
     def _update_scale(self) -> None:
-        """Recalculate the bin size and pixmap offset for the timeline bar.
+        """Recalculate the floating-point bin size for the timeline bar.
 
-        Determines how many frames each horizontal pixel represents and computes the necessary
-        padding to center the bar, based on the widget width and total frame count.
+        Determines how many frames each horizontal pixel represents based on the
+        widget width and total frame count. Content fills the full widget width.
         """
         width = self.size().width()
 
         if width and self._num_frames:
-            pad_size = math.ceil(float(self._num_frames) / width) * width - self._num_frames
-            self._bin_size = int(self._num_frames + pad_size) // width
-
-            padding = (self._bin_size * width - self._num_frames) // self._bin_size
-            self._pixmap_offset = padding // 2
+            self._float_bin_size = self._num_frames / width

--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/timeline_label_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/timeline_label_widget.py
@@ -34,19 +34,11 @@ def _downsample_to_size(
 ) -> npt.NDArray[np.uint8]:
     """Downsample a class-index array to ``size`` pixels via proportional color blending.
 
-    Each output pixel is the weighted average of the LUT colors for all frames in
-    the corresponding bin, with each class contributing in proportion to its frame
-    count.  Class 0 (background/unlabeled) is included in the blend, so a bin that
-    is half labeled shows as a half-intensity color against background — faithfully
-    representing label density rather than just label identity.
-
-    This replaces the previous binary-mode ``MIX`` color: bins containing multiple
-    classes produce a visible blend of those class colors rather than collapsing to
-    an opaque purple indicator.  This is strictly more informative and works
-    uniformly for both binary and multi-class LUTs with no special cases.
-
-    Padding frames added to make the array evenly divisible contribute class 0
-    (background) to the blend.
+    Each output pixel covers an equal-width interval in frame space. Frame
+    contributions are weighted by the fractional overlap between that pixel's
+    interval and each source frame interval. This avoids introducing synthetic
+    background at the right edge when the frame count is not evenly divisible by
+    the widget width.
 
     Args:
         labels: Integer class-index array (0 = unlabeled/background, 1+ = class indices).
@@ -60,18 +52,32 @@ def _downsample_to_size(
         return np.zeros((0, 4), dtype=np.uint8)
 
     n_classes = len(lut)
-    pad_size = math.ceil(labels.size / size) * size - labels.size
-    padded = np.append(labels, np.zeros(pad_size, dtype=labels.dtype))
-    bin_size = padded.size // size
-    binned = padded.reshape(size, bin_size)  # (size, bin_size)
-
-    # Count occurrences of each class per bin: shape (size, n_classes)
+    n_frames = labels.size
+    edges = np.linspace(0.0, float(n_frames), num=size + 1, dtype=np.float64)
     counts = np.zeros((size, n_classes), dtype=np.float32)
-    for c in range(n_classes):
-        counts[:, c] = (binned == c).sum(axis=1)
 
-    # Proportional weighted average color per bin
-    colors = (counts @ lut.astype(np.float32)) / bin_size
+    for i in range(size):
+        start = edges[i]
+        end = edges[i + 1]
+        if end <= start:
+            continue
+
+        first = math.floor(start)
+        last = math.ceil(end)
+
+        for frame in range(first, last):
+            frame_start = float(frame)
+            frame_end = frame_start + 1.0
+            overlap = min(end, frame_end) - max(start, frame_start)
+            if overlap <= 0.0 or frame < 0 or frame >= n_frames:
+                continue
+
+            label = int(labels[frame])
+            if 0 <= label < n_classes:
+                counts[i, label] += overlap
+
+    bin_widths = (edges[1:] - edges[:-1]).astype(np.float32)
+    colors = (counts @ lut.astype(np.float32)) / bin_widths[:, np.newaxis]
     return colors.clip(0, 255).astype(np.uint8)
 
 
@@ -158,6 +164,7 @@ class TimelineLabelWidget(QWidget):
 
         self._update_scale()
         self._update_bar()
+        self.update()
 
     def paintEvent(self, event: QPaintEvent) -> None:
         """Render the timeline label bar and highlight the current frame.
@@ -165,10 +172,20 @@ class TimelineLabelWidget(QWidget):
         Args:
             event (QPaintEvent): The paint event.
         """
-        if self._pixmap is None or self._float_bin_size == 0.0:
+        widget_width = self.size().width()
+        if widget_width <= 0 or self._num_frames == 0:
             return
 
-        fbs = self._float_bin_size
+        if self._labels is not None and (
+            self._pixmap is None or self._pixmap.width() != widget_width
+        ):
+            self._float_bin_size = self._num_frames / widget_width
+            self._update_bar()
+
+        if self._pixmap is None:
+            return
+
+        fbs = self._num_frames / widget_width
 
         qp = QPainter(self)
 

--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/timeline_label_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/timeline_label_widget.py
@@ -270,10 +270,15 @@ class TimelineLabelWidget(QWidget):
         width = self.size().width()
         height = self.size().height()
 
-        self._pixmap = QPixmap(width, height)
-        self._pixmap.fill(Qt.GlobalColor.transparent)
+        if width <= 0 or height <= 0:
+            return
 
         colors = _downsample_to_size(self._labels, self._color_lut, width)
+        if colors.size == 0:
+            return
+
+        self._pixmap = QPixmap(width, height)
+        self._pixmap.fill(Qt.GlobalColor.transparent)
 
         color_bar = np.repeat(colors[np.newaxis, :, :], self._bar_height, axis=0)
 
@@ -292,8 +297,12 @@ class TimelineLabelWidget(QWidget):
 
         Determines how many frames each horizontal pixel represents based on the
         widget width and total frame count. Content fills the full widget width.
+        Resets to 0.0 (disabling drawing) when either dimension is unavailable.
         """
         width = self.size().width()
 
         if width and self._num_frames:
             self._float_bin_size = self._num_frames / width
+        else:
+            self._float_bin_size = 0.0
+            self._pixmap = None


### PR DESCRIPTION
This pull request refactors the label overview widgets to use floating-point pixel widths for frames, ensuring that the label bars always fill the full widget width with no padding. It also updates the rendering logic to handle variable-width frames more accurately, resulting in improved visual fidelity, especially for zoomed or non-integer frame-to-pixel ratios. The changes affect manual, predicted, and utility components, and remove legacy integer-based sizing logic.

**Widget rendering and sizing improvements:**

* Replaced integer-based per-frame pixel width and offset calculations with floating-point `frame_width`, ensuring the label bar fully fills the widget width without side padding. All frame-to-pixel calculations now use floating-point math and `math.floor` for pixel alignment.

* Updated the rendering of the main label and prediction bars to expand each frame horizontally according to its (possibly fractional) pixel width, improving alignment and appearance at all zoom levels. 

**Padding and bar filling logic:**

* Changed the approach to padding: the entire bar is filled with the padding pattern, and in-bounds content is drawn over it, eliminating the need for offset and adjusted width calculations. 
**Selection and tick rendering:**

* Refactored selection overlay and tick rendering to use floating-point frame-to-pixel mapping, ensuring overlays and tick marks align precisely with frame boundaries regardless of zoom or widget size. 

**Utility and type updates:**

* Updated utility functions and type annotations to use floating-point types and Qt floating-point classes (`QPointF`, `QPolygonF`) for improved precision.

These changes collectively modernize the label overview widgets for more accurate and visually consistent rendering across different widget sizes and zoom levels.