### PR TITLE
Add compact mode to timeline label widgets for all-identity view

### DIFF
--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/label_overview_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/label_overview_widget.py
@@ -27,6 +27,8 @@ class LabelOverviewWidget(QWidget):
     """
 
     def __init__(self, *args, **kwargs) -> None:
+        # need to strip "compact" out of kwargs before calling super
+        compact = kwargs.pop("compact", False)
         super().__init__(*args, **kwargs)
 
         self._num_frames = 0
@@ -38,9 +40,27 @@ class LabelOverviewWidget(QWidget):
         self._container = QWidget(self)
 
         self._timeline_widget = self._timeline_widget_factory(self._container)
-        self._label_widget = self._label_widget_factory(self._container)
+        self._label_widget = self._label_widget_factory(self._container, compact)
 
         self._set_layout()
+
+    @property
+    def compact(self) -> bool:
+        """Whether the label widget is in compact mode.
+
+        Returns:
+            True if compact mode is active, False otherwise.
+        """
+        return self._label_widget.compact
+
+    @compact.setter
+    def compact(self, value: bool) -> None:
+        """Set compact mode on the label widget.
+
+        Args:
+            value: True to enable compact mode, False to disable.
+        """
+        self._label_widget.compact = value
 
     @classmethod
     def _timeline_widget_factory(cls, parent: QWidget) -> TimelineLabelWidget:
@@ -51,12 +71,12 @@ class LabelOverviewWidget(QWidget):
         return TimelineLabelWidget(parent)
 
     @classmethod
-    def _label_widget_factory(cls, parent: QWidget) -> ManualLabelWidget:
+    def _label_widget_factory(cls, parent: QWidget, compact: bool = False) -> ManualLabelWidget:
         """factory method to create the label widget
 
         This is done to make it easier to subclass the widget and swap out the label widget
         """
-        return ManualLabelWidget(parent)
+        return ManualLabelWidget(parent, compact=compact)
 
     def _set_layout(self) -> None:
         """Set up the vertical layout for the widget.

--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/manual_label_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/manual_label_widget.py
@@ -39,6 +39,7 @@ class ManualLabelWidget(QWidget):
     _BORDER_COLOR = QColor(212, 212, 212)
 
     _BAR_HEIGHT = 30
+    _BAR_HEIGHT_COMPACT = 18
     _DEFAULT_WIDTH = 400
     _DEFAULT_WINDOW_SIZE = 100
     _TICK_HEIGHT = 4
@@ -54,6 +55,8 @@ class ManualLabelWidget(QWidget):
     GAP_ALPHA = 128  # semi-transparent for gaps
 
     def __init__(self, *args, **kwargs) -> None:
+        # need to strip "compact" out of kwargs before calling super
+        self._compact = compact = kwargs.pop("compact", False)
         super().__init__(*args, **kwargs)
 
         # allow widget to expand horizontally but maintain fixed vertical size
@@ -80,7 +83,7 @@ class ManualLabelWidget(QWidget):
         # search results to render in the bar
         self._search_results: list[SearchHit] = []
 
-        self._bar_height = self._BAR_HEIGHT
+        self._bar_height = self._BAR_HEIGHT_COMPACT if compact else self._BAR_HEIGHT
 
         # size each frame takes up in the bar in pixels
         self._frame_width = self.size().width() // self._window_frames_total
@@ -91,6 +94,24 @@ class ManualLabelWidget(QWidget):
         self._position_marker_pen = QPen(POSITION_MARKER_COLOR, 1, Qt.PenStyle.SolidLine)
         self._selection_brush = QBrush(SELECTION_COLOR, Qt.BrushStyle.DiagCrossPattern)
         self._padding_brush = QBrush(BACKGROUND_COLOR, Qt.BrushStyle.Dense6Pattern)
+
+    @property
+    def compact(self) -> bool:
+        """Whether the widget is in compact mode.
+
+        Returns:
+            bool: True if the widget is in compact mode, False otherwise.
+        """
+        return self._compact
+
+    @compact.setter
+    def compact(self, value: bool) -> None:
+        """Set compact mode and trigger a layout and repaint update."""
+        if self._compact != value:
+            self._compact = value
+            self._bar_height = self._BAR_HEIGHT_COMPACT if self._compact else self._BAR_HEIGHT
+            self.updateGeometry()
+            self.update()
 
     def sizeHint(self) -> QSize:
         """Return the recommended initial size for the widget.

--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/predicted_label_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/predicted_label_widget.py
@@ -138,8 +138,12 @@ class PredictedLabelWidget(ManualLabelWidget):
         self._probabilities = probabilities
         self.update()
 
-    def start_selection(self, start_frame: int) -> None:
-        """Not supported in PredictedLabelWidget"""
+    def start_selection(self, start_frame: int, end_frame: int | None = None) -> None:
+        """Not supported in PredictedLabelWidget.
+
+        Raises:
+            NotImplementedError: Always; selection is not supported on prediction widgets.
+        """
         raise NotImplementedError
 
     def clear_selection(self) -> None:

--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/prediction_overview_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/prediction_overview_widget.py
@@ -1,4 +1,5 @@
 import numpy as np
+from PySide6.QtWidgets import QWidget
 
 from .label_overview_widget import LabelOverviewWidget
 from .predicted_label_widget import PredictedLabelWidget
@@ -18,8 +19,9 @@ class PredictionOverviewWidget(LabelOverviewWidget):
         return TimelinePredictionWidget(parent)
 
     @classmethod
-    def _label_widget_factory(cls, parent):
-        return PredictedLabelWidget(parent)
+    def _label_widget_factory(cls, parent: QWidget, compact: bool = False) -> PredictedLabelWidget:
+        """Create a PredictedLabelWidget as the label widget for this overview."""
+        return PredictedLabelWidget(parent, compact=compact)
 
     def set_labels(self, labels: np.ndarray, probabilities: np.ndarray):
         """set prediction data to display

--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/timeline_label_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/timeline_label_widget.py
@@ -49,8 +49,8 @@ class TimelineLabelWidget(QWidget):
         ],
         dtype=np.uint8,
     )
-    _BAR_HEIGHT = 8  # height of the bar in pixels
-    _BAR_PADDING = 3  # padding around the bar in pixels
+    _BAR_HEIGHT = 7  # height of the bar in pixels
+    _BAR_PADDING = 2  # padding around the bar in pixels
     _WINDOW_SIZE = 100  # number of frames to show on either side of the current frame
 
     def __init__(self, *args, **kwargs) -> None:

--- a/src/jabs/ui/stacked_timeline_widget/stacked_timeline_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/stacked_timeline_widget.py
@@ -52,21 +52,21 @@ class StackedTimelineWidget(QWidget):
 
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
-        self._active_identity_index = None
-        self._selection_starting_frame = None
-        self._selection_ending_frame = None
+        self._active_identity_index: int | None = None
+        self._selection_starting_frame: int | None = None
+        self._selection_ending_frame: int | None = None
         self._view_mode = self.ViewMode.LABELS_AND_PREDICTIONS
         self._identity_mode = self.IdentityMode.ACTIVE
         self._num_identities = 0
         self._num_frames = 0
         self._framerate = 0
         self._label_overview_widgets: list[LabelOverviewWidget] = []
-        self._prediction_overview_widgets = []
-        self._identity_frames = []
+        self._prediction_overview_widgets: list[PredictionOverviewWidget] = []
+        self._identity_frames: list[QFrame] = []
         self._frame_labels = FrameLabelsWidget(self)
         self._pose: PoseEstimation | None = None
 
-        self._layout = QVBoxLayout(self)
+        self._layout: QVBoxLayout = QVBoxLayout(self)
         self._layout.setContentsMargins(0, 0, 0, 0)
         self._layout.setSpacing(0)
 
@@ -77,14 +77,16 @@ class StackedTimelineWidget(QWidget):
 
     def _label_overview_widget_factory(self, parent) -> LabelOverviewWidget:
         """Factory method to create a label overview widget."""
-        widget = LabelOverviewWidget(parent)
+        widget = LabelOverviewWidget(parent, compact=self._identity_mode == self.IdentityMode.ALL)
         widget.num_frames = self.num_frames
         widget.framerate = self.framerate
         return widget
 
     def _prediction_overview_widget_factory(self, parent) -> PredictionOverviewWidget:
         """Factory method to create a prediction overview widget."""
-        widget = PredictionOverviewWidget(parent)
+        widget = PredictionOverviewWidget(
+            parent, compact=self._identity_mode == self.IdentityMode.ALL
+        )
         widget.num_frames = self.num_frames
         widget.framerate = self.framerate
         return widget
@@ -231,7 +233,7 @@ class StackedTimelineWidget(QWidget):
         self._framerate = value
 
     @property
-    def active_identity_index(self) -> int:
+    def active_identity_index(self) -> int | None:
         """Get the index of the active identity."""
         return self._active_identity_index
 
@@ -255,7 +257,7 @@ class StackedTimelineWidget(QWidget):
             self._active_identity_index = value
 
             # Transfer selection to new active widget if selection is active
-            if selection_frame is not None:
+            if selection_frame is not None and self._active_identity_index is not None:
                 self._label_overview_widgets[self._active_identity_index].start_selection(
                     selection_frame,
                     self._selection_ending_frame,
@@ -275,12 +277,14 @@ class StackedTimelineWidget(QWidget):
             self._set_active_frame_border(-1)
 
     def _update_widget_visibility(self) -> None:
+        """Rebuild the layout to show only the widgets appropriate for the current modes."""
         # Remove all widgets from the layout
         while self._layout.count():
             item = self._layout.takeAt(0)
-            widget = item.widget()
-            if widget is not None:
-                widget.hide()
+            if item is not None:
+                widget = item.widget()
+                if widget is not None:
+                    widget.hide()
 
         # Add only the widgets needed for the current mode
         if self._identity_mode == self.IdentityMode.ALL:
@@ -291,6 +295,8 @@ class StackedTimelineWidget(QWidget):
                     self._label_overview_widgets[i],
                     self._prediction_overview_widgets[i],
                 )
+                self._label_overview_widgets[i].compact = True
+                self._prediction_overview_widgets[i].compact = True
         elif (
             self._identity_mode == self.IdentityMode.ACTIVE
             and self._active_identity_index is not None
@@ -303,6 +309,8 @@ class StackedTimelineWidget(QWidget):
                 self._label_overview_widgets[idx],
                 self._prediction_overview_widgets[idx],
             )
+            self._label_overview_widgets[idx].compact = False
+            self._prediction_overview_widgets[idx].compact = False
 
         # Add FrameLabelsWidget last
         self._layout.addWidget(self._frame_labels)


### PR DESCRIPTION
This pull request adds support for a "compact" display mode for label and prediction overview widgets in the timeline UI. The compact mode reduces the visual height of the widgets, making it easier to display multiple identities at once. The implementation introduces a `compact` property to relevant widgets, updates factory methods and constructors to accept this parameter, and ensures the correct mode is set based on the current identity display mode.

**Compact mode support for overview widgets:**

* Added a `compact` parameter and property to `LabelOverviewWidget`, `ManualLabelWidget`, and `PredictedLabelWidget`, allowing these widgets to adjust their layout and bar height for a more compact display. The bar height in compact mode is reduced (e.g., from 30 to 18 in `ManualLabelWidget`). 
* Updated widget factory methods in `stacked_timeline_widget.py` to pass the `compact` parameter based on the current identity mode, ensuring that widgets are initialized in the correct display mode. 

**Widget and layout improvements:**

* Modified the `_update_widget_visibility` method to toggle the `compact` property on all visible label and prediction overview widgets depending on the selected identity mode (ALL or ACTIVE). 
* Improved type annotations and initialization for internal widget lists and selection-related attributes in `StackedTimelineWidget` for better code clarity and type safety. 

**Other minor changes:**

* Adjusted bar height and padding constants in `TimelineLabelWidget` for a more compact appearance. 
* Updated the signature and documentation of the `start_selection` method in `PredictedLabelWidget` to clarify that selection is not supported.
