### PR TITLE
Implement MultiClassClassifier with validation and visualization enhancements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,8 @@ cache invalidation logic (version mismatch, pose hash, distance scale).
 - Use American English spelling (e.g., "behavior" not "behaviour").
 - Prefer importing at the top of the module. It is acceptable to import within
   functions/methods if an expensive import is only needed in specific code paths.
+- Do not use ambiguous `–` (EN DASH) in docstrings. Use `-` (HYPHEN-MINUS) to avoid 
+  Ruff RUF001 error.
 
 ## Coding Standards
 

--- a/dev/preview_multiclass_timeline.py
+++ b/dev/preview_multiclass_timeline.py
@@ -1,0 +1,349 @@
+"""Preview script: StackedTimelineWidget with fake multi-class data.
+
+Run with:
+    uv run python preview_multiclass_timeline.py
+
+Displays 3 identities, 3 behaviors, ~2 000 frames.  A slider scrubs through
+frames; radio buttons toggle binary / multi-class mode and single / all-identity
+view so you can compare layouts.
+"""
+
+import sys
+
+import numpy as np
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QKeySequence, QShortcut
+from PySide6.QtWidgets import (
+    QApplication,
+    QButtonGroup,
+    QCheckBox,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QMainWindow,
+    QPushButton,
+    QRadioButton,
+    QScrollArea,
+    QSlider,
+    QVBoxLayout,
+    QWidget,
+)
+
+from jabs.core.enums import ClassifierMode
+from jabs.ui.stacked_timeline_widget import StackedTimelineWidget
+
+# ---------------------------------------------------------------------------
+# Fake pose shim (duck-types the attributes/method that _reset_layout needs)
+# ---------------------------------------------------------------------------
+
+
+class _FakePose:
+    def __init__(self, num_identities: int, num_frames: int) -> None:
+        self.num_identities = num_identities
+        self.num_frames = num_frames
+
+    def identity_index_to_display(self, index: int) -> str:
+        return f"Mouse {index + 1}"
+
+
+# ---------------------------------------------------------------------------
+# Fake data generation
+# ---------------------------------------------------------------------------
+
+NUM_IDENTITIES = 3
+NUM_FRAMES = 2000
+FRAMERATE = 30
+BEHAVIORS = ["grooming", "rearing", "locomotion"]
+
+rng = np.random.default_rng(seed=42)
+
+
+def _make_bouts(n_frames: int, avg_gap: int = 120, avg_dur: int = 60) -> np.ndarray:
+    """Return a boolean mask with random on/off bouts."""
+    mask = np.zeros(n_frames, dtype=bool)
+    frame = 0
+    while frame < n_frames:
+        frame += max(10, int(rng.exponential(avg_gap)))
+        dur = max(5, int(rng.exponential(avg_dur)))
+        mask[frame : frame + dur] = True
+        frame += dur
+    return mask
+
+
+def _make_multiclass_labels(n_frames: int) -> np.ndarray:
+    """Build a combined class-index label array for one identity.
+
+    Index layout (matches build_multiclass_color_lut):
+      0 = unlabeled, 1 = "None", 2 = grooming, 3 = rearing, 4 = locomotion
+    """
+    labels = np.zeros(n_frames, dtype=np.int16)
+    for behavior_idx in range(len(BEHAVIORS)):
+        bouts = _make_bouts(n_frames, avg_gap=200, avg_dur=50)
+        free = labels == 0
+        labels[free & bouts] = behavior_idx + 2
+    none_bouts = _make_bouts(n_frames, avg_gap=400, avg_dur=20)
+    labels[(labels == 0) & none_bouts] = 1
+    return labels
+
+
+def _make_binary_labels(n_frames: int) -> np.ndarray:
+    """Binary LUT-index labels: 1 = not-behavior, 2 = behavior."""
+    arr = np.ones(n_frames, dtype=np.int16)
+    arr[_make_bouts(n_frames, avg_gap=200, avg_dur=60)] = 2
+    return arr
+
+
+def _make_per_class_predictions(
+    n_frames: int,
+) -> tuple[list[np.ndarray], list[np.ndarray]]:
+    """Per-class binary predictions + probabilities for one identity.
+
+    Returns one array per class: [None/background, behA, behB, behC, ...].
+    Each prediction array uses the 3-entry per-class LUT:
+      0 = no pose, 1 = not this class, 2 = this class predicted.
+    """
+    behavior_bouts = [_make_bouts(n_frames, avg_gap=200, avg_dur=55) for _ in BEHAVIORS]
+    any_behavior = np.zeros(n_frames, dtype=bool)
+    for b in behavior_bouts:
+        any_behavior |= b
+
+    preds, probs = [], []
+
+    # None/background class: predicted wherever no behavior is active
+    none_pred = np.ones(n_frames, dtype=np.int16)
+    none_pred[~any_behavior] = 2
+    none_prob = np.where(
+        ~any_behavior,
+        rng.uniform(0.6, 1.0, n_frames),
+        rng.uniform(0.0, 0.3, n_frames),
+    ).astype(np.float32)
+    preds.append(none_pred)
+    probs.append(none_prob)
+
+    for bouts in behavior_bouts:
+        pred = np.ones(n_frames, dtype=np.int16)
+        pred[bouts] = 2
+        prob = np.where(
+            bouts,
+            rng.uniform(0.6, 1.0, n_frames),
+            rng.uniform(0.0, 0.3, n_frames),
+        ).astype(np.float32)
+        preds.append(pred)
+        probs.append(prob)
+
+    return preds, probs
+
+
+# ---------------------------------------------------------------------------
+# Pre-generate data for all identities
+# ---------------------------------------------------------------------------
+
+MULTICLASS_LABELS = [_make_multiclass_labels(NUM_FRAMES) for _ in range(NUM_IDENTITIES)]
+BINARY_LABELS = [_make_binary_labels(NUM_FRAMES) for _ in range(NUM_IDENTITIES)]
+MASKS = [np.ones(NUM_FRAMES, dtype=np.int8) for _ in range(NUM_IDENTITIES)]
+
+_mc_data = [_make_per_class_predictions(NUM_FRAMES) for _ in range(NUM_IDENTITIES)]
+MULTICLASS_PREDS_LIST = [preds for preds, _ in _mc_data]
+MULTICLASS_PROBS_LIST = [probs for _, probs in _mc_data]
+
+BINARY_PREDS_LIST = [[_make_binary_labels(NUM_FRAMES)] for _ in range(NUM_IDENTITIES)]
+BINARY_PROBS_LIST = [
+    [rng.uniform(0.0, 1.0, NUM_FRAMES).astype(np.float32)] for _ in range(NUM_IDENTITIES)
+]
+
+FAKE_POSE = _FakePose(NUM_IDENTITIES, NUM_FRAMES)
+
+
+# ---------------------------------------------------------------------------
+# Main window
+# ---------------------------------------------------------------------------
+
+
+class PreviewWindow(QMainWindow):
+    """Simple preview window for StackedTimelineWidget multi-class layout."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("StackedTimelineWidget — multi-class preview")
+        self.resize(1200, 500)
+
+        self._mode = ClassifierMode.MULTICLASS
+
+        central = QWidget()
+        self.setCentralWidget(central)
+        root_layout = QVBoxLayout(central)
+
+        # ---- Controls row --------------------------------------------------
+        controls = QWidget()
+        controls_layout = QHBoxLayout(controls)
+        controls_layout.setContentsMargins(4, 4, 4, 4)
+
+        # Classifier mode toggle
+        mode_box = QGroupBox("Classifier mode")
+        mode_layout = QHBoxLayout(mode_box)
+        self._rb_multiclass = QRadioButton("Multi-class")
+        self._rb_binary = QRadioButton("Binary")
+        self._rb_multiclass.setChecked(True)
+        mode_group = QButtonGroup(self)
+        mode_group.addButton(self._rb_multiclass)
+        mode_group.addButton(self._rb_binary)
+        mode_layout.addWidget(self._rb_multiclass)
+        mode_layout.addWidget(self._rb_binary)
+        self._rb_multiclass.toggled.connect(self._on_mode_toggled)
+
+        # Identity view toggle
+        identity_box = QGroupBox("Identity view")
+        identity_layout = QHBoxLayout(identity_box)
+        self._rb_active = QRadioButton("Active only")
+        self._rb_all = QRadioButton("All animals")
+        self._rb_active.setChecked(True)
+        identity_group = QButtonGroup(self)
+        identity_group.addButton(self._rb_active)
+        identity_group.addButton(self._rb_all)
+        identity_layout.addWidget(self._rb_active)
+        identity_layout.addWidget(self._rb_all)
+        self._rb_all.toggled.connect(self._on_identity_mode_toggled)
+
+        # Collapse inactive checkboxes (only relevant in all-animals mode)
+        collapse_box = QGroupBox("Collapse inactive")
+        collapse_layout = QHBoxLayout(collapse_box)
+        self._chk_collapse_label = QCheckBox("Label bar")
+        self._chk_collapse_label.setChecked(False)
+        self._chk_collapse_label.setEnabled(False)
+        self._chk_collapse_combined = QCheckBox("Combined bar")
+        self._chk_collapse_combined.setChecked(False)
+        self._chk_collapse_combined.setEnabled(False)
+        self._chk_collapse_per_class = QCheckBox("Per-class bars")
+        self._chk_collapse_per_class.setChecked(True)
+        self._chk_collapse_per_class.setEnabled(False)
+        collapse_layout.addWidget(self._chk_collapse_label)
+        collapse_layout.addWidget(self._chk_collapse_combined)
+        collapse_layout.addWidget(self._chk_collapse_per_class)
+        self._chk_collapse_label.toggled.connect(
+            lambda v: setattr(self._timeline, "collapse_inactive_label_bar", v)
+        )
+        self._chk_collapse_combined.toggled.connect(
+            lambda v: setattr(self._timeline, "collapse_inactive_combined_bar", v)
+        )
+        self._chk_collapse_per_class.toggled.connect(
+            lambda v: setattr(self._timeline, "collapse_inactive_per_class_bars", v)
+        )
+
+        # Frame slider
+        slider_box = QGroupBox(f"Frame  (0 - {NUM_FRAMES - 1})")
+        slider_layout = QHBoxLayout(slider_box)
+        self._slider = QSlider(Qt.Orientation.Horizontal)
+        self._slider.setRange(0, NUM_FRAMES - 1)
+        self._slider.setValue(0)
+        self._frame_label = QLabel("0")
+        self._frame_label.setFixedWidth(50)
+        slider_layout.addWidget(self._slider)
+        slider_layout.addWidget(self._frame_label)
+        self._slider.valueChanged.connect(self._on_frame_changed)
+
+        # Active identity selector
+        identity_sel_box = QGroupBox("Active identity  ([ / ]  or  Tab)")
+        identity_sel_layout = QHBoxLayout(identity_sel_box)
+        self._btn_prev_id = QPushButton("<")
+        self._btn_prev_id.setFixedWidth(28)
+        self._btn_next_id = QPushButton(">")
+        self._btn_next_id.setFixedWidth(28)
+        self._active_id_label = QLabel(self._identity_display(0))
+        self._active_id_label.setFixedWidth(70)
+        identity_sel_layout.addWidget(self._btn_prev_id)
+        identity_sel_layout.addWidget(self._active_id_label)
+        identity_sel_layout.addWidget(self._btn_next_id)
+        self._btn_prev_id.clicked.connect(self._prev_identity)
+        self._btn_next_id.clicked.connect(self._next_identity)
+
+        controls_layout.addWidget(mode_box)
+        controls_layout.addWidget(identity_box)
+        controls_layout.addWidget(collapse_box)
+        controls_layout.addWidget(identity_sel_box)
+        controls_layout.addWidget(slider_box, stretch=1)
+
+        root_layout.addWidget(controls)
+
+        # ---- Keyboard shortcuts -------------------------------------------
+        QShortcut(QKeySequence(Qt.Key.Key_Tab), self).activated.connect(self._next_identity)
+        QShortcut(QKeySequence("["), self).activated.connect(self._prev_identity)
+        QShortcut(QKeySequence("]"), self).activated.connect(self._next_identity)
+
+        # ---- Scrollable timeline area -------------------------------------
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+
+        self._timeline = StackedTimelineWidget()
+        scroll.setWidget(self._timeline)
+        root_layout.addWidget(scroll, stretch=1)
+
+        # ---- Load initial data -------------------------------------------
+        self._timeline.pose = FAKE_POSE
+        self._timeline.framerate = FRAMERATE
+        self._apply_mode()
+
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _identity_display(index: int) -> str:
+        return FAKE_POSE.identity_index_to_display(index)
+
+    def _set_active_identity(self, index: int) -> None:
+        self._timeline.active_identity_index = index
+        self._active_id_label.setText(
+            f"{self._identity_display(index)}  ({index + 1}/{NUM_IDENTITIES})"
+        )
+
+    def _prev_identity(self) -> None:
+        current = self._timeline.active_identity_index or 0
+        self._set_active_identity((current - 1) % NUM_IDENTITIES)
+
+    def _next_identity(self) -> None:
+        current = self._timeline.active_identity_index or 0
+        self._set_active_identity((current + 1) % NUM_IDENTITIES)
+
+    def _apply_mode(self) -> None:
+        """Push the current mode + fake data into the timeline widget."""
+        if self._mode == ClassifierMode.MULTICLASS:
+            self._timeline.set_classifier_mode(ClassifierMode.MULTICLASS, BEHAVIORS)
+            self._timeline.set_labels(MULTICLASS_LABELS, MASKS)
+            self._timeline.set_predictions(MULTICLASS_PREDS_LIST, MULTICLASS_PROBS_LIST)
+        else:
+            self._timeline.set_classifier_mode(ClassifierMode.BINARY, [])
+            self._timeline.set_labels(BINARY_LABELS, MASKS)
+            self._timeline.set_predictions(BINARY_PREDS_LIST, BINARY_PROBS_LIST)
+
+    def _on_mode_toggled(self, checked: bool) -> None:
+        if checked:
+            self._mode = ClassifierMode.MULTICLASS
+        else:
+            self._mode = ClassifierMode.BINARY
+        self._apply_mode()
+
+    def _on_identity_mode_toggled(self, _checked: bool) -> None:
+        is_all = self._rb_all.isChecked()
+        self._timeline.identity_mode = (
+            StackedTimelineWidget.IdentityMode.ALL
+            if is_all
+            else StackedTimelineWidget.IdentityMode.ACTIVE
+        )
+        self._chk_collapse_label.setEnabled(is_all)
+        self._chk_collapse_combined.setEnabled(is_all)
+        self._chk_collapse_per_class.setEnabled(is_all)
+
+    def _on_frame_changed(self, frame: int) -> None:
+        self._frame_label.setText(str(frame))
+        self._timeline.set_current_frame(frame)
+
+
+def main() -> None:
+    """Entry point."""
+    app = QApplication(sys.argv)
+    win = PreviewWindow()
+    win.show()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/preview_multiclass_timeline.py
+++ b/dev/preview_multiclass_timeline.py
@@ -229,6 +229,17 @@ class PreviewWindow(QMainWindow):
             lambda v: setattr(self._timeline, "collapse_inactive_per_class_bars", v)
         )
 
+        # Hide per-class rows entirely for inactive animals
+        hide_box = QGroupBox("Hide inactive")
+        hide_layout = QHBoxLayout(hide_box)
+        self._chk_hide_per_class = QCheckBox("Per-class bars")
+        self._chk_hide_per_class.setChecked(False)
+        self._chk_hide_per_class.setEnabled(False)
+        hide_layout.addWidget(self._chk_hide_per_class)
+        self._chk_hide_per_class.toggled.connect(
+            lambda v: setattr(self._timeline, "hide_inactive_per_class_widgets", v)
+        )
+
         # Frame slider
         slider_box = QGroupBox(f"Frame  (0 - {NUM_FRAMES - 1})")
         slider_layout = QHBoxLayout(slider_box)
@@ -259,9 +270,11 @@ class PreviewWindow(QMainWindow):
         controls_layout.addWidget(mode_box)
         controls_layout.addWidget(identity_box)
         controls_layout.addWidget(collapse_box)
+        controls_layout.addWidget(hide_box)
         controls_layout.addWidget(identity_sel_box)
         controls_layout.addWidget(slider_box, stretch=1)
 
+        self._controls = controls
         root_layout.addWidget(controls)
 
         # ---- Keyboard shortcuts -------------------------------------------
@@ -270,13 +283,13 @@ class PreviewWindow(QMainWindow):
         QShortcut(QKeySequence("]"), self).activated.connect(self._next_identity)
 
         # ---- Scrollable timeline area -------------------------------------
-        scroll = QScrollArea()
-        scroll.setWidgetResizable(True)
-        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self._scroll = QScrollArea()
+        self._scroll.setWidgetResizable(True)
+        self._scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
 
         self._timeline = StackedTimelineWidget()
-        scroll.setWidget(self._timeline)
-        root_layout.addWidget(scroll, stretch=1)
+        self._scroll.setWidget(self._timeline)
+        root_layout.addWidget(self._scroll, stretch=1)
 
         # ---- Load initial data -------------------------------------------
         self._timeline.pose = FAKE_POSE
@@ -331,6 +344,25 @@ class PreviewWindow(QMainWindow):
         self._chk_collapse_label.setEnabled(is_all)
         self._chk_collapse_combined.setEnabled(is_all)
         self._chk_collapse_per_class.setEnabled(is_all)
+        self._chk_hide_per_class.setEnabled(is_all)
+        self._resize_to_content()
+
+    def _resize_to_content(self) -> None:
+        """Resize the window height to fit the current timeline content."""
+        margins = self.centralWidget().layout().contentsMargins()
+        controls_h = self._controls.sizeHint().height()
+        timeline_h = self._timeline.sizeHint().height()
+        chrome = self.frameGeometry().height() - self.geometry().height()
+        needed = (
+            controls_h
+            + timeline_h
+            + margins.top()
+            + margins.bottom()
+            + chrome
+            + 8  # a little breathing room
+        )
+        screen_h = self.screen().availableGeometry().height()
+        self.resize(self.width(), min(needed, screen_h - 40))
 
     def _on_frame_changed(self, frame: int) -> None:
         self._frame_label.setText(str(frame))

--- a/docs/user-guide/cli-tools.md
+++ b/docs/user-guide/cli-tools.md
@@ -161,7 +161,7 @@ jabs-init <project_dir> [--metadata <metadata.json>] [--force] [--processes <N>]
 - `--force`: Recompute features even if cache files already exist.
 - `--processes <N>`: Number of parallel workers to use for feature computation. If omitted, this defaults to the logical CPU count.
 - `-w WINDOW_SIZE`: Window size(s) to pre-compute. Can be repeated (e.g. `-w 2 -w 5`). Defaults to 5 if omitted.
-- `--cache-format {hdf5,parquet}`: Feature cache storage format. Defaults to `parquet`. Use `hdf5` only for compatibility with older JABS versions.
+- `--cache-format {hdf5,parquet}`: Feature cache storage format. If omitted, the existing project setting is preserved. New projects default to `parquet`; projects created before this option existed default to `hdf5`. Pass `--cache-format` explicitly only when you want to change or set the format — use `--force` alongside it to rewrite existing cache files in the new format.
 - `--skip-feature-generation`: Validate and initialize the project without computing features.
 
 **Examples:**

--- a/docs/user-guide/cli-tools.md
+++ b/docs/user-guide/cli-tools.md
@@ -20,7 +20,8 @@ See `jabs-classify COMMAND --help` for information on a specific command.
 usage: jabs-classify classify [-h] [--random-forest | --xgboost]
                             (--training TRAINING | --classifier CLASSIFIER) --input-pose
                             INPUT_POSE --out-dir OUT_DIR [--fps FPS]
-                            [--feature-dir FEATURE_DIR]
+                            [--feature-dir FEATURE_DIR] [--skip-window-cache]
+                            [--use-pose-hash]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -28,6 +29,12 @@ optional arguments:
   --feature-dir FEATURE_DIR
                         Feature cache dir. If present, look here for features before computing.
                         If features need to be computed, they will be saved here.
+  --skip-window-cache   Only cache per-frame features when --feature-dir is provided, reducing
+                        cache size at the cost of needing to re-calculate window features.
+  --use-pose-hash       Include the pose file hash as a subdirectory level in the feature cache
+                        path (e.g. <feature-dir>/<video>/<pose-hash>/<identity>). Prevents
+                        collisions when multiple pipelines share a feature cache directory and
+                        different pose files happen to share the same video name.
 
 required arguments:
   --input-pose INPUT_POSE
@@ -45,6 +52,8 @@ Classifier Input (one of the following is required):
   --classifier CLASSIFIER
                         Classifier file produced from the `jabs-classify train` command
 ```
+
+When `--feature-dir` is provided, `jabs-classify` automatically detects the existing cache format (HDF5 or Parquet) and reads from it. New cache files are always written in Parquet format. If the directory already contains an HDF5 cache, it is read as-is and any new window features are added to the existing HDF5 file — no conversion takes place.
 
 ### Train Command
 
@@ -77,6 +86,7 @@ JABS includes a script called `jabs-features`, which can be used to generate a f
 usage: jabs-features [-h] --pose-file POSE_FILE --pose-version POSE_VERSION
                             --feature-dir FEATURE_DIR [--use-cm-distances]
                             [--window-size WINDOW_SIZE] [--fps FPS]
+                            [--use-pose-hash]
 
 options:
   -h, --help            show this help message and exit
@@ -90,7 +100,12 @@ options:
   --window-size WINDOW_SIZE
                         window size for features (default none)
   --fps FPS             frames per second to use for feature calculation
+  --use-pose-hash       Include the pose file hash as a subdirectory level in the feature cache
+                        path (e.g. <feature-dir>/<video>/<pose-hash>/<identity>). Prevents
+                        collisions when a shared cache directory is used across multiple pipelines.
 ```
+
+Features are always written in Parquet format. Use `--use-pose-hash` when building a shared feature cache for multiple pipelines where video filenames may collide.
 
 ## jabs-cli
 
@@ -138,20 +153,31 @@ The `jabs-init` command initializes a JABS project directory and computes featur
 
 ```bash
 jabs-init <project_dir> [--metadata <metadata.json>] [--force] [--processes <N>]
+          [-w WINDOW_SIZE] [--cache-format {hdf5,parquet}] [--skip-feature-generation]
 ```
 
 - `<project_dir>`: Path to the JABS project directory containing video and pose files.
 - `--metadata <metadata.json>`: Optional path to a JSON metadata file describing the project and videos.
-- `--force`: Overwrite existing features and settings if present.
+- `--force`: Recompute features even if cache files already exist.
 - `--processes <N>`: Number of parallel workers to use for feature computation. If omitted, this defaults to the logical CPU count.
+- `-w WINDOW_SIZE`: Window size(s) to pre-compute. Can be repeated (e.g. `-w 2 -w 5`). Defaults to 5 if omitted.
+- `--cache-format {hdf5,parquet}`: Feature cache storage format. Defaults to `parquet`. Use `hdf5` only for compatibility with older JABS versions.
+- `--skip-feature-generation`: Validate and initialize the project without computing features.
 
-**Example:**
+**Examples:**
 
 ```bash
-jabs-init /path/to/project --metadata project_metadata.json --processes 8
+# Initialize a project with default settings (Parquet cache, window size 5)
+jabs-init /path/to/project
+
+# Initialize with metadata, 8 workers, and explicit window sizes
+jabs-init /path/to/project --metadata project_metadata.json --processes 8 -w 2 -w 5
+
+# Migrate an existing HDF5 cache to Parquet (recomputes all features)
+jabs-init /path/to/project --cache-format parquet --force
 ```
 
-See the [Project Setup Guide](project-setup.md#initialization--jabs-init) for a brief overview.
+See the [Project Setup Guide](project-setup.md#initialization--jabs-init) for a brief overview and [Feature Cache Format](project-setup.md#feature-cache-format) for migration guidance.
 
 ## jabs-cli update-pose
 

--- a/docs/user-guide/keyboard-shortcuts.md
+++ b/docs/user-guide/keyboard-shortcuts.md
@@ -13,7 +13,8 @@
 
 | Action                        | Shortcut   |
 |-------------------------------|------------|
-| Play / Pause video            | Space bar  |
+| Play / Pause video            | Space bar        |
+| Play current bout             | Shift+Space bar  |
 | Previous / Next frame         | ← / →      |
 | Move forward / back 10 frames | ↑ / ↓      |
 | Previous / Next video         | , / .      |

--- a/docs/user-guide/keyboard-shortcuts.md
+++ b/docs/user-guide/keyboard-shortcuts.md
@@ -2,41 +2,42 @@
 
 ## Application
 
-| Action                      | Shortcut      |
-| --------------------------- | ------------- |
-| Quit JABS                   | Ctrl+Q / ⌘Q   |
-| Export current frame        | Ctrl+E / ⌘E   |
-| Export training data        | Ctrl+T / ⌘T   |
-| Open behavior search dialog | Ctrl+F / ⌘F   |
+| Action                      | Shortcut    |
+|-----------------------------|-------------|
+| Quit JABS                   | Ctrl+Q / ⌘Q |
+| Export current frame        | Ctrl+E / ⌘E |
+| Export training data        | Ctrl+T / ⌘T |
+| Open behavior search dialog | Ctrl+F / ⌘F |
 
 ## Video Navigation
 
-| Action                        | Shortcut  |
-| ----------------------------- | --------- |
-| Play / Pause video            | Space bar |
-| Previous / Next frame         | ← / →     |
-| Move forward / back 10 frames | ↑ / ↓     |
-| Previous / Next video         | , / .     |
+| Action                        | Shortcut   |
+|-------------------------------|------------|
+| Play / Pause video            | Space bar  |
+| Previous / Next frame         | ← / →      |
+| Move forward / back 10 frames | ↑ / ↓      |
+| Previous / Next video         | , / .      |
 
 ## Labeling
 
-| Action                                   | Shortcut       |
-| ---------------------------------------- | -------------- |
-| Start select mode                        | z, x, c        |
-| Label selection as behavior              | z              |
-| Clear labels from selection              | x              |
-| Label selection as not behavior          | c              |
-| Exit select mode without making a change | Esc            |
-| Select all frames                        | Ctrl+A / ⌘A   |
+| Action                                   | Shortcut           |
+|------------------------------------------|--------------------|
+| Start select mode                        | z, x, c            |
+| Label selection as behavior              | z                  |
+| Clear labels from selection              | x                  |
+| Label selection as not behavior          | c                  |
+| Exit select mode without making a change | Esc                |
+| Select all frames                        | Ctrl+A / ⌘A        |
+| Select current bout                      | Ctrl+Shift+A / ⌘⇧A |
 
 ## Identity & Overlays
 
 | Action                            | Shortcut          |
-| --------------------------------- | ----------------- |
+|-----------------------------------|-------------------|
 | Switch to next / previous subject | Shift+↑ / Shift+↓ |
 | Toggle track overlay              | t                 |
 | Toggle pose overlay               | p                 |
 | Toggle landmark overlay           | l                 |
-| Toggle Minimalist Identity Labels | Ctrl+I / ⌘I   |
+| Toggle Minimalist Identity Labels | Ctrl+I / ⌘I       |
 
 > **Note:** Next/previous subject order follows the "Identity Selection" dropdown ordering.

--- a/docs/user-guide/project-setup.md
+++ b/docs/user-guide/project-setup.md
@@ -166,7 +166,19 @@ This directory contains trained classifiers. Currently, these are stored in Pyth
 
 ### jabs/features
 
-This directory contains the computed features. There is one directory per project video, and within each video directory there will be one feature subdirectory per identity. Feature files are portable between machines, but JABS may need to recompute the features if they were created with a different version of JABS. Feature files contain a version attribute that is incremented when features are added or changed, or the format of the features file is changed.
+This directory contains the computed features. There is one directory per project video, and within each video directory there will be one feature subdirectory per identity:
+
+```
+jabs/features/
+└── video_name/
+    ├── 0/          ← identity 0
+    ├── 1/          ← identity 1
+    └── ...
+```
+
+Feature files are portable between machines, but JABS may need to recompute them if the version of JABS that computed them is different from the one reading them. Each cache records a feature version number that is incremented whenever features are added, changed, or the cache format is updated.
+
+JABS supports two feature cache formats: **HDF5** (the original format) and **Parquet** (the current default). See [Feature Cache Format](#feature-cache-format) below for details and migration guidance.
 
 ### jabs/predictions
 
@@ -175,3 +187,44 @@ This directory contains one HDF5 prediction file per video (e.g., `VIDEO_1.h5`).
 ### jabs/training_logs
 
 This directory contains training reports generated each time a classifier is trained. Reports are saved as Markdown files with filenames in the format `<BehaviorName>_<timestamp>_training_report.md`. Each report includes training performance metrics, cross-validation results, and feature importance rankings. These reports provide a permanent record of training sessions for documentation and comparison purposes.
+
+## Feature Cache Format
+
+JABS supports two storage formats for the computed feature cache:
+
+| Format      | Description |
+|-------------|-------------|
+| **Parquet** | The current default. A columnar format that offers faster reads and smaller file sizes. Each identity directory contains `metadata.json`, `per_frame.parquet`, and one `window_<N>.parquet` file per cached window size. |
+| **HDF5**    | The original format. All features for an identity are stored in a single `features.h5` file. Supported by all versions of JABS. |
+
+New projects created with `jabs-init` or the GUI default to Parquet. JABS automatically detects the format of existing cache files on read, so HDF5 and Parquet projects both open correctly without any manual configuration.
+
+### Changing the cache format for a project (GUI)
+
+The cache format for a project is stored in `jabs/project.json` and can be changed from the GUI at any time via **Edit > Project Settings > Feature Cache Format**.
+
+Changing the setting alone does not convert existing cache files — JABS reads whatever format is already on disk. To force the cache to be regenerated in the new format:
+
+1. Open the project in JABS.
+2. Go to **Edit > Project Settings > Feature Cache Format** and select the desired format.
+3. Click **OK** to save.
+4. Use **File > Clear Feature Cache…** to delete all existing cache files.
+5. Trigger a training or classification run. JABS will recompute and write the cache in the new format on the next cache miss.
+
+### Migrating an existing project to Parquet (CLI)
+
+Use `jabs-init` with `--cache-format parquet` and `--force` to recompute all features and write them in Parquet format:
+
+```bash
+jabs-init /path/to/project --cache-format parquet --force
+```
+
+`--force` is required to overwrite existing HDF5 cache files. Without it, `jabs-init` skips identities that already have a valid cache. The `--cache-format parquet` flag is also written to `project.json` so the GUI and subsequent CLI runs use Parquet going forward.
+
+If the project has multiple window sizes, pass them explicitly so they are all pre-computed:
+
+```bash
+jabs-init /path/to/project --cache-format parquet --force -w 2 -w 5
+```
+
+To migrate back to HDF5, use `--cache-format hdf5 --force` in the same way.

--- a/packages/jabs-core/src/jabs/core/abstract/pose_est.py
+++ b/packages/jabs-core/src/jabs/core/abstract/pose_est.py
@@ -91,6 +91,11 @@ class PoseEstimation(ABC):
             KeypointIndex.MID_TAIL,
             KeypointIndex.TIP_TAIL,
         ),
+        (
+            KeypointIndex.LEFT_EAR,
+            KeypointIndex.NOSE,
+            KeypointIndex.RIGHT_EAR,
+        ),
     )
 
     # Pose based on the Envision Hydra model will have fewer keypoints,

--- a/packages/jabs-core/src/jabs/core/constants.py
+++ b/packages/jabs-core/src/jabs/core/constants.py
@@ -14,6 +14,7 @@ COMPRESSION_OPTS_DEFAULT = 6
 # settings keys for project settings stored in the project.json file
 CV_GROUPING_KEY = "cv_grouping"
 CLASSIFIER_MODE_KEY = "classifier_mode"
+CACHE_FORMAT_KEY = "cache_format"
 
 # reserved behavior name used in multi-class mode to store explicit negative labels
 MULTICLASS_NONE_BEHAVIOR = "None"

--- a/packages/jabs-core/src/jabs/core/enums/cache_format.py
+++ b/packages/jabs-core/src/jabs/core/enums/cache_format.py
@@ -3,8 +3,12 @@
 from enum import Enum
 
 
-class CacheFormat(Enum):
-    """Storage format for a project's feature cache."""
+class CacheFormat(str, Enum):
+    """Storage format for a project's feature cache.
+
+    Inheriting from str allows for easy serialization to/from JSON (the enum
+    will automatically be serialized using the enum value).
+    """
 
     HDF5 = "hdf5"
     PARQUET = "parquet"

--- a/packages/jabs-io/src/jabs/io/feature_cache/parquet.py
+++ b/packages/jabs-io/src/jabs/io/feature_cache/parquet.py
@@ -58,8 +58,12 @@ def _metadata_to_dict(metadata: FeatureCacheMetadata) -> dict[str, object]:
         "identity": metadata.identity,
         "num_frames": metadata.num_frames,
         "pose_hash": metadata.pose_hash,
-        "distance_scale_factor": metadata.distance_scale_factor,
-        "avg_wall_length": metadata.avg_wall_length,
+        "distance_scale_factor": float(metadata.distance_scale_factor)
+        if metadata.distance_scale_factor is not None
+        else None,
+        "avg_wall_length": float(metadata.avg_wall_length)
+        if metadata.avg_wall_length is not None
+        else None,
         "cached_window_sizes": sorted(metadata.cached_window_sizes),
     }
 

--- a/packages/jabs-vision/src/jabs/vision/timm/inference/__init__.py
+++ b/packages/jabs-vision/src/jabs/vision/timm/inference/__init__.py
@@ -1,12 +1,16 @@
 """Inference utilities for jabs-vision."""
 
-from .confidence import compute_heatmap_confidence
+from .confidence import (
+    compute_confidence_labels,
+    compute_heatmap_confidence,
+    sample_confidence_at_coords,
+)
 from .decoding import decode_heatmaps, get_max_preds
 
 __all__ = [
-    # Confidence
+    "compute_confidence_labels",
     "compute_heatmap_confidence",
-    # Decoding
     "decode_heatmaps",
     "get_max_preds",
+    "sample_confidence_at_coords",
 ]

--- a/packages/jabs-vision/src/jabs/vision/timm/inference/__init__.py
+++ b/packages/jabs-vision/src/jabs/vision/timm/inference/__init__.py
@@ -1,0 +1,12 @@
+"""Inference utilities for jabs-vision."""
+
+from .confidence import compute_heatmap_confidence
+from .decoding import decode_heatmaps, get_max_preds
+
+__all__ = [
+    # Confidence
+    "compute_heatmap_confidence",
+    # Decoding
+    "decode_heatmaps",
+    "get_max_preds",
+]

--- a/packages/jabs-vision/src/jabs/vision/timm/inference/confidence.py
+++ b/packages/jabs-vision/src/jabs/vision/timm/inference/confidence.py
@@ -18,8 +18,9 @@ def compute_heatmap_confidence(heatmaps: Tensor) -> Tensor:
     """
     if heatmaps.ndim != 4:
         raise ValueError(f"Expected 4D tensor, got shape {heatmaps.shape}")
-    probs = torch.sigmoid(heatmaps)
-    return probs.flatten(start_dim=2).max(dim=-1).values
+    # sigmoid is monotonic, so max-then-sigmoid == sigmoid-then-max but cheaper.
+    max_logits = heatmaps.flatten(start_dim=2).max(dim=-1).values
+    return torch.sigmoid(max_logits)
 
 
 def sample_confidence_at_coords(
@@ -46,6 +47,12 @@ def sample_confidence_at_coords(
         raise ValueError(f"Expected coords to have shape (B, K, 2), but got {tuple(coords.shape)}")
 
     B, K, H, W = confidence_maps.shape
+
+    if coords.shape[0] != B or coords.shape[1] != K:
+        raise ValueError(
+            f"Expected coords to have leading dimensions {(B, K)} to match "
+            f"confidence_maps, but got {tuple(coords.shape[:2])}"
+        )
 
     if H < 2 or W < 2:
         # Fallback for tiny maps
@@ -99,6 +106,16 @@ def compute_confidence_labels(
             raise ValueError("Must provide image_diagonal or image_size")
         H, W = image_size
         image_diagonal = (H**2 + W**2) ** 0.5
+
+    if predictions.shape != ground_truth.shape:
+        raise ValueError(
+            f"predictions and ground_truth must have the same shape, "
+            f"got {tuple(predictions.shape)} and {tuple(ground_truth.shape)}"
+        )
+    if predictions.shape[-1] != 2:
+        raise ValueError(
+            f"Expected last dimension to be 2 (x, y coordinates), got {predictions.shape[-1]}"
+        )
 
     distances = torch.norm(predictions - ground_truth, dim=-1)
     threshold = torch.as_tensor(

--- a/packages/jabs-vision/src/jabs/vision/timm/inference/confidence.py
+++ b/packages/jabs-vision/src/jabs/vision/timm/inference/confidence.py
@@ -1,0 +1,100 @@
+"""Confidence extraction and sampling utilities."""
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+
+def compute_heatmap_confidence(heatmaps: Tensor) -> Tensor:
+    """Derive confidence from heatmap peak values.
+
+    Simple approach: sigmoid of the max value per keypoint.
+
+    Args:
+        heatmaps: (B, K, H, W) heatmap tensor.
+
+    Returns:
+        (B, K) confidence scores in [0, 1].
+    """
+    if heatmaps.ndim != 4:
+        raise ValueError(f"Expected 4D tensor, got shape {heatmaps.shape}")
+    probs = torch.sigmoid(heatmaps)
+    return probs.flatten(start_dim=2).max(dim=-1).values
+
+
+def sample_confidence_at_coords(
+    confidence_maps: Tensor,
+    coords: Tensor,
+) -> Tensor:
+    """Sample confidence logits at predicted coordinate locations.
+
+    Uses bilinear interpolation via grid_sample for sub-pixel accuracy.
+
+    Args:
+        confidence_maps: (B, K, H, W) confidence logit maps.
+        coords: (B, K, 2) coordinates in heatmap space (x, y).
+
+    Returns:
+        (B, K) confidence logits sampled at each coordinate.
+    """
+    B, K, H, W = confidence_maps.shape
+
+    if H < 2 or W < 2:
+        # Fallback for tiny maps
+        return confidence_maps.mean(dim=(-2, -1))
+
+    # Clamp coordinates to valid range
+    coords = coords.to(confidence_maps.dtype).clone()
+    coords[..., 0] = coords[..., 0].clamp(0, W - 1)
+    coords[..., 1] = coords[..., 1].clamp(0, H - 1)
+
+    # Normalize to [-1, 1] for grid_sample
+    grid_x = (coords[..., 0] / (W - 1)) * 2 - 1
+    grid_y = (coords[..., 1] / (H - 1)) * 2 - 1
+
+    # Sample each keypoint channel
+    conf_logits = torch.zeros((B, K), device=confidence_maps.device, dtype=confidence_maps.dtype)
+    for k in range(K):
+        grid = torch.stack([grid_x[:, k], grid_y[:, k]], dim=-1).view(B, 1, 1, 2)
+        sampled = F.grid_sample(
+            confidence_maps[:, k : k + 1],
+            grid,
+            mode="bilinear",
+            align_corners=True,
+            padding_mode="border",
+        )
+        conf_logits[:, k] = sampled.view(B)
+
+    return conf_logits
+
+
+def compute_confidence_labels(
+    predictions: Tensor,
+    ground_truth: Tensor,
+    threshold_fraction: float = 0.003,
+    image_diagonal: float | Tensor | None = None,
+    image_size: tuple[int, int] | None = None,
+) -> Tensor:
+    """Compute binary labels for confidence supervision.
+
+    A prediction is "correct" if within threshold_fraction * diagonal of GT.
+
+    Args:
+        predictions: (B, K, 2) predicted coordinates.
+        ground_truth: (B, K, 2) ground truth coordinates.
+        threshold_fraction: Fraction of image diagonal for threshold.
+        image_diagonal: Precomputed diagonal, or computed from image_size.
+        image_size: (H, W) to compute diagonal if not provided.
+
+    Returns:
+        (B, K) binary labels (1.0 = correct, 0.0 = incorrect).
+    """
+    if image_diagonal is None:
+        if image_size is None:
+            raise ValueError("Must provide image_diagonal or image_size")
+        H, W = image_size
+        image_diagonal = (H**2 + W**2) ** 0.5
+
+    threshold = threshold_fraction * image_diagonal
+    distances = torch.norm(predictions - ground_truth, dim=-1)
+    return (distances <= threshold).float()

--- a/packages/jabs-vision/src/jabs/vision/timm/inference/confidence.py
+++ b/packages/jabs-vision/src/jabs/vision/timm/inference/confidence.py
@@ -37,6 +37,14 @@ def sample_confidence_at_coords(
     Returns:
         (B, K) confidence logits sampled at each coordinate.
     """
+    if confidence_maps.ndim != 4:
+        raise ValueError(
+            f"Expected confidence_maps to have shape (B, K, H, W), "
+            f"but got {tuple(confidence_maps.shape)}"
+        )
+    if coords.ndim != 3 or coords.shape[-1] != 2:
+        raise ValueError(f"Expected coords to have shape (B, K, 2), but got {tuple(coords.shape)}")
+
     B, K, H, W = confidence_maps.shape
 
     if H < 2 or W < 2:
@@ -44,7 +52,7 @@ def sample_confidence_at_coords(
         return confidence_maps.mean(dim=(-2, -1))
 
     # Clamp coordinates to valid range
-    coords = coords.to(confidence_maps.dtype).clone()
+    coords = coords.to(device=confidence_maps.device, dtype=confidence_maps.dtype).clone()
     coords[..., 0] = coords[..., 0].clamp(0, W - 1)
     coords[..., 1] = coords[..., 1].clamp(0, H - 1)
 
@@ -52,20 +60,17 @@ def sample_confidence_at_coords(
     grid_x = (coords[..., 0] / (W - 1)) * 2 - 1
     grid_y = (coords[..., 1] / (H - 1)) * 2 - 1
 
-    # Sample each keypoint channel
-    conf_logits = torch.zeros((B, K), device=confidence_maps.device, dtype=confidence_maps.dtype)
-    for k in range(K):
-        grid = torch.stack([grid_x[:, k], grid_y[:, k]], dim=-1).view(B, 1, 1, 2)
-        sampled = F.grid_sample(
-            confidence_maps[:, k : k + 1],
-            grid,
-            mode="bilinear",
-            align_corners=True,
-            padding_mode="border",
-        )
-        conf_logits[:, k] = sampled.view(B)
+    flat_conf_maps = confidence_maps.reshape(B * K, 1, H, W)
+    grid = torch.stack([grid_x, grid_y], dim=-1).reshape(B * K, 1, 1, 2)
 
-    return conf_logits
+    sampled = F.grid_sample(
+        flat_conf_maps,
+        grid,
+        mode="bilinear",
+        align_corners=True,
+        padding_mode="border",
+    )
+    return sampled.reshape(B, K)
 
 
 def compute_confidence_labels(
@@ -95,6 +100,14 @@ def compute_confidence_labels(
         H, W = image_size
         image_diagonal = (H**2 + W**2) ** 0.5
 
-    threshold = threshold_fraction * image_diagonal
     distances = torch.norm(predictions - ground_truth, dim=-1)
+    threshold = torch.as_tensor(
+        threshold_fraction,
+        device=distances.device,
+        dtype=distances.dtype,
+    ) * torch.as_tensor(
+        image_diagonal,
+        device=distances.device,
+        dtype=distances.dtype,
+    )
     return (distances <= threshold).float()

--- a/packages/jabs-vision/src/jabs/vision/timm/inference/confidence.py
+++ b/packages/jabs-vision/src/jabs/vision/timm/inference/confidence.py
@@ -52,19 +52,23 @@ def sample_confidence_at_coords(
     grid_x = (coords[..., 0] / (W - 1)) * 2 - 1
     grid_y = (coords[..., 1] / (H - 1)) * 2 - 1
 
-    # Sample each keypoint channel
-    conf_logits = torch.zeros((B, K), device=confidence_maps.device, dtype=confidence_maps.dtype)
-    for k in range(K):
-        grid = torch.stack([grid_x[:, k], grid_y[:, k]], dim=-1).view(B, 1, 1, 2)
-        sampled = F.grid_sample(
-            confidence_maps[:, k : k + 1],
-            grid,
-            mode="bilinear",
-            align_corners=True,
-            padding_mode="border",
-        )
-        conf_logits[:, k] = sampled.view(B)
+    # Vectorized sampling over all keypoints with a single grid_sample call
+    # confidence_maps: (B, K, H, W) -> (B*K, 1, H, W)
+    flat_conf_maps = confidence_maps.view(B * K, 1, H, W)
 
+    # Build grid: (B, K, 2) -> (B*K, 1, 1, 2)
+    grid = torch.stack([grid_x, grid_y], dim=-1).view(B * K, 1, 1, 2)
+
+    sampled = F.grid_sample(
+        flat_conf_maps,
+        grid,
+        mode="bilinear",
+        align_corners=True,
+        padding_mode="border",
+    )
+
+    # sampled: (B*K, 1, 1, 1) -> (B, K)
+    conf_logits = sampled.view(B, K)
     return conf_logits
 
 

--- a/packages/jabs-vision/src/jabs/vision/timm/inference/decoding.py
+++ b/packages/jabs-vision/src/jabs/vision/timm/inference/decoding.py
@@ -102,12 +102,12 @@ def decode_heatmaps(
             )
 
             # Hessian matrix and gradient vector
-            H = torch.tensor([[dxx, dxy], [dxy, dyy]], device=device, dtype=val.dtype)
+            hessian = torch.tensor([[dxx, dxy], [dxy, dyy]], device=device, dtype=val.dtype)
             g = torch.tensor([dx, dy], device=device, dtype=val.dtype)
 
             try:
-                H_inv = torch.inverse(H)
-                delta = -torch.matmul(H_inv, g)
+                hessian_inv = torch.inverse(hessian)
+                delta = -torch.matmul(hessian_inv, g)
                 refined_coords[b, k, 0] += delta[0]
                 refined_coords[b, k, 1] += delta[1]
             except RuntimeError:

--- a/packages/jabs-vision/src/jabs/vision/timm/inference/decoding.py
+++ b/packages/jabs-vision/src/jabs/vision/timm/inference/decoding.py
@@ -14,22 +14,33 @@ def get_max_preds(heatmaps: Tensor) -> tuple[Tensor, Tensor]:
 
     Returns:
         Tuple of (coords, maxvals) where:
-            - coords: (B, K, 2) integer coordinates (x, y)
+            - coords: (B, K, 2) floating-point pixel coordinates (x, y)
+              whose values are integer-valued argmax indices
             - maxvals: (B, K, 1) maximum values
     """
-    B, K, H, W = heatmaps.shape
+    if heatmaps.ndim != 4:
+        raise ValueError(
+            f"Expected heatmaps to have 4 dimensions (B, K, H, W), "
+            f"but got shape {tuple(heatmaps.shape)}"
+        )
+
+    B, K, _, W = heatmaps.shape
 
     # Flatten spatial dimensions: (B, K, H*W)
-    heatmaps_flat = heatmaps.view(B, K, -1)
+    heatmaps_flat = heatmaps.reshape(B, K, -1)
 
     # Get max values and indices
     maxvals, idx = torch.max(heatmaps_flat, dim=2)
     maxvals = maxvals.unsqueeze(-1)
 
     # Convert flat index to (x, y) coordinates
-    preds = torch.zeros((B, K, 2), device=heatmaps.device, dtype=heatmaps.dtype)
-    preds[..., 0] = idx % W  # x coordinate
-    preds[..., 1] = idx // W  # y coordinate
+    preds = torch.stack(
+        [
+            (idx % W).to(dtype=heatmaps.dtype),
+            torch.div(idx, W, rounding_mode="floor").to(dtype=heatmaps.dtype),
+        ],
+        dim=-1,
+    )
 
     return preds, maxvals
 
@@ -54,13 +65,18 @@ def decode_heatmaps(
         Taylor expansion to achieve sub-pixel accuracy. Reference:
         https://arxiv.org/abs/1910.06278
     """
-    B, K, H, W = heatmaps.shape
-    device = heatmaps.device
+    if heatmaps.ndim != 4:
+        raise ValueError(
+            f"Expected heatmaps to have 4 dimensions (B, K, H, W), "
+            f"but got shape {tuple(heatmaps.shape)}"
+        )
 
-    # Get integer argmax coordinates
+    B, K, H, W = heatmaps.shape
+
+    # Get argmax coordinates in floating point so DARK can refine them in place.
     coords, _ = get_max_preds(heatmaps)
 
-    if not use_dark:
+    if not use_dark or H < 5 or W < 5:
         return coords
 
     # DARK refinement using Taylor expansion
@@ -95,17 +111,21 @@ def decode_heatmaps(
                 + val[cy - 1, cx - 1]
             )
 
-            # Hessian matrix and gradient vector
-            H = torch.tensor([[dxx, dxy], [dxy, dyy]], device=device, dtype=val.dtype)
-            g = torch.tensor([dx, dy], device=device, dtype=val.dtype)
+            # Build the local quadratic approximation without materializing Python scalars.
+            hessian = torch.stack(
+                [
+                    torch.stack([dxx, dxy]),
+                    torch.stack([dxy, dyy]),
+                ]
+            )
+            grad = torch.stack([dx, dy])
 
             try:
-                H_inv = torch.inverse(H)
-                delta = -torch.matmul(H_inv, g)
+                delta = torch.linalg.solve(hessian, -grad)
                 refined_coords[b, k, 0] += delta[0]
                 refined_coords[b, k, 1] += delta[1]
             except RuntimeError:
-                # Singular matrix, skip refinement for this keypoint
+                # Singular matrix or solve failure, skip refinement for this keypoint.
                 continue
 
     return refined_coords

--- a/packages/jabs-vision/src/jabs/vision/timm/inference/decoding.py
+++ b/packages/jabs-vision/src/jabs/vision/timm/inference/decoding.py
@@ -48,14 +48,12 @@ def get_max_preds(heatmaps: Tensor) -> tuple[Tensor, Tensor]:
 def decode_heatmaps(
     heatmaps: Tensor,
     use_dark: bool = False,
-    sigma: float = 2.0,
 ) -> Tensor:
     """Decode heatmaps to (x, y) coordinates.
 
     Args:
         heatmaps: Heatmaps of shape (B, K, H, W).
         use_dark: If True, apply DARK refinement for sub-pixel accuracy.
-        sigma: Gaussian sigma (used for DARK refinement documentation).
 
     Returns:
         Coordinates of shape (B, K, 2).
@@ -84,48 +82,71 @@ def decode_heatmaps(
     # where g is gradient (1st derivative), H is Hessian (2nd derivative)
 
     # Clamp coordinates to avoid boundary issues during gradient computation
-    px = coords[..., 0].long().clamp(2, W - 3)
-    py = coords[..., 1].long().clamp(2, H - 3)
+    px = coords[..., 0].long().clamp(2, W - 3)  # (B, K)
+    py = coords[..., 1].long().clamp(2, H - 3)  # (B, K)
+
+    # Batch indices for advanced indexing: (B, K) each
+    batch_idx = torch.arange(B, device=heatmaps.device)[:, None]
+    keypoint_idx = torch.arange(K, device=heatmaps.device)[None, :]
+
+    # First derivative (central difference)
+    dx = 0.5 * (
+        heatmaps[batch_idx, keypoint_idx, py, px + 1]
+        - heatmaps[batch_idx, keypoint_idx, py, px - 1]
+    )
+    dy = 0.5 * (
+        heatmaps[batch_idx, keypoint_idx, py + 1, px]
+        - heatmaps[batch_idx, keypoint_idx, py - 1, px]
+    )
+
+    # Second derivative (central difference)
+    center = heatmaps[batch_idx, keypoint_idx, py, px]
+    dxx = (
+        heatmaps[batch_idx, keypoint_idx, py, px + 1]
+        - 2 * center
+        + heatmaps[batch_idx, keypoint_idx, py, px - 1]
+    )
+    dyy = (
+        heatmaps[batch_idx, keypoint_idx, py + 1, px]
+        - 2 * center
+        + heatmaps[batch_idx, keypoint_idx, py - 1, px]
+    )
+    dxy = 0.25 * (
+        heatmaps[batch_idx, keypoint_idx, py + 1, px + 1]
+        - heatmaps[batch_idx, keypoint_idx, py + 1, px - 1]
+        - heatmaps[batch_idx, keypoint_idx, py - 1, px + 1]
+        + heatmaps[batch_idx, keypoint_idx, py - 1, px - 1]
+    )
+
+    # Build batched Hessians (B, K, 2, 2) and gradients (B, K, 2)
+    hessian = torch.stack(
+        [
+            torch.stack([dxx, dxy], dim=-1),
+            torch.stack([dxy, dyy], dim=-1),
+        ],
+        dim=-2,
+    )
+    grad = torch.stack([dx, dy], dim=-1)
+
+    # Flatten to (B*K, 2, 2) and (B*K, 2) for batched solve
+    hessian_flat = hessian.reshape(-1, 2, 2)
+    grad_flat = grad.reshape(-1, 2)
+
+    # Only solve where the Hessian is non-singular and finite
+    det = hessian_flat[:, 0, 0] * hessian_flat[:, 1, 1] - hessian_flat[:, 0, 1] ** 2
+    solvable = torch.isfinite(hessian_flat).all(dim=(-2, -1)) & torch.isfinite(grad_flat).all(
+        dim=-1
+    )
+    solvable = solvable & (det.abs() > torch.finfo(hessian_flat.dtype).eps)
 
     refined_coords = coords.clone()
 
-    for b in range(B):
-        for k in range(K):
-            cx, cy = px[b, k], py[b, k]
-            val = heatmaps[b, k]
-
-            # First derivative (central difference)
-            # dx = 0.5 * (h[x+1] - h[x-1])
-            # dy = 0.5 * (h[y+1] - h[y-1])
-            dx = 0.5 * (val[cy, cx + 1] - val[cy, cx - 1])
-            dy = 0.5 * (val[cy + 1, cx] - val[cy - 1, cx])
-
-            # Second derivative (central difference)
-            # dxx = h[x+1] - 2*h[x] + h[x-1]
-            dxx = val[cy, cx + 1] - 2 * val[cy, cx] + val[cy, cx - 1]
-            dyy = val[cy + 1, cx] - 2 * val[cy, cx] + val[cy - 1, cx]
-            dxy = 0.25 * (
-                val[cy + 1, cx + 1]
-                - val[cy + 1, cx - 1]
-                - val[cy - 1, cx + 1]
-                + val[cy - 1, cx - 1]
-            )
-
-            # Build the local quadratic approximation without materializing Python scalars.
-            hessian = torch.stack(
-                [
-                    torch.stack([dxx, dxy]),
-                    torch.stack([dxy, dyy]),
-                ]
-            )
-            grad = torch.stack([dx, dy])
-
-            try:
-                delta = torch.linalg.solve(hessian, -grad)
-                refined_coords[b, k, 0] += delta[0]
-                refined_coords[b, k, 1] += delta[1]
-            except RuntimeError:
-                # Singular matrix or solve failure, skip refinement for this keypoint.
-                continue
+    if torch.any(solvable):
+        delta = torch.linalg.solve(
+            hessian_flat[solvable],
+            -grad_flat[solvable].unsqueeze(-1),
+        ).squeeze(-1)
+        refined_flat = refined_coords.reshape(-1, 2)
+        refined_flat[solvable] += delta
 
     return refined_coords

--- a/packages/jabs-vision/src/jabs/vision/timm/inference/decoding.py
+++ b/packages/jabs-vision/src/jabs/vision/timm/inference/decoding.py
@@ -1,0 +1,111 @@
+"""Heatmap decoding utilities for keypoint detection."""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+
+def get_max_preds(heatmaps: Tensor) -> tuple[Tensor, Tensor]:
+    """Get keypoint predictions from the maximum value of each heatmap.
+
+    Args:
+        heatmaps: Heatmaps of shape (B, K, H, W).
+
+    Returns:
+        Tuple of (coords, maxvals) where:
+            - coords: (B, K, 2) integer coordinates (x, y)
+            - maxvals: (B, K, 1) maximum values
+    """
+    B, K, H, W = heatmaps.shape
+
+    # Flatten spatial dimensions: (B, K, H*W)
+    heatmaps_flat = heatmaps.view(B, K, -1)
+
+    # Get max values and indices
+    maxvals, idx = torch.max(heatmaps_flat, dim=2)
+    maxvals = maxvals.unsqueeze(-1)
+
+    # Convert flat index to (x, y) coordinates
+    preds = torch.zeros((B, K, 2), device=heatmaps.device, dtype=heatmaps.dtype)
+    preds[..., 0] = idx % W  # x coordinate
+    preds[..., 1] = idx // W  # y coordinate
+
+    return preds, maxvals
+
+
+def decode_heatmaps(
+    heatmaps: Tensor,
+    use_dark: bool = False,
+    sigma: float = 2.0,
+) -> Tensor:
+    """Decode heatmaps to (x, y) coordinates.
+
+    Args:
+        heatmaps: Heatmaps of shape (B, K, H, W).
+        use_dark: If True, apply DARK refinement for sub-pixel accuracy.
+        sigma: Gaussian sigma (used for DARK refinement documentation).
+
+    Returns:
+        Coordinates of shape (B, K, 2).
+
+    Note:
+        DARK (Distribution-Aware coordinate Representation of Keypoints) uses
+        Taylor expansion to achieve sub-pixel accuracy. Reference:
+        https://arxiv.org/abs/1910.06278
+    """
+    B, K, H, W = heatmaps.shape
+    device = heatmaps.device
+
+    # Get integer argmax coordinates
+    coords, _ = get_max_preds(heatmaps)
+
+    if not use_dark:
+        return coords
+
+    # DARK refinement using Taylor expansion
+    # p = p_int - H^-1 * g
+    # where g is gradient (1st derivative), H is Hessian (2nd derivative)
+
+    # Clamp coordinates to avoid boundary issues during gradient computation
+    px = coords[..., 0].long().clamp(2, W - 3)
+    py = coords[..., 1].long().clamp(2, H - 3)
+
+    refined_coords = coords.clone()
+
+    for b in range(B):
+        for k in range(K):
+            cx, cy = px[b, k], py[b, k]
+            val = heatmaps[b, k]
+
+            # First derivative (central difference)
+            # dx = 0.5 * (h[x+1] - h[x-1])
+            # dy = 0.5 * (h[y+1] - h[y-1])
+            dx = 0.5 * (val[cy, cx + 1] - val[cy, cx - 1])
+            dy = 0.5 * (val[cy + 1, cx] - val[cy - 1, cx])
+
+            # Second derivative (central difference)
+            # dxx = h[x+1] - 2*h[x] + h[x-1]
+            dxx = val[cy, cx + 1] - 2 * val[cy, cx] + val[cy, cx - 1]
+            dyy = val[cy + 1, cx] - 2 * val[cy, cx] + val[cy - 1, cx]
+            dxy = 0.25 * (
+                val[cy + 1, cx + 1]
+                - val[cy + 1, cx - 1]
+                - val[cy - 1, cx + 1]
+                + val[cy - 1, cx - 1]
+            )
+
+            # Hessian matrix and gradient vector
+            H = torch.tensor([[dxx, dxy], [dxy, dyy]], device=device, dtype=val.dtype)
+            g = torch.tensor([dx, dy], device=device, dtype=val.dtype)
+
+            try:
+                H_inv = torch.inverse(H)
+                delta = -torch.matmul(H_inv, g)
+                refined_coords[b, k, 0] += delta[0]
+                refined_coords[b, k, 1] += delta[1]
+            except RuntimeError:
+                # Singular matrix, skip refinement for this keypoint
+                continue
+
+    return refined_coords

--- a/packages/jabs-vision/src/jabs/vision/timm/inference/decoding.py
+++ b/packages/jabs-vision/src/jabs/vision/timm/inference/decoding.py
@@ -17,10 +17,16 @@ def get_max_preds(heatmaps: Tensor) -> tuple[Tensor, Tensor]:
             - coords: (B, K, 2) integer coordinates (x, y)
             - maxvals: (B, K, 1) maximum values
     """
+    if heatmaps.ndim != 4:
+        raise ValueError(
+            f"Expected heatmaps to have 4 dimensions (B, K, H, W), "
+            f"but got shape {tuple(heatmaps.shape)}"
+        )
+
     B, K, H, W = heatmaps.shape
 
     # Flatten spatial dimensions: (B, K, H*W)
-    heatmaps_flat = heatmaps.view(B, K, -1)
+    heatmaps_flat = heatmaps.reshape(B, K, -1)
 
     # Get max values and indices
     maxvals, idx = torch.max(heatmaps_flat, dim=2)

--- a/packages/jabs-vision/tests/timm/inference/__init__.py
+++ b/packages/jabs-vision/tests/timm/inference/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the jabs.vision.timm.inference code."""

--- a/packages/jabs-vision/tests/timm/inference/test_confidence.py
+++ b/packages/jabs-vision/tests/timm/inference/test_confidence.py
@@ -1,0 +1,62 @@
+"""Tests for timm confidence helpers."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from jabs.vision.timm.inference import (
+    compute_confidence_labels,
+    compute_heatmap_confidence,
+    sample_confidence_at_coords,
+)
+
+
+def test_compute_heatmap_confidence_uses_sigmoid_peak() -> None:
+    """Heatmap confidence should be the max sigmoid score per keypoint."""
+    heatmaps = torch.tensor(
+        [[[[0.0, 1.0], [-2.0, 0.5]], [[-1.0, 0.0], [2.0, -3.0]]]],
+        dtype=torch.float32,
+    )
+
+    conf = compute_heatmap_confidence(heatmaps)
+
+    expected = torch.sigmoid(torch.tensor([[1.0, 2.0]], dtype=torch.float32))
+    assert torch.allclose(conf, expected)
+
+
+def test_sample_confidence_at_coords_samples_each_keypoint() -> None:
+    """Sampling should return the value at integral coordinates for every keypoint."""
+    confidence_maps = torch.zeros((1, 2, 3, 4), dtype=torch.float32)
+    confidence_maps[0, 0, 1, 2] = 0.7
+    confidence_maps[0, 1, 2, 1] = 0.4
+    coords = torch.tensor([[[2.0, 1.0], [1.0, 2.0]]], dtype=torch.float32)
+
+    sampled = sample_confidence_at_coords(confidence_maps, coords)
+
+    assert torch.allclose(sampled, torch.tensor([[0.7, 0.4]], dtype=torch.float32))
+
+
+def test_sample_confidence_at_coords_validates_shape() -> None:
+    """Bad coordinate shapes should fail early."""
+    with pytest.raises(ValueError, match="shape \\(B, K, 2\\)"):
+        sample_confidence_at_coords(
+            torch.zeros((1, 2, 3, 4), dtype=torch.float32),
+            torch.zeros((1, 2), dtype=torch.float32),
+        )
+
+
+def test_compute_confidence_labels_accepts_tensor_diagonal() -> None:
+    """Tensor diagonals with a different dtype should be normalized before comparison."""
+    predictions = torch.tensor([[[3.0, 4.0], [0.0, 0.0]]], dtype=torch.float32)
+    ground_truth = torch.tensor([[[0.0, 0.0], [0.0, 1.0]]], dtype=torch.float32)
+    image_diagonal = torch.tensor(100.0, dtype=torch.float64)
+
+    labels = compute_confidence_labels(
+        predictions,
+        ground_truth,
+        threshold_fraction=0.05,
+        image_diagonal=image_diagonal,
+    )
+
+    assert torch.equal(labels, torch.tensor([[1.0, 1.0]], dtype=torch.float32))

--- a/packages/jabs-vision/tests/timm/inference/test_confidence.py
+++ b/packages/jabs-vision/tests/timm/inference/test_confidence.py
@@ -46,6 +46,38 @@ def test_sample_confidence_at_coords_validates_shape() -> None:
         )
 
 
+def test_sample_confidence_at_coords_validates_leading_dims() -> None:
+    """Coords with mismatched (B, K) should fail early."""
+    confidence_maps = torch.zeros((2, 3, 4, 4), dtype=torch.float32)
+    coords = torch.zeros((1, 3, 2), dtype=torch.float32)  # B mismatch
+
+    with pytest.raises(ValueError, match="leading dimensions"):
+        sample_confidence_at_coords(confidence_maps, coords)
+
+    coords_k = torch.zeros((2, 5, 2), dtype=torch.float32)  # K mismatch
+
+    with pytest.raises(ValueError, match="leading dimensions"):
+        sample_confidence_at_coords(confidence_maps, coords_k)
+
+
+def test_compute_confidence_labels_validates_shape_mismatch() -> None:
+    """Mismatched prediction and ground_truth shapes should fail."""
+    predictions = torch.zeros((1, 3, 2), dtype=torch.float32)
+    ground_truth = torch.zeros((1, 4, 2), dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="same shape"):
+        compute_confidence_labels(predictions, ground_truth, image_size=(100, 100))
+
+
+def test_compute_confidence_labels_validates_last_dim() -> None:
+    """Last dimension != 2 should fail."""
+    predictions = torch.zeros((1, 3, 3), dtype=torch.float32)
+    ground_truth = torch.zeros((1, 3, 3), dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="last dimension to be 2"):
+        compute_confidence_labels(predictions, ground_truth, image_size=(100, 100))
+
+
 def test_compute_confidence_labels_accepts_tensor_diagonal() -> None:
     """Tensor diagonals with a different dtype should be normalized before comparison."""
     predictions = torch.tensor([[[3.0, 4.0], [0.0, 0.0]]], dtype=torch.float32)

--- a/packages/jabs-vision/tests/timm/inference/test_decoding.py
+++ b/packages/jabs-vision/tests/timm/inference/test_decoding.py
@@ -1,0 +1,58 @@
+"""Tests for timm heatmap decoding helpers."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from jabs.vision.timm.inference import decode_heatmaps, get_max_preds
+
+
+def test_get_max_preds_handles_non_contiguous_heatmaps() -> None:
+    """Argmax decoding should work for non-contiguous tensors."""
+    base = torch.zeros((1, 5, 6, 2), dtype=torch.float32)
+    base[0, 2, 4, 1] = 3.0
+    heatmaps = base.permute(0, 3, 1, 2)
+
+    coords, maxvals = get_max_preds(heatmaps)
+
+    assert not heatmaps.is_contiguous()
+    assert coords.dtype == heatmaps.dtype
+    assert torch.equal(coords[0, 1], torch.tensor([4.0, 2.0]))
+    assert torch.equal(maxvals[0, 1], torch.tensor([3.0]))
+
+
+def test_get_max_preds_validates_rank() -> None:
+    """Bad heatmap rank should fail with a clear error."""
+    with pytest.raises(ValueError, match="4 dimensions"):
+        get_max_preds(torch.zeros((2, 3, 4), dtype=torch.float32))
+
+
+def test_decode_heatmaps_dark_falls_back_on_small_heatmaps() -> None:
+    """DARK should return plain argmax coords when a full neighborhood is unavailable."""
+    heatmaps = torch.zeros((1, 1, 4, 4), dtype=torch.float32)
+    heatmaps[0, 0, 1, 2] = 5.0
+
+    plain = decode_heatmaps(heatmaps, use_dark=False)
+    refined = decode_heatmaps(heatmaps, use_dark=True)
+
+    assert torch.equal(refined, plain)
+
+
+def test_decode_heatmaps_dark_applies_subpixel_refinement() -> None:
+    """DARK refinement should move coordinates off the integer argmax when the gradient supports it."""
+    heatmaps = torch.zeros((1, 1, 7, 7), dtype=torch.float32)
+    patch = torch.tensor(
+        [
+            [0.4, 0.6, 0.7],
+            [0.5, 1.0, 0.9],
+            [0.3, 0.5, 0.6],
+        ],
+        dtype=torch.float32,
+    )
+    heatmaps[0, 0, 2:5, 2:5] = patch
+
+    refined = decode_heatmaps(heatmaps, use_dark=True)
+
+    assert refined[0, 0, 0] > 3.0
+    assert refined[0, 0, 1] < 3.0

--- a/packages/jabs-vision/tests/timm/inference/test_public_api.py
+++ b/packages/jabs-vision/tests/timm/inference/test_public_api.py
@@ -1,0 +1,15 @@
+"""Smoke tests for the public timm inference API."""
+
+from __future__ import annotations
+
+from jabs.vision.timm import inference
+from jabs.vision.timm.inference import confidence, decoding
+
+
+def test_public_exports() -> None:
+    """Public package re-exports the intended inference helpers."""
+    assert inference.compute_heatmap_confidence is confidence.compute_heatmap_confidence
+    assert inference.sample_confidence_at_coords is confidence.sample_confidence_at_coords
+    assert inference.compute_confidence_labels is confidence.compute_confidence_labels
+    assert inference.get_max_preds is decoding.get_max_preds
+    assert inference.decode_heatmaps is decoding.decode_heatmaps

--- a/src/jabs/feature_extraction/features.py
+++ b/src/jabs/feature_extraction/features.py
@@ -123,7 +123,7 @@ class IdentityFeatures:
         self._identity_mask = pose_est.identity_mask(identity)
         self._op_settings = _normalize_op_settings(op_settings) if op_settings else None
         self._distance_scale_factor = (
-            pose_est.cm_per_pixel if op_settings.get("cm_units", False) else None
+            pose_est.cm_per_pixel if (op_settings or {}).get("cm_units", False) else None
         )
 
         if directory is None:

--- a/src/jabs/feature_extraction/features.py
+++ b/src/jabs/feature_extraction/features.py
@@ -40,11 +40,27 @@ _FEATURE_MODULES = [BaseFeatureGroup, SocialFeatureGroup, SegmentationFeatureGro
 
 _EXTENDED_FEATURE_MODULES = [LandmarkFeatureGroup]
 
-_BASE_FILTERS = {
-    "social": SocialFeatureGroup.module_names(),
-    "segmentation": SegmentationFeatureGroup.module_names(),
+_BASE_FILTERS: dict[str, dict[str, list[str]]] = {
+    "social": {"_all": SocialFeatureGroup.module_names()},
+    "segmentation": {"_all": SegmentationFeatureGroup.module_names()},
     "static_objects": LandmarkFeatureGroup.feature_map,
 }
+
+
+def _normalize_op_settings(settings: dict) -> dict:
+    """Normalize op_settings so all _BASE_FILTERS keys map to ``dict[str, bool]``.
+
+    project.json stores simple feature-group toggles (social, segmentation) as plain
+    booleans and compound settings (static_objects) as nested dicts.  Converting the
+    plain booleans to ``{"_all": value}`` at read time means downstream filter code
+    can always iterate uniformly without branching on the value type.
+    """
+    result = dict(settings)
+    for key in _BASE_FILTERS:
+        if key in result and not isinstance(result[key], dict):
+            result[key] = {"_all": result[key]}
+    return result
+
 
 _WINDOW_FILTERS = {
     "window": list(Feature._window_operations.keys()),
@@ -97,6 +113,7 @@ class IdentityFeatures:
         op_settings: dict | None = None,
         cache_window: bool = True,
         cache_format: CacheFormat = CacheFormat.HDF5,
+        include_pose_hash: bool = False,
     ) -> None:
         self._pose_version = pose_est.format_major_version
         self._num_frames = pose_est.num_frames
@@ -104,16 +121,18 @@ class IdentityFeatures:
         self._pose_hash = pose_est.hash
         self._identity = identity
         self._identity_mask = pose_est.identity_mask(identity)
-        self._op_settings = dict(op_settings) if op_settings else None
+        self._op_settings = _normalize_op_settings(op_settings) if op_settings else None
         self._distance_scale_factor = (
             pose_est.cm_per_pixel if op_settings.get("cm_units", False) else None
         )
 
-        self._identity_feature_dir = (
-            None
-            if directory is None
-            else (Path(directory) / Path(source_file).stem / str(self._identity))
-        )
+        if directory is None:
+            self._identity_feature_dir = None
+        else:
+            base = Path(directory) / Path(source_file).stem
+            if include_pose_hash:
+                base = base / self._pose_hash
+            self._identity_feature_dir = base / str(self._identity)
         self._cache_window = cache_window
         self._compute_social_features = pose_est.format_major_version >= 3
 
@@ -142,6 +161,12 @@ class IdentityFeatures:
 
         # will hold an array that indicates if each frame is valid for this identity
         self._frame_valid = None
+
+        # per-frame features: one of these will be set after __init__ completes.
+        # _per_frame_flat is set on cache-hit paths (avoids unflatten/re-flatten).
+        # _per_frame is set on cache-miss/compute paths and lazily from _per_frame_flat.
+        self._per_frame: PerFrameFeatureMap | None = None
+        self._per_frame_flat: FlatFeatureMap | None = None
 
         # per frame features
         point_mask = pose_est.get_identity_point_mask(identity)
@@ -285,7 +310,9 @@ class IdentityFeatures:
         cache_data = self._reader.read_per_frame(self._identity_feature_dir)
         self._frame_valid = cache_data.frame_valid
         assert len(self._frame_valid) == self._num_frames
-        self._per_frame = self._unflatten_per_frame(cache_data.features)
+        # Store the flat dict directly; skip unflatten here.
+        # _per_frame is built lazily by get_per_frame() if the nested format is needed.
+        self._per_frame_flat = cache_data.features
 
     def __save_per_frame(self) -> None:
         """Save per-frame features to the cache."""
@@ -465,6 +492,17 @@ class IdentityFeatures:
 
         return final_features
 
+    def _compute_base_filter_names(self) -> list[str]:
+        """Return the list of top-level module names to remove based on op_settings."""
+        names: list[str] = []
+        for setting_name, sub_settings in self._op_settings.items():
+            if setting_name not in _BASE_FILTERS:
+                continue
+            for sub_key, enabled in sub_settings.items():
+                if not enabled:
+                    names += _BASE_FILTERS[setting_name].get(sub_key, [])
+        return names
+
     def get_per_frame(self, labels: np.ndarray | None = None) -> PerFrameFeatureMap:
         """get per frame features
 
@@ -491,6 +529,9 @@ class IdentityFeatures:
 
             features are filtered by self.op_settings
         """
+        if self._per_frame is None:
+            self._per_frame = self._unflatten_per_frame(self._per_frame_flat)
+
         if labels is None:
             features = self._per_frame
 
@@ -512,6 +553,39 @@ class IdentityFeatures:
 
         return features
 
+    def get_per_frame_flat(self, labels: np.ndarray | None = None) -> FlatFeatureMap:
+        """Return per-frame features as a flat ``{module feature: array}`` dict.
+
+        When features were loaded from a cache file the flat representation stored
+        directly at load time is returned, skipping the unflatten→flatten round-trip
+        that ``get_per_frame()`` + ``merge_per_frame_features()`` would otherwise incur.
+
+        Args:
+            labels: If provided, only return features for frames where the label is
+                not NONE and the identity exists.
+
+        Returns:
+            Flat dict mapping ``"module_name feature_name"`` keys to 1-D arrays.
+        """
+        if self._per_frame_flat is not None:
+            if labels is not None:
+                mask = (labels != jabs.project.track_labels.TrackLabels.Label.NONE) & (
+                    self._identity_mask != 0
+                )
+                flat: FlatFeatureMap = {k: v[mask] for k, v in self._per_frame_flat.items()}
+            else:
+                flat = self._per_frame_flat
+
+            if self._op_settings is not None:
+                names_to_remove = self._compute_base_filter_names()
+                if names_to_remove:
+                    flat = {
+                        k: v for k, v in flat.items() if k.split(" ", 1)[0] not in names_to_remove
+                    }
+            return flat
+
+        return self.merge_per_frame_features(self.get_per_frame(labels))
+
     def get_features(self, window_size: int) -> dict:
         """get features and corresponding frame indexes for classification
 
@@ -524,15 +598,15 @@ class IdentityFeatures:
         Returns:
             dictionary with the following keys:
 
-            'per_frame': dict with feature name as keys, numpy array as values
-            'window': dict, see _compute_window_features
+            'per_frame': flat dict with ``"module feature"`` keys, numpy array values
+            'window': flat dict with ``"module op feature"`` keys, numpy array values
             'frame_indexes': 1D np array, maps elements of per frame and window
                feature arrays back to global frame indexes
 
             features are filtered by self.op_settings
         """
-        per_frame_features = self.get_per_frame()
-        window_features = self.get_window_features(window_size)
+        per_frame_features = self.get_per_frame_flat()
+        window_features = self.merge_window_features(self.get_window_features(window_size))
 
         indexes = np.arange(self._num_frames)[self._frame_valid == 1]
 
@@ -543,7 +617,7 @@ class IdentityFeatures:
         }
 
     def _filter_base_features_by_op(self, features: PerFrameFeatureMap) -> PerFrameFeatureMap:
-        """filter either per_frame or window features by the self._op_settings
+        """Filter per-frame or window features by op_settings.
 
         Args:
             features: dict of feature data
@@ -551,20 +625,7 @@ class IdentityFeatures:
         Returns:
             filtered features
         """
-        names_to_remove = []
-        for setting_name, setting_val in self._op_settings.items():
-            # skip if no filter assigned or we want to keep
-            if setting_name not in _BASE_FILTERS or setting_val is True:
-                continue
-            # special case for static objects, which are nested in a second dict
-            if isinstance(setting_val, dict):
-                for sub_setting, sub_val in setting_val.items():
-                    if not sub_val:
-                        names_to_remove = names_to_remove + _BASE_FILTERS[setting_name].get(
-                            sub_setting, []
-                        )
-            else:
-                names_to_remove = names_to_remove + _BASE_FILTERS[setting_name]
+        names_to_remove = self._compute_base_filter_names()
         return {k: v for k, v in features.items() if k not in names_to_remove}
 
     def _filter_window_features_by_op(self, features: WindowFeatureMap) -> WindowFeatureMap:

--- a/src/jabs/project/parallel_workers.py
+++ b/src/jabs/project/parallel_workers.py
@@ -6,6 +6,7 @@ be executed by ProcessPoolExecutor workers, managed by Project.get_labeled_featu
 """
 
 import json
+import logging
 import multiprocessing
 import sys
 from pathlib import Path
@@ -15,11 +16,14 @@ import numpy as np
 import pandas as pd
 
 import jabs.feature_extraction as fe
+from jabs.core.enums import CacheFormat
 from jabs.pose_estimation import open_pose_file
 from jabs.video_reader.utilities import get_fps
 
 from .track_labels import TrackLabels
 from .video_labels import VideoLabels
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from jabs.pose_estimation import PoseEstimation
@@ -40,6 +44,7 @@ class FeatureLoadJobSpec(TypedDict):
     cache_dir: Path | None
     behavior_settings: dict[str, object]
     behavior_name: str | None
+    cache_format: str
 
 
 class CollectFeatureLoadResult(TypedDict):
@@ -131,6 +136,14 @@ def collect_labeled_features(job: FeatureLoadJobSpec) -> CollectFeatureLoadResul
             continue
 
         # Feature extraction for this identity
+        try:
+            cache_format = CacheFormat(job["cache_format"])
+        except (KeyError, ValueError):
+            logger.error(
+                "Unknown cache_format %r in job spec; falling back to HDF5",
+                job.get("cache_format"),
+            )
+            cache_format = CacheFormat.HDF5
         features = fe.IdentityFeatures(
             video,
             identity,
@@ -138,11 +151,11 @@ def collect_labeled_features(job: FeatureLoadJobSpec) -> CollectFeatureLoadResul
             pose_est,
             fps=fps,
             op_settings=behavior_settings,
+            cache_format=cache_format,
         )
 
         # Per-frame features
-        per_frame = features.get_per_frame(labels)
-        per_frame = fe.IdentityFeatures.merge_per_frame_features(per_frame)
+        per_frame = features.get_per_frame_flat(labels)
 
         # Window features
         window_size: int = behavior_settings["window_size"]

--- a/src/jabs/project/parallel_workers.py
+++ b/src/jabs/project/parallel_workers.py
@@ -136,14 +136,7 @@ def collect_labeled_features(job: FeatureLoadJobSpec) -> CollectFeatureLoadResul
             continue
 
         # Feature extraction for this identity
-        try:
-            cache_format = CacheFormat(job["cache_format"])
-        except (KeyError, ValueError):
-            logger.error(
-                "Unknown cache_format %r in job spec; falling back to HDF5",
-                job.get("cache_format"),
-            )
-            cache_format = CacheFormat.HDF5
+        cache_format = CacheFormat(job["cache_format"])
         features = fe.IdentityFeatures(
             video,
             identity,

--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -2,6 +2,7 @@ import contextlib
 import getpass
 import gzip
 import json
+import logging
 import shutil
 import sys
 from collections.abc import Callable
@@ -28,6 +29,8 @@ from .session_tracker import SessionTracker
 from .settings_manager import SettingsManager
 from .video_labels import VideoLabels
 from .video_manager import VideoManager
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from jabs.classifier import Classifier
@@ -95,6 +98,11 @@ class Project:
         self._total_project_identities = 0
         self._enabled_extended_features = {}
 
+        # Capture whether project.json exists before SettingsManager loads it.
+        # Used below to choose the cache_format default: Parquet for brand-new projects,
+        # HDF5 for existing projects that predate the setting (conservative back-compat).
+        is_new_project = not self._paths.project_file.exists()
+
         self._settings_manager = SettingsManager(self._paths)
         self._video_manager = VideoManager(self._paths, self._settings_manager, enable_video_check)
         self._feature_manager = FeatureManager(
@@ -107,10 +115,12 @@ class Project:
         if self._settings_manager.project_settings.get("defaults") != self.get_project_defaults():
             self._settings_manager.save_project_file({"defaults": self.get_project_defaults()})
 
-        # Persist cache_format for projects that predate this setting (conservative HDF5 default).
+        # Persist cache_format. New projects default to Parquet; existing projects that
+        # predate this setting default to HDF5 to preserve backward compatibility.
         existing_settings = dict(self._settings_manager.project_settings.get("settings", {}))
         if CACHE_FORMAT_KEY not in existing_settings:
-            existing_settings[CACHE_FORMAT_KEY] = CacheFormat.HDF5.value
+            default_format = CacheFormat.PARQUET if is_new_project else CacheFormat.HDF5
+            existing_settings[CACHE_FORMAT_KEY] = default_format.value
             self._settings_manager.save_project_file({"settings": existing_settings})
 
         # Shared application-level process pool for feature extraction
@@ -195,8 +205,10 @@ class Project:
         """Get the feature cache format for this project.
 
         Returns:
-            The configured ``CacheFormat``. Defaults to ``CacheFormat.HDF5`` if
-            the setting is absent or contains an unrecognized value.
+            The configured ``CacheFormat``. The setting is always written to
+            ``project.json`` on first open, so this property should never read an
+            absent value in practice. Falls back to ``CacheFormat.HDF5`` for
+            unrecognized values.
         """
         raw = self._settings_manager.project_settings.get("settings", {}).get(
             CACHE_FORMAT_KEY, CacheFormat.HDF5.value
@@ -204,6 +216,9 @@ class Project:
         try:
             return CacheFormat(raw)
         except ValueError:
+            logger.error(
+                "Unrecognized cache_format value %r in project.json; falling back to HDF5", raw
+            )
             return CacheFormat.HDF5
 
     def clear_feature_cache(self) -> None:

--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -15,7 +15,8 @@ import numpy as np
 import pandas as pd
 
 import jabs.feature_extraction as fe
-from jabs.core.enums import CrossValidationGroupingStrategy, ProjectDistanceUnit
+from jabs.core.constants import CACHE_FORMAT_KEY
+from jabs.core.enums import CacheFormat, CrossValidationGroupingStrategy, ProjectDistanceUnit
 from jabs.pose_estimation import PoseEstimation, open_pose_file
 
 from .feature_manager import FeatureManager
@@ -106,6 +107,12 @@ class Project:
         if self._settings_manager.project_settings.get("defaults") != self.get_project_defaults():
             self._settings_manager.save_project_file({"defaults": self.get_project_defaults()})
 
+        # Persist cache_format for projects that predate this setting (conservative HDF5 default).
+        existing_settings = dict(self._settings_manager.project_settings.get("settings", {}))
+        if CACHE_FORMAT_KEY not in existing_settings:
+            existing_settings[CACHE_FORMAT_KEY] = CacheFormat.HDF5.value
+            self._settings_manager.save_project_file({"settings": existing_settings})
+
         # Shared application-level process pool for feature extraction
         self._process_pool = process_pool
 
@@ -182,6 +189,40 @@ class Project:
     def project_paths(self) -> ProjectPaths:
         """get the project paths object for this project"""
         return self._paths
+
+    @property
+    def cache_format(self) -> CacheFormat:
+        """Get the feature cache format for this project.
+
+        Returns:
+            The configured ``CacheFormat``. Defaults to ``CacheFormat.HDF5`` if
+            the setting is absent or contains an unrecognized value.
+        """
+        raw = self._settings_manager.project_settings.get("settings", {}).get(
+            CACHE_FORMAT_KEY, CacheFormat.HDF5.value
+        )
+        try:
+            return CacheFormat(raw)
+        except ValueError:
+            return CacheFormat.HDF5
+
+    def clear_feature_cache(self) -> None:
+        """Delete all feature cache files for every identity in the project.
+
+        Removes HDF5 and Parquet cache files from each per-identity directory
+        under the features directory. The directories themselves are preserved.
+        The new format will be written on the next cache miss.
+        """
+        from jabs.io.feature_cache import clear_cache
+
+        feature_dir = self._paths.feature_dir
+        if not feature_dir.exists():
+            return
+        for video_dir in feature_dir.iterdir():
+            if video_dir.is_dir():
+                for identity_dir in video_dir.iterdir():
+                    if identity_dir.is_dir():
+                        clear_cache(identity_dir)
 
     def get_derived_file_paths(self, video_name: str) -> list[Path]:
         """Return a list of paths for files derived from a given video.
@@ -639,6 +680,7 @@ class Project:
                 "cache_dir": self._paths.cache_dir,
                 "behavior_settings": behavior_settings,
                 "behavior_name": behavior,
+                "cache_format": self.cache_format.value,
             }
             jobs.append(job)
 

--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -234,10 +234,20 @@ class Project:
         if not feature_dir.exists():
             return
         for video_dir in feature_dir.iterdir():
-            if video_dir.is_dir():
-                for identity_dir in video_dir.iterdir():
-                    if identity_dir.is_dir():
-                        clear_cache(identity_dir)
+            if not video_dir.is_dir():
+                continue
+            for sub in video_dir.iterdir():
+                if not sub.is_dir():
+                    continue
+                try:
+                    int(sub.name)
+                    # sub is an identity directory (flat layout: features/<video>/<id>)
+                    clear_cache(sub)
+                except ValueError:
+                    # sub is a pose-hash directory (hash layout: features/<video>/<hash>/<id>)
+                    for identity_dir in sub.iterdir():
+                        if identity_dir.is_dir():
+                            clear_cache(identity_dir)
 
     def get_derived_file_paths(self, video_name: str) -> list[Path]:
         """Return a list of paths for files derived from a given video.

--- a/src/jabs/project/settings_manager.py
+++ b/src/jabs/project/settings_manager.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import typing
 
 import jabs.feature_extraction as feature_extraction
@@ -12,6 +13,8 @@ from jabs.version import version_str
 
 if typing.TYPE_CHECKING:
     from .project_paths import ProjectPaths
+
+logger = logging.getLogger(__name__)
 
 
 class SettingsManager:
@@ -102,6 +105,7 @@ class SettingsManager:
         try:
             return ClassifierMode(mode_str)
         except ValueError:
+            logger.warning("Invalid classifier mode %r in project file, using default", mode_str)
             return DEFAULT_CLASSIFIER_MODE
 
     @property
@@ -117,6 +121,9 @@ class SettingsManager:
         try:
             return CrossValidationGroupingStrategy(grouping_str)
         except ValueError:
+            logger.warning(
+                "Invalid CV grouping strategy %r in project file, using default", grouping_str
+            )
             return DEFAULT_CV_GROUPING_STRATEGY
 
     def video_metadata(self, video: str) -> dict:

--- a/src/jabs/project/video_manager.py
+++ b/src/jabs/project/video_manager.py
@@ -1,5 +1,5 @@
 import json
-import sys
+import logging
 from pathlib import Path
 
 from jabs.pose_estimation import (
@@ -13,6 +13,8 @@ from jabs.video_reader import VideoReader
 from .project_paths import ProjectPaths
 from .settings_manager import SettingsManager
 from .video_labels import VideoLabels
+
+logger = logging.getLogger(__name__)
 
 
 class VideoManager:
@@ -75,7 +77,7 @@ class VideoManager:
         try:
             self.check_video_name(video_name)
         except ValueError as e:
-            print(f"Error removing video {video_name}: {e}", file=sys.stderr)
+            logger.warning("Error removing video %s: %s", video_name, e)
         else:
             self._videos.remove(video_name)
             del self._video_identity_count[video_name]
@@ -191,9 +193,11 @@ class VideoManager:
             pose_frames = get_frames_from_file(path)
             vid_frames = VideoReader.get_nframes_from_file(self.video_path(v))
             if pose_frames != vid_frames:
-                print(
-                    f"{v}: video and pose file have different number of frames",
-                    file=sys.stderr,
+                logger.error(
+                    "%s: video and pose file have different number of frames (video=%s, pose=%s)",
+                    v,
+                    vid_frames,
+                    pose_frames,
                 )
                 err = True
         if err:
@@ -207,7 +211,7 @@ class VideoManager:
                 # Populate cache during validation
                 self._pose_path_cache[v] = get_pose_path(self.video_path(v), self._paths.pose_dir)
             except ValueError:
-                print(f"{v} missing pose file", file=sys.stderr)
+                logger.error("%s missing pose file", v)
                 err = True
         if err:
             raise ValueError("Project missing pose file for one or more video")

--- a/src/jabs/resources/docs/user_guide/cli-tools.md
+++ b/src/jabs/resources/docs/user_guide/cli-tools.md
@@ -161,7 +161,7 @@ jabs-init <project_dir> [--metadata <metadata.json>] [--force] [--processes <N>]
 - `--force`: Recompute features even if cache files already exist.
 - `--processes <N>`: Number of parallel workers to use for feature computation. If omitted, this defaults to the logical CPU count.
 - `-w WINDOW_SIZE`: Window size(s) to pre-compute. Can be repeated (e.g. `-w 2 -w 5`). Defaults to 5 if omitted.
-- `--cache-format {hdf5,parquet}`: Feature cache storage format. Defaults to `parquet`. Use `hdf5` only for compatibility with older JABS versions.
+- `--cache-format {hdf5,parquet}`: Feature cache storage format. If omitted, the existing project setting is preserved. New projects default to `parquet`; projects created before this option existed default to `hdf5`. Pass `--cache-format` explicitly only when you want to change or set the format — use `--force` alongside it to rewrite existing cache files in the new format.
 - `--skip-feature-generation`: Validate and initialize the project without computing features.
 
 **Examples:**

--- a/src/jabs/resources/docs/user_guide/cli-tools.md
+++ b/src/jabs/resources/docs/user_guide/cli-tools.md
@@ -20,7 +20,8 @@ See `jabs-classify COMMAND --help` for information on a specific command.
 usage: jabs-classify classify [-h] [--random-forest | --xgboost]
                             (--training TRAINING | --classifier CLASSIFIER) --input-pose
                             INPUT_POSE --out-dir OUT_DIR [--fps FPS]
-                            [--feature-dir FEATURE_DIR]
+                            [--feature-dir FEATURE_DIR] [--skip-window-cache]
+                            [--use-pose-hash]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -28,6 +29,12 @@ optional arguments:
   --feature-dir FEATURE_DIR
                         Feature cache dir. If present, look here for features before computing.
                         If features need to be computed, they will be saved here.
+  --skip-window-cache   Only cache per-frame features when --feature-dir is provided, reducing
+                        cache size at the cost of needing to re-calculate window features.
+  --use-pose-hash       Include the pose file hash as a subdirectory level in the feature cache
+                        path (e.g. <feature-dir>/<video>/<pose-hash>/<identity>). Prevents
+                        collisions when multiple pipelines share a feature cache directory and
+                        different pose files happen to share the same video name.
 
 required arguments:
   --input-pose INPUT_POSE
@@ -45,6 +52,8 @@ Classifier Input (one of the following is required):
   --classifier CLASSIFIER
                         Classifier file produced from the `jabs-classify train` command
 ```
+
+When `--feature-dir` is provided, `jabs-classify` automatically detects the existing cache format (HDF5 or Parquet) and reads from it. New cache files are always written in Parquet format. If the directory already contains an HDF5 cache, it is read as-is and any new window features are added to the existing HDF5 file — no conversion takes place.
 
 ### Train Command
 
@@ -77,6 +86,7 @@ JABS includes a script called `jabs-features`, which can be used to generate a f
 usage: jabs-features [-h] --pose-file POSE_FILE --pose-version POSE_VERSION
                             --feature-dir FEATURE_DIR [--use-cm-distances]
                             [--window-size WINDOW_SIZE] [--fps FPS]
+                            [--use-pose-hash]
 
 options:
   -h, --help            show this help message and exit
@@ -90,7 +100,12 @@ options:
   --window-size WINDOW_SIZE
                         window size for features (default none)
   --fps FPS             frames per second to use for feature calculation
+  --use-pose-hash       Include the pose file hash as a subdirectory level in the feature cache
+                        path (e.g. <feature-dir>/<video>/<pose-hash>/<identity>). Prevents
+                        collisions when a shared cache directory is used across multiple pipelines.
 ```
+
+Features are always written in Parquet format. Use `--use-pose-hash` when building a shared feature cache for multiple pipelines where video filenames may collide.
 
 ## jabs-cli
 
@@ -111,7 +126,7 @@ Options:
 
 Commands:
   postprocess           Apply a postprocessing pipeline to a JABS prediction HDF5 file.
-  convert-to-nwb        Convert a JABS pose estimation file to NWB format.
+  convert-to-nwb        Convert a JABS pose HDF5 file to NWB format.
   cross-validation      Run leave-one-group-out cross-validation for a JABS project.
   export-training       Export training data for a specified behavior and JABS project directory.
   prune                 Prune unused videos from a JABS project directory.
@@ -121,8 +136,8 @@ Commands:
   update-pose           Update a JABS project to use updated pose files while remapping labels.
 ```
 
-See [NWB Export](nwb-export.md) for full documentation of the `convert-to-nwb` command
-and NWB file structure.
+For full documentation of the `convert-to-nwb` command, including output modes, subjects
+and session metadata JSON formats, and NWB file structure, see [NWB Export](nwb-export.md).
 
 To get help for a specific command, run:
 
@@ -138,20 +153,31 @@ The `jabs-init` command initializes a JABS project directory and computes featur
 
 ```bash
 jabs-init <project_dir> [--metadata <metadata.json>] [--force] [--processes <N>]
+          [-w WINDOW_SIZE] [--cache-format {hdf5,parquet}] [--skip-feature-generation]
 ```
 
 - `<project_dir>`: Path to the JABS project directory containing video and pose files.
 - `--metadata <metadata.json>`: Optional path to a JSON metadata file describing the project and videos.
-- `--force`: Overwrite existing features and settings if present.
+- `--force`: Recompute features even if cache files already exist.
 - `--processes <N>`: Number of parallel workers to use for feature computation. If omitted, this defaults to the logical CPU count.
+- `-w WINDOW_SIZE`: Window size(s) to pre-compute. Can be repeated (e.g. `-w 2 -w 5`). Defaults to 5 if omitted.
+- `--cache-format {hdf5,parquet}`: Feature cache storage format. Defaults to `parquet`. Use `hdf5` only for compatibility with older JABS versions.
+- `--skip-feature-generation`: Validate and initialize the project without computing features.
 
-**Example:**
+**Examples:**
 
 ```bash
-jabs-init /path/to/project --metadata project_metadata.json --processes 8
+# Initialize a project with default settings (Parquet cache, window size 5)
+jabs-init /path/to/project
+
+# Initialize with metadata, 8 workers, and explicit window sizes
+jabs-init /path/to/project --metadata project_metadata.json --processes 8 -w 2 -w 5
+
+# Migrate an existing HDF5 cache to Parquet (recomputes all features)
+jabs-init /path/to/project --cache-format parquet --force
 ```
 
-See the [Project Setup Guide](project-setup.md#initialization--jabs-init) for a brief overview.
+See the [Project Setup Guide](project-setup.md#initialization--jabs-init) for a brief overview and [Feature Cache Format](project-setup.md#feature-cache-format) for migration guidance.
 
 ## jabs-cli update-pose
 
@@ -406,19 +432,19 @@ are replaced with underscores). Use `--list-behaviors` to check the names in a f
 
 Each stage entry has the following fields:
 
-| Field        | Required | Description                                                                                        |
-|--------------|----------|----------------------------------------------------------------------------------------------------|
-| `stage_name` | Yes      | Name of the postprocessing stage class (see [Available stages](#available-stages) below).          |
-| `parameters` | Yes      | Object of stage-specific parameters, or `null` if the stage takes no parameters.                   |
-| `enabled`    | No       | Boolean; defaults to `true`. Set to `false` to skip the stage without removing it from the config. |
+| Field | Required | Description |
+|---|---|---|
+| `stage_name` | Yes | Name of the postprocessing stage class (see [Available stages](#available-stages) below). |
+| `parameters` | Yes | Object of stage-specific parameters, or `null` if the stage takes no parameters. |
+| `enabled` | No | Boolean; defaults to `true`. Set to `false` to skip the stage without removing it from the config. |
 
 #### Available stages
 
-| Stage name                | Parameter                         | Description                                                                                                       |
-|---------------------------|-----------------------------------|-------------------------------------------------------------------------------------------------------------------|
-| `GapInterpolationStage`   | `max_interpolation_gap` (int > 0) | Fill short gaps of no-prediction frames between behavior bouts. Gaps up to this length (inclusive) are filled in. |
-| `BoutStitchingStage`      | `max_stitch_gap` (int > 0)        | Merge behavior bouts separated by short not-behavior gaps. Gaps up to this length (inclusive) are stitched over.  |
-| `BoutDurationFilterStage` | `min_duration` (int > 0)          | Remove behavior bouts shorter than the specified duration (in frames).                                            |
+| Stage name | Parameter | Description |
+|---|---|---|
+| `GapInterpolationStage` | `max_interpolation_gap` (int > 0) | Fill short gaps of no-prediction frames between behavior bouts. Gaps up to this length (inclusive) are filled in. |
+| `BoutStitchingStage` | `max_stitch_gap` (int > 0) | Merge behavior bouts separated by short not-behavior gaps. Gaps up to this length (inclusive) are stitched over. |
+| `BoutDurationFilterStage` | `min_duration` (int > 0) | Remove behavior bouts shorter than the specified duration (in frames). |
 
 Stages are applied in the order they appear in the list. A typical pipeline runs
 `GapInterpolationStage` or `BoutStitchingStage` before `BoutDurationFilterStage` so

--- a/src/jabs/resources/docs/user_guide/keyboard-shortcuts.md
+++ b/src/jabs/resources/docs/user_guide/keyboard-shortcuts.md
@@ -3,7 +3,7 @@
 ## Application
 
 | Action                      | Shortcut      |
-| --------------------------- | ------------- |
+|-----------------------------|---------------|
 | Quit JABS                   | Ctrl+Q / ⌘Q   |
 | Export current frame        | Ctrl+E / ⌘E   |
 | Export training data        | Ctrl+T / ⌘T   |
@@ -11,32 +11,33 @@
 
 ## Video Navigation
 
-| Action                        | Shortcut  |
-| ----------------------------- | --------- |
-| Play / Pause video            | Space bar |
-| Previous / Next frame         | ← / →     |
-| Move forward / back 10 frames | ↑ / ↓     |
-| Previous / Next video         | , / .     |
+| Action                        | Shortcut    |
+|-------------------------------|-------------|
+| Play / Pause video            | Space bar   |
+| Previous / Next frame         | ← / →       |
+| Move forward / back 10 frames | ↑ / ↓       |
+| Previous / Next video         | , / .       |
 
 ## Labeling
 
-| Action                                   | Shortcut       |
-| ---------------------------------------- | -------------- |
-| Start select mode                        | z, x, c        |
-| Label selection as behavior              | z              |
-| Clear labels from selection              | x              |
-| Label selection as not behavior          | c              |
-| Exit select mode without making a change | Esc            |
-| Select all frames                        | Ctrl+A / ⌘A   |
+| Action                                   | Shortcut           |
+|------------------------------------------|--------------------|
+| Start select mode                        | z, x, c            |
+| Label selection as behavior              | z                  |
+| Clear labels from selection              | x                  |
+| Label selection as not behavior          | c                  |
+| Exit select mode without making a change | Esc                |
+| Select all frames                        | Ctrl+A / ⌘A        |
+| Select current bout                      | Ctrl+Shift+A / ⌘⇧A |
 
 ## Identity & Overlays
 
 | Action                            | Shortcut          |
-| --------------------------------- | ----------------- |
+|-----------------------------------|-------------------|
 | Switch to next / previous subject | Shift+↑ / Shift+↓ |
 | Toggle track overlay              | t                 |
 | Toggle pose overlay               | p                 |
 | Toggle landmark overlay           | l                 |
-| Toggle Minimalist Identity Labels | Ctrl+I / ⌘I   |
+| Toggle Minimalist Identity Labels | Ctrl+I / ⌘I       |
 
 > **Note:** Next/previous subject order follows the "Identity Selection" dropdown ordering.

--- a/src/jabs/resources/docs/user_guide/keyboard-shortcuts.md
+++ b/src/jabs/resources/docs/user_guide/keyboard-shortcuts.md
@@ -13,7 +13,8 @@
 
 | Action                        | Shortcut    |
 |-------------------------------|-------------|
-| Play / Pause video            | Space bar   |
+| Play / Pause video            | Space bar        |
+| Play current bout             | Shift+Space bar  |
 | Previous / Next frame         | ← / →       |
 | Move forward / back 10 frames | ↑ / ↓       |
 | Previous / Next video         | , / .       |

--- a/src/jabs/resources/docs/user_guide/project-setup.md
+++ b/src/jabs/resources/docs/user_guide/project-setup.md
@@ -166,7 +166,19 @@ This directory contains trained classifiers. Currently, these are stored in Pyth
 
 ### jabs/features
 
-This directory contains the computed features. There is one directory per project video, and within each video directory there will be one feature subdirectory per identity. Feature files are portable between machines, but JABS may need to recompute the features if they were created with a different version of JABS. Feature files contain a version attribute that is incremented when features are added or changed, or the format of the features file is changed.
+This directory contains the computed features. There is one directory per project video, and within each video directory there will be one feature subdirectory per identity:
+
+```
+jabs/features/
+└── video_name/
+    ├── 0/          ← identity 0
+    ├── 1/          ← identity 1
+    └── ...
+```
+
+Feature files are portable between machines, but JABS may need to recompute them if the version of JABS that computed them is different from the one reading them. Each cache records a feature version number that is incremented whenever features are added, changed, or the cache format is updated.
+
+JABS supports two feature cache formats: **HDF5** (the original format) and **Parquet** (the current default). See [Feature Cache Format](#feature-cache-format) below for details and migration guidance.
 
 ### jabs/predictions
 
@@ -175,3 +187,44 @@ This directory contains one HDF5 prediction file per video (e.g., `VIDEO_1.h5`).
 ### jabs/training_logs
 
 This directory contains training reports generated each time a classifier is trained. Reports are saved as Markdown files with filenames in the format `<BehaviorName>_<timestamp>_training_report.md`. Each report includes training performance metrics, cross-validation results, and feature importance rankings. These reports provide a permanent record of training sessions for documentation and comparison purposes.
+
+## Feature Cache Format
+
+JABS supports two storage formats for the computed feature cache:
+
+| Format      | Description |
+|-------------|-------------|
+| **Parquet** | The current default. A columnar format that offers faster reads and smaller file sizes. Each identity directory contains `metadata.json`, `per_frame.parquet`, and one `window_<N>.parquet` file per cached window size. |
+| **HDF5**    | The original format. All features for an identity are stored in a single `features.h5` file. Supported by all versions of JABS. |
+
+New projects created with `jabs-init` or the GUI default to Parquet. JABS automatically detects the format of existing cache files on read, so HDF5 and Parquet projects both open correctly without any manual configuration.
+
+### Changing the cache format for a project (GUI)
+
+The cache format for a project is stored in `jabs/project.json` and can be changed from the GUI at any time via **Edit > Project Settings > Feature Cache Format**.
+
+Changing the setting alone does not convert existing cache files — JABS reads whatever format is already on disk. To force the cache to be regenerated in the new format:
+
+1. Open the project in JABS.
+2. Go to **Edit > Project Settings > Feature Cache Format** and select the desired format.
+3. Click **OK** to save.
+4. Use **File > Clear Feature Cache…** to delete all existing cache files.
+5. Trigger a training or classification run. JABS will recompute and write the cache in the new format on the next cache miss.
+
+### Migrating an existing project to Parquet (CLI)
+
+Use `jabs-init` with `--cache-format parquet` and `--force` to recompute all features and write them in Parquet format:
+
+```bash
+jabs-init /path/to/project --cache-format parquet --force
+```
+
+`--force` is required to overwrite existing HDF5 cache files. Without it, `jabs-init` skips identities that already have a valid cache. The `--cache-format parquet` flag is also written to `project.json` so the GUI and subsequent CLI runs use Parquet going forward.
+
+If the project has multiple window sizes, pass them explicitly so they are all pre-computed:
+
+```bash
+jabs-init /path/to/project --cache-format parquet --force -w 2 -w 5
+```
+
+To migrate back to HDF5, use `--cache-format hdf5 --force` in the same way.

--- a/src/jabs/scripts/classify.py
+++ b/src/jabs/scripts/classify.py
@@ -17,6 +17,7 @@ from rich.progress import BarColumn, Progress, TextColumn
 
 from jabs.classifier import Classifier
 from jabs.core.constants import APP_NAME
+from jabs.core.enums import CacheFormat
 from jabs.feature_extraction import IdentityFeatures
 from jabs.pose_estimation import open_pose_file
 from jabs.project.prediction_manager import PredictionManager
@@ -46,6 +47,7 @@ def train_and_classify(
     fps=DEFAULT_FPS,
     feature_dir: str | None = None,
     cache_window: bool = False,
+    use_pose_hash: bool = False,
 ):
     """Train a classifier using the provided training file and classify behaviors in a pose file.
 
@@ -59,6 +61,7 @@ def train_and_classify(
         fps (int, optional): Frames per second for feature extraction. Defaults to DEFAULT_FPS.
         feature_dir (str or None, optional): Directory for feature cache. If provided, features are cached here.
         cache_window (bool, optional): Whether to cache window features. Defaults to False.
+        use_pose_hash (bool, optional): Include pose file hash as a subdirectory in the cache path. Defaults to False.
     """
     if not training_file_path.exists():
         sys.exit("Unable to open training data\n")
@@ -72,6 +75,7 @@ def train_and_classify(
         fps,
         feature_dir,
         cache_window,
+        use_pose_hash=use_pose_hash,
     )
 
 
@@ -83,6 +87,7 @@ def classify_pose(
     fps=DEFAULT_FPS,
     feature_dir: str | None = None,
     cache_window: bool = False,
+    use_pose_hash: bool = False,
 ):
     """Classify behaviors in a pose file using a trained classifier.
 
@@ -97,6 +102,7 @@ def classify_pose(
         fps (int, optional): Frames per second for feature extraction. Defaults to DEFAULT_FPS.
         feature_dir (str or None, optional): Directory for feature cache. If provided, features are cached here.
         cache_window (bool, optional): Whether to cache window features. Defaults to False.
+        use_pose_hash (bool, optional): Include pose file hash as a subdirectory in the cache path. Defaults to False.
     """
     pose_est = open_pose_file(input_pose_file)
     pose_stem = get_pose_stem(input_pose_file)
@@ -125,14 +131,12 @@ def classify_pose(
                 fps=fps,
                 op_settings=classifier_settings,
                 cache_window=cache_window,
+                cache_format=CacheFormat.PARQUET,
+                include_pose_hash=use_pose_hash,
             ).get_features(classifier_settings["window_size"])
 
-            per_frame_features = pd.DataFrame(
-                IdentityFeatures.merge_per_frame_features(features["per_frame"])
-            )
-            window_features = pd.DataFrame(
-                IdentityFeatures.merge_window_features(features["window"])
-            )
+            per_frame_features = pd.DataFrame(features["per_frame"])
+            window_features = pd.DataFrame(features["window"])
 
             data = Classifier.combine_data(per_frame_features, window_features)
 
@@ -283,6 +287,17 @@ def classify_main():
         default=False,
         action="store_true",
     )
+    parser.add_argument(
+        "--use-pose-hash",
+        help=(
+            "Include the pose file hash as a subdirectory level in the feature cache path "
+            "(e.g. <feature-dir>/<video>/<pose-hash>/<identity>). "
+            "Prevents collisions when multiple pipelines share a feature cache directory "
+            "and different pose files happen to share the same video name."
+        ),
+        default=False,
+        action="store_true",
+    )
 
     args = parser.parse_args(classify_args)
 
@@ -297,6 +312,7 @@ def classify_main():
             fps=args.fps,
             feature_dir=args.feature_dir,
             cache_window=not args.skip_window_cache,
+            use_pose_hash=args.use_pose_hash,
         )
     elif args.classifier is not None:
         try:
@@ -327,6 +343,7 @@ def classify_main():
             fps=args.fps,
             feature_dir=args.feature_dir,
             cache_window=not args.skip_window_cache,
+            use_pose_hash=args.use_pose_hash,
         )
 
 

--- a/src/jabs/scripts/generate_features.py
+++ b/src/jabs/scripts/generate_features.py
@@ -9,7 +9,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from jabs.core.enums import ProjectDistanceUnit
+from jabs.core.enums import CacheFormat, ProjectDistanceUnit
 from jabs.feature_extraction.features import IdentityFeatures
 from jabs.pose_estimation import open_pose_file
 from jabs.project import Project
@@ -47,6 +47,8 @@ def generate_feature_cache(args):
             fps=args.fps,
             op_settings=settings,
             cache_window=cache_window,
+            cache_format=CacheFormat.PARQUET,
+            include_pose_hash=args.use_pose_hash,
         )
         # Window features are not automatically generated.
         if cache_window:
@@ -91,6 +93,17 @@ def main():
     )
     parser.add_argument(
         "--fps", default=30, help="frames per second to use for feature calculation"
+    )
+    parser.add_argument(
+        "--use-pose-hash",
+        action="store_true",
+        dest="use_pose_hash",
+        default=False,
+        help=(
+            "include the pose file hash as a subdirectory level in the feature cache path "
+            "(e.g. <feature-dir>/<video>/<pose-hash>/<identity>); "
+            "prevents collisions when a shared cache dir is used across multiple pipelines"
+        ),
     )
     args = parser.parse_args()
 

--- a/src/jabs/scripts/initialize_project.py
+++ b/src/jabs/scripts/initialize_project.py
@@ -35,14 +35,7 @@ def generate_files_worker(params: dict):
     """worker function used for generating project feature and cache files"""
     project = params["project"]
     pose_est = project.load_pose_est(project.video_manager.video_path(params["video"]))
-    try:
-        cache_format = CacheFormat(params.get("cache_format", CacheFormat.HDF5.value))
-    except ValueError:
-        logger.error(
-            "Unknown cache_format %r in job params; falling back to HDF5",
-            params.get("cache_format"),
-        )
-        cache_format = CacheFormat.HDF5
+    cache_format = CacheFormat(params["cache_format"])
 
     features = jabs.feature_extraction.IdentityFeatures(
         params["video"],
@@ -240,7 +233,7 @@ def run_initialize_project(
     metadata_path: Path | None,
     skip_feature_generation: bool,
     project_dir: Path,
-    cache_format: CacheFormat = CacheFormat.PARQUET,
+    cache_format: CacheFormat | None = None,
 ) -> None:
     """Run project initialization and optional feature generation."""
     pool = Pool(processes)
@@ -264,11 +257,16 @@ def run_initialize_project(
         distance_unit = project.feature_manager.distance_unit
         _apply_project_metadata(project, metadata)
 
-        # Write the requested cache format to project.json so subsequent opens
-        # (including subprocess workers that re-open the project) see it.
+        # Resolve the effective cache format. For new projects, Project.__init__ already
+        # wrote CACHE_FORMAT_KEY into project.json, so existing_settings always has the key
+        # (or it's an older HDf5 project that predates this setting key, which implies HDF5).
+        # We only override it when the user explicitly passes --cache-format.
         existing_settings = dict(project.settings_manager.project_settings.get("settings", {}))
-        existing_settings[CACHE_FORMAT_KEY] = cache_format.value
-        project.settings_manager.save_project_file({"settings": existing_settings})
+        if cache_format is None:
+            cache_format = CacheFormat(existing_settings[CACHE_FORMAT_KEY])
+        else:
+            existing_settings[CACHE_FORMAT_KEY] = cache_format.value
+            project.settings_manager.save_project_file({"settings": existing_settings})
 
         # iterate over each video and try to pair it with an h5 file
         # this test is quick, don't bother to parallelize
@@ -334,7 +332,7 @@ def run_initialize_project(
     "-f",
     "--force",
     is_flag=True,
-    help="recompute features even if file already exists",
+    help="Recompute features even if they already exist. Does not change the cache format; pass --cache-format explicitly to migrate.",
 )
 @click.option(
     "-p",
@@ -381,9 +379,12 @@ def run_initialize_project(
     "--cache-format",
     "cache_format",
     type=click.Choice([f.value for f in CacheFormat], case_sensitive=False),
-    default=CacheFormat.PARQUET.value,
-    show_default=True,
-    help="Feature cache storage format to use for this project",
+    default=None,
+    help=(
+        "Feature cache storage format. If omitted, the existing project setting is "
+        "preserved; new projects default to Parquet; projects created before this "
+        "option existed default to HDF5."
+    ),
 )
 @click.argument("project_dir", type=click.Path(path_type=Path))
 def main(
@@ -393,7 +394,7 @@ def main(
     force_pixel_distances: bool,
     metadata: Path | None,
     skip_feature_generation: bool,
-    cache_format: str,
+    cache_format: str | None,
     project_dir: Path,
 ) -> None:
     """jabs-init."""
@@ -405,7 +406,7 @@ def main(
         metadata_path=metadata,
         skip_feature_generation=skip_feature_generation,
         project_dir=project_dir,
-        cache_format=CacheFormat(cache_format),
+        cache_format=CacheFormat(cache_format) if cache_format is not None else None,
     )
 
 

--- a/src/jabs/scripts/initialize_project.py
+++ b/src/jabs/scripts/initialize_project.py
@@ -7,6 +7,7 @@ overwrite existing feature H5 files.
 """
 
 import json
+import logging
 import os
 from multiprocessing import Pool
 from pathlib import Path
@@ -18,10 +19,13 @@ from rich.progress import Progress
 import jabs.feature_extraction
 import jabs.pose_estimation
 import jabs.project
-from jabs.core.enums import ProjectDistanceUnit
+from jabs.core.constants import CACHE_FORMAT_KEY
+from jabs.core.enums import CacheFormat, ProjectDistanceUnit
 from jabs.project.video_manager import VideoManager
 from jabs.schema.metadata import validate_metadata
 from jabs.video_reader import VideoReader
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_WINDOW_SIZE = 5
 DEFAULT_PROCESSES = os.cpu_count() or 1
@@ -31,6 +35,14 @@ def generate_files_worker(params: dict):
     """worker function used for generating project feature and cache files"""
     project = params["project"]
     pose_est = project.load_pose_est(project.video_manager.video_path(params["video"]))
+    try:
+        cache_format = CacheFormat(params.get("cache_format", CacheFormat.HDF5.value))
+    except ValueError:
+        logger.error(
+            "Unknown cache_format %r in job params; falling back to HDF5",
+            params.get("cache_format"),
+        )
+        cache_format = CacheFormat.HDF5
 
     features = jabs.feature_extraction.IdentityFeatures(
         params["video"],
@@ -39,6 +51,7 @@ def generate_files_worker(params: dict):
         pose_est,
         force=params["force"],
         op_settings=project.get_project_defaults(),
+        cache_format=cache_format,
     )
 
     # unlike per frame features, window features are not automatically
@@ -132,6 +145,7 @@ def compute_project_features(
     window_sizes: list[int],
     force: bool,
     pool: Pool,
+    cache_format: CacheFormat = CacheFormat.PARQUET,
 ) -> None:
     """Compute features for all identities in the project."""
 
@@ -146,6 +160,7 @@ def compute_project_features(
                     "project": project,
                     "force": force,
                     "window_sizes": window_sizes,
+                    "cache_format": cache_format.value,
                 }
 
     total_identities = project.total_project_identities
@@ -225,6 +240,7 @@ def run_initialize_project(
     metadata_path: Path | None,
     skip_feature_generation: bool,
     project_dir: Path,
+    cache_format: CacheFormat = CacheFormat.PARQUET,
 ) -> None:
     """Run project initialization and optional feature generation."""
     pool = Pool(processes)
@@ -247,6 +263,12 @@ def run_initialize_project(
         project = jabs.project.Project(project_dir, enable_session_tracker=False)
         distance_unit = project.feature_manager.distance_unit
         _apply_project_metadata(project, metadata)
+
+        # Write the requested cache format to project.json so subsequent opens
+        # (including subprocess workers that re-open the project) see it.
+        existing_settings = dict(project.settings_manager.project_settings.get("settings", {}))
+        existing_settings[CACHE_FORMAT_KEY] = cache_format.value
+        project.settings_manager.save_project_file({"settings": existing_settings})
 
         # iterate over each video and try to pair it with an h5 file
         # this test is quick, don't bother to parallelize
@@ -279,7 +301,7 @@ def run_initialize_project(
 
         # compute features in parallel, this might take a while
         if not skip_feature_generation:
-            compute_project_features(project, resolved_window_sizes, force, pool)
+            compute_project_features(project, resolved_window_sizes, force, pool, cache_format)
 
         # save window sizes to project settings
         deduped_window_sizes = set(
@@ -355,6 +377,14 @@ def run_initialize_project(
     is_flag=True,
     help="Skip feature calculation and only initialize/validate the project",
 )
+@click.option(
+    "--cache-format",
+    "cache_format",
+    type=click.Choice([f.value for f in CacheFormat], case_sensitive=False),
+    default=CacheFormat.PARQUET.value,
+    show_default=True,
+    help="Feature cache storage format to use for this project",
+)
 @click.argument("project_dir", type=click.Path(path_type=Path))
 def main(
     force: bool,
@@ -363,6 +393,7 @@ def main(
     force_pixel_distances: bool,
     metadata: Path | None,
     skip_feature_generation: bool,
+    cache_format: str,
     project_dir: Path,
 ) -> None:
     """jabs-init."""
@@ -374,6 +405,7 @@ def main(
         metadata_path=metadata,
         skip_feature_generation=skip_feature_generation,
         project_dir=project_dir,
+        cache_format=CacheFormat(cache_format),
     )
 
 

--- a/src/jabs/ui/classification_thread.py
+++ b/src/jabs/ui/classification_thread.py
@@ -1,3 +1,5 @@
+import time
+
 import numpy as np
 import pandas as pd
 from PySide6.QtCore import QThread, Signal
@@ -43,7 +45,7 @@ class ClassifyThread(QThread):
         projects with many videos.
     """
 
-    classification_complete = Signal(dict)
+    classification_complete = Signal(dict, int)
     current_status = Signal(str)
     update_progress = Signal(int)
     error_callback = Signal(Exception)
@@ -86,6 +88,7 @@ class ClassifyThread(QThread):
         current_video_predictions = {}
         current_video_probabilities = {}
         current_video_predictions_postprocessed = {}
+        t0_ns = time.perf_counter_ns()
 
         def check_termination_requested() -> None:
             if self._should_terminate:
@@ -124,18 +127,15 @@ class ClassifyThread(QThread):
                         pose_est,
                         fps=fps,
                         op_settings=project_settings,
+                        cache_format=self._project.cache_format,
                     )
                     feature_values = features.get_features(
                         project_settings.get("window_size", DEFAULT_WINDOW_SIZE)
                     )
 
                     # reformat the data in a single 2D numpy array to pass to the classifier
-                    per_frame_features = pd.DataFrame(
-                        IdentityFeatures.merge_per_frame_features(feature_values["per_frame"])
-                    )
-                    window_features = pd.DataFrame(
-                        IdentityFeatures.merge_window_features(feature_values["window"])
-                    )
+                    per_frame_features = pd.DataFrame(feature_values["per_frame"])
+                    window_features = pd.DataFrame(feature_values["window"])
                     data = self._classifier.combine_data(per_frame_features, window_features)
 
                     check_termination_requested()
@@ -178,6 +178,7 @@ class ClassifyThread(QThread):
                 self._tasks_complete += 1
                 self.update_progress.emit(self._tasks_complete)
 
+            elapsed_ms = int((time.perf_counter_ns() - t0_ns) // 1_000_000)
             # emits the predictions, probabilities, and frame indexes for the video currently loaded in
             # the video player, so that it can update the UI accordingly to show the new predictions
             self.classification_complete.emit(
@@ -185,7 +186,8 @@ class ClassifyThread(QThread):
                     "predictions": current_video_predictions,
                     "probabilities": current_video_probabilities,
                     "predictions_postprocessed": current_video_predictions_postprocessed,
-                }
+                },
+                elapsed_ms,
             )
         except Exception as e:
             # if there was an exception, we'll emit the Exception as a signal so that

--- a/src/jabs/ui/main_window/central_widget.py
+++ b/src/jabs/ui/main_window/central_widget.py
@@ -918,7 +918,7 @@ class CentralWidget(QtWidgets.QWidget):
         # start classification thread
         self._classify_thread.start()
 
-    def _classify_thread_complete(self, output: dict) -> None:
+    def _classify_thread_complete(self, output: dict, elapsed_ms: int) -> None:
         """update the gui when the classification is complete"""
         # display the new predictions
         self._predictions = output["predictions"]
@@ -926,7 +926,9 @@ class CentralWidget(QtWidgets.QWidget):
         self._predictions_postprocessed = output["predictions_postprocessed"]
         self._cleanup_progress_dialog()
         self._cleanup_classify_thread()
-        self.status_message.emit("Classification Complete", 3000)
+        self.status_message.emit(
+            f"Classification Complete. Elapsed time: {elapsed_ms / 1000:.1f}s", 20000
+        )
         self._set_prediction_vis()
 
     def _update_classify_progress(self, step: int) -> None:

--- a/src/jabs/ui/main_window/central_widget.py
+++ b/src/jabs/ui/main_window/central_widget.py
@@ -1096,6 +1096,8 @@ class CentralWidget(QtWidgets.QWidget):
             # Binary predictions from individual behavior classifiers must not be pushed
             # into the multiclass timeline layout -- the widget structure is incompatible
             # and the data is meaningless in a multiclass context.
+            if self._label_overlay_mode == PlayerWidget.LabelOverlayMode.PREDICTION:
+                self._player_widget.set_labels(None)
             return
 
         self._prediction_list, self._probability_list = self._get_prediction_list()

--- a/src/jabs/ui/main_window/central_widget.py
+++ b/src/jabs/ui/main_window/central_widget.py
@@ -725,6 +725,7 @@ class CentralWidget(QtWidgets.QWidget):
         self._update_label_counts()
         self.set_train_button_enabled_state()
         self._player_widget.reload_frame()
+        self._set_label_track()
 
     def _set_identities(self, identities: list[str]) -> None:
         """populate the identity_selection combobox"""
@@ -1049,7 +1050,13 @@ class CentralWidget(QtWidgets.QWidget):
 
     def _set_prediction_vis(self) -> None:
         """update data being displayed by the prediction visualization widget"""
-        if self._loaded_video is None:
+        if self._project is None or self._loaded_video is None:
+            return
+
+        if self._project.settings_manager.classifier_mode == ClassifierMode.MULTICLASS:
+            # Binary predictions from individual behavior classifiers must not be pushed
+            # into the multiclass timeline layout -- the widget structure is incompatible
+            # and the data is meaningless in a multiclass context.
             return
 
         self._prediction_list, self._probability_list = self._get_prediction_list()

--- a/src/jabs/ui/main_window/central_widget.py
+++ b/src/jabs/ui/main_window/central_widget.py
@@ -571,7 +571,6 @@ class CentralWidget(QtWidgets.QWidget):
         ):
             return
 
-        current_frame = self._player_widget.current_frame
         identity = self._controls.current_identity_index
         behavior = self._controls.current_behavior
 
@@ -583,22 +582,11 @@ class CentralWidget(QtWidgets.QWidget):
         if labels is None or len(labels) == 0:
             return
 
-        current_label = labels[current_frame]
-        if current_label not in (
-            TrackLabels.Label.BEHAVIOR.value,
-            TrackLabels.Label.NOT_BEHAVIOR.value,
-        ):
+        bout = self._get_bout_range(labels, self._player_widget.current_frame)
+        if bout is None:
             return
 
-        start = current_frame
-        while start > 0 and labels[start - 1] == current_label:
-            start -= 1
-
-        num_frames = len(labels)
-        end = current_frame
-        while end < num_frames and labels[end] == current_label:
-            end += 1
-        end -= 1
+        start, end = bout
 
         if not self._controls.select_button_is_checked:
             self._controls.toggle_select_button()
@@ -607,6 +595,36 @@ class CentralWidget(QtWidgets.QWidget):
         self._selection_start = start
         self._selection_end = end
         self._stacked_timeline.start_selection(start, end)
+
+    @staticmethod
+    def _get_bout_range(labels: np.ndarray, current_frame: int) -> tuple[int, int] | None:
+        """Return the (start, end) frame indices of the labeled bout at current_frame.
+
+        Args:
+            labels: Per-frame label array for a single identity/behavior track.
+            current_frame: Index of the current frame.
+
+        Returns:
+            Inclusive (start, end) frame indices, or None if the current frame is
+            not labeled BEHAVIOR or NOT_BEHAVIOR.
+        """
+        current_label = labels[current_frame]
+        if current_label not in (
+            TrackLabels.Label.BEHAVIOR.value,
+            TrackLabels.Label.NOT_BEHAVIOR.value,
+        ):
+            return None
+
+        start = current_frame
+        while start > 0 and labels[start - 1] == current_label:
+            start -= 1
+
+        end = current_frame
+        while end < len(labels) and labels[end] == current_label:
+            end += 1
+        end -= 1
+
+        return start, end
 
     @property
     def _curr_selection_end(self) -> int:
@@ -1331,27 +1349,11 @@ class CentralWidget(QtWidgets.QWidget):
         if labels is None or len(labels) == 0:
             return
 
-        current_label = labels[current_frame]
-        # Only play if current label is BEHAVIOR or NOT_BEHAVIOR
-        if current_label not in (
-            TrackLabels.Label.BEHAVIOR.value,
-            TrackLabels.Label.NOT_BEHAVIOR.value,
-        ):
+        bout = self._get_bout_range(labels, current_frame)
+        if bout is None:
             return
 
-        # Find start of bout
-        start = current_frame
-        while start > 0 and labels[start - 1] == current_label:
-            start -= 1
-
-        # Find end of bout (inclusive)
-        num_frames = len(labels)
-        end = current_frame
-        while end < num_frames and labels[end] == current_label:
-            end += 1
-        end -= 1
-
-        self._player_widget.play_range(start, end)
+        self._player_widget.play_range(*bout)
 
     def _on_timeline_annotation_button_clicked(self) -> None:
         """Handle the event when the button to create a new timeline annotation is clicked.

--- a/src/jabs/ui/main_window/central_widget.py
+++ b/src/jabs/ui/main_window/central_widget.py
@@ -806,6 +806,9 @@ class CentralWidget(QtWidgets.QWidget):
                     ],
                     mask_list,
                 )
+                if self._label_overlay_mode == PlayerWidget.LabelOverlayMode.LABEL:
+                    label_list = self._get_label_list()
+                    self._player_widget.set_labels([labels.get_labels() for labels in label_list])
             else:
                 label_list = self._get_label_list()
                 self._stacked_timeline.set_labels(

--- a/src/jabs/ui/main_window/central_widget.py
+++ b/src/jabs/ui/main_window/central_widget.py
@@ -559,6 +559,55 @@ class CentralWidget(QtWidgets.QWidget):
                 self._selection_end = num_frames - 1
                 self._stacked_timeline.start_selection(self._selection_start, self._selection_end)
 
+    def select_current_bout(self) -> None:
+        """Select all frames in the current bout (contiguous labeled run at the current frame).
+
+        Only activates when the current frame has a BEHAVIOR or NOT_BEHAVIOR label.
+        """
+        if (
+            not self._controls.select_button_enabled
+            or self._labels is None
+            or self._pose_est is None
+        ):
+            return
+
+        current_frame = self._player_widget.current_frame
+        identity = self._controls.current_identity_index
+        behavior = self._controls.current_behavior
+
+        if identity == -1 or behavior == "":
+            return
+
+        labels = self._labels.get_track_labels(str(identity), behavior).get_labels()
+
+        if labels is None or len(labels) == 0:
+            return
+
+        current_label = labels[current_frame]
+        if current_label not in (
+            TrackLabels.Label.BEHAVIOR.value,
+            TrackLabels.Label.NOT_BEHAVIOR.value,
+        ):
+            return
+
+        start = current_frame
+        while start > 0 and labels[start - 1] == current_label:
+            start -= 1
+
+        num_frames = len(labels)
+        end = current_frame
+        while end < num_frames and labels[end] == current_label:
+            end += 1
+        end -= 1
+
+        if not self._controls.select_button_is_checked:
+            self._controls.toggle_select_button()
+
+        self._controls.enable_label_buttons()
+        self._selection_start = start
+        self._selection_end = end
+        self._stacked_timeline.start_selection(start, end)
+
     @property
     def _curr_selection_end(self) -> int:
         """Get the end of the current selection.

--- a/src/jabs/ui/main_window/central_widget.py
+++ b/src/jabs/ui/main_window/central_widget.py
@@ -512,6 +512,42 @@ class CentralWidget(QtWidgets.QWidget):
         """set the timeline view mode"""
         self._stacked_timeline.identity_mode = identity_mode
 
+    @property
+    def mc_collapse_label_bar(self) -> bool:
+        """Whether inactive identity label bars are collapsed in multiclass all-animals mode."""
+        return self._stacked_timeline.collapse_inactive_label_bar
+
+    @mc_collapse_label_bar.setter
+    def mc_collapse_label_bar(self, value: bool) -> None:
+        self._stacked_timeline.collapse_inactive_label_bar = value
+
+    @property
+    def mc_collapse_combined_bar(self) -> bool:
+        """Whether inactive combined prediction bars are collapsed in multiclass all-animals mode."""
+        return self._stacked_timeline.collapse_inactive_combined_bar
+
+    @mc_collapse_combined_bar.setter
+    def mc_collapse_combined_bar(self, value: bool) -> None:
+        self._stacked_timeline.collapse_inactive_combined_bar = value
+
+    @property
+    def mc_collapse_per_class_bars(self) -> bool:
+        """Whether inactive per-class prediction bars are collapsed in multiclass all-animals mode."""
+        return self._stacked_timeline.collapse_inactive_per_class_bars
+
+    @mc_collapse_per_class_bars.setter
+    def mc_collapse_per_class_bars(self, value: bool) -> None:
+        self._stacked_timeline.collapse_inactive_per_class_bars = value
+
+    @property
+    def mc_hide_per_class_rows(self) -> bool:
+        """Whether per-class prediction rows are hidden for inactive identities."""
+        return self._stacked_timeline.hide_inactive_per_class_widgets
+
+    @mc_hide_per_class_rows.setter
+    def mc_hide_per_class_rows(self, value: bool) -> None:
+        self._stacked_timeline.hide_inactive_per_class_widgets = value
+
     def _on_behavior_changed(self) -> None:
         """make UI changes to reflect the currently selected behavior"""
         if self._project is None:

--- a/src/jabs/ui/main_window/central_widget.py
+++ b/src/jabs/ui/main_window/central_widget.py
@@ -368,6 +368,10 @@ class CentralWidget(QtWidgets.QWidget):
 
             self._stacked_timeline.pose = self._pose_est
             self._stacked_timeline.framerate = self._player_widget.stream_fps
+            self._stacked_timeline.set_classifier_mode(
+                self._project.settings_manager.classifier_mode,
+                self._controls.behaviors,
+            )
             self._suppress_label_track_update = False
             self._set_label_track()
             self._update_select_button_state()
@@ -686,18 +690,27 @@ class CentralWidget(QtWidgets.QWidget):
         identity = self._controls.current_identity_index
 
         if identity != -1 and behavior != "" and self._labels is not None:
-            label_list = self._get_label_list()
             mask_list = [
                 self._pose_est.identity_mask(i) for i in range(self._pose_est.num_identities)
             ]
-            self._stacked_timeline.set_labels(
-                [track_labels_to_lut_indices(t) for t in label_list],
-                mask_list,
-            )
-
-            if self._label_overlay_mode == PlayerWidget.LabelOverlayMode.LABEL:
-                # if configured to show labels, update the player widget with the new labels
-                self._player_widget.set_labels([labels.get_labels() for labels in label_list])
+            if self._project.settings_manager.classifier_mode == ClassifierMode.MULTICLASS:
+                behavior_names = self._controls.behaviors
+                self._stacked_timeline.set_labels(
+                    [
+                        self._labels.build_multiclass_label_array(str(i), behavior_names)
+                        for i in range(self._pose_est.num_identities)
+                    ],
+                    mask_list,
+                )
+            else:
+                label_list = self._get_label_list()
+                self._stacked_timeline.set_labels(
+                    [track_labels_to_lut_indices(t) for t in label_list],
+                    mask_list,
+                )
+                if self._label_overlay_mode == PlayerWidget.LabelOverlayMode.LABEL:
+                    # if configured to show labels, update the player widget with the new labels
+                    self._player_widget.set_labels([labels.get_labels() for labels in label_list])
 
         self._set_prediction_vis()
 
@@ -972,8 +985,8 @@ class CentralWidget(QtWidgets.QWidget):
 
         self._prediction_list, self._probability_list = self._get_prediction_list()
         self._stacked_timeline.set_predictions(
-            [binary_predictions_to_lut_indices(p) for p in self._prediction_list],
-            self._probability_list,
+            [[binary_predictions_to_lut_indices(p)] for p in self._prediction_list],
+            [[prob] for prob in self._probability_list],
         )
         if self._label_overlay_mode == PlayerWidget.LabelOverlayMode.PREDICTION:
             # if the player is set to show predictions, update the player widget
@@ -1012,6 +1025,20 @@ class CentralWidget(QtWidgets.QWidget):
             prediction_list.append(predictions[i])
             probability_list.append(self._probabilities[i])
         return prediction_list, probability_list
+
+    def update_classifier_mode_display(self) -> None:
+        """Rebuild the timeline layout and refresh labels to reflect the current classifier mode.
+
+        Rebuilds the stacked timeline's per-identity widget structure and re-renders
+        all label bars.  Has no effect if no video is currently loaded.
+        """
+        if self._project is None or self._loaded_video is None:
+            return
+        self._stacked_timeline.set_classifier_mode(
+            self._project.settings_manager.classifier_mode,
+            self._controls.behaviors,
+        )
+        self._set_label_track()
 
     def set_train_button_enabled_state(self) -> None:
         """set the enabled property of the train button

--- a/src/jabs/ui/main_window/main_window.py
+++ b/src/jabs/ui/main_window/main_window.py
@@ -325,6 +325,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self._project.feature_manager.can_use_segmentation_features
         )
         self._menu_refs.clear_cache.setEnabled(True)
+        self._menu_refs.clear_feature_cache.setEnabled(True)
         available_objects = self._project.feature_manager.static_objects
         for static_object, menu_item in self._menu_refs.enable_landmark_features.items():
             if static_object in available_objects:

--- a/src/jabs/ui/main_window/main_window.py
+++ b/src/jabs/ui/main_window/main_window.py
@@ -460,6 +460,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self._central_widget.controls.set_classifier_mode(
             self._project.settings_manager.classifier_mode
         )
+        # rebuild the timeline layout and refresh labels for the new mode
+        self._central_widget.update_classifier_mode_display()
 
     def on_app_settings_changed(self) -> None:
         """Slot called when application settings are changed via JabsSettingsDialog.

--- a/src/jabs/ui/main_window/main_window.py
+++ b/src/jabs/ui/main_window/main_window.py
@@ -463,6 +463,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         # rebuild the timeline layout and refresh labels for the new mode
         self._central_widget.update_classifier_mode_display()
+        self.menu_handlers.update_mc_layout_actions_enabled_state()
 
     def on_app_settings_changed(self) -> None:
         """Slot called when application settings are changed via JabsSettingsDialog.

--- a/src/jabs/ui/main_window/menu_builder.py
+++ b/src/jabs/ui/main_window/menu_builder.py
@@ -64,6 +64,12 @@ class MenuReferences:
     timeline_raw_predictions: QtGui.QAction
     timeline_postprocessed_predictions: QtGui.QAction
 
+    # Multi-class layout actions (enabled only in multiclass + all-animals mode)
+    mc_collapse_label_bar: QtGui.QAction
+    mc_collapse_combined_bar: QtGui.QAction
+    mc_collapse_per_class_bars: QtGui.QAction
+    mc_hide_per_class_rows: QtGui.QAction
+
     # Label overlay actions
     label_overlay_none: QtGui.QAction
     label_overlay_labels: QtGui.QAction
@@ -447,10 +453,47 @@ class MenuBuilder:
             self.handlers.on_timeline_prediction_type_changed
         )
 
+        timeline_menu.addSeparator()
+
+        # Fourth group: multi-class layout options (only active in multiclass + all-animals mode)
+        mc_collapse_label_bar = QtGui.QAction(
+            "Collapse Inactive Label Bars", self.main_window, checkable=True
+        )
+        mc_collapse_combined_bar = QtGui.QAction(
+            "Collapse Inactive Combined Prediction Bars", self.main_window, checkable=True
+        )
+        mc_collapse_per_class_bars = QtGui.QAction(
+            "Collapse Inactive Per-class Predictions", self.main_window, checkable=True
+        )
+        mc_hide_per_class_rows = QtGui.QAction(
+            "Hide Inactive Per-class Rows", self.main_window, checkable=True
+        )
+
+        timeline_menu.addAction(mc_collapse_label_bar)
+        timeline_menu.addAction(mc_collapse_combined_bar)
+        timeline_menu.addAction(mc_collapse_per_class_bars)
+        timeline_menu.addAction(mc_hide_per_class_rows)
+
+        mc_collapse_label_bar.triggered.connect(self.handlers.on_mc_collapse_label_bar_changed)
+        mc_collapse_combined_bar.triggered.connect(
+            self.handlers.on_mc_collapse_combined_bar_changed
+        )
+        mc_collapse_per_class_bars.triggered.connect(
+            self.handlers.on_mc_collapse_per_class_bars_changed
+        )
+        mc_hide_per_class_rows.triggered.connect(self.handlers.on_mc_hide_per_class_rows_changed)
+
         # Set defaults
         timeline_labels_preds.setChecked(True)
         timeline_selected_animal.setChecked(True)
         timeline_raw_predictions.setChecked(True)
+        mc_collapse_per_class_bars.setChecked(True)
+
+        # Disabled until multiclass + all-animals mode is active
+        mc_collapse_label_bar.setEnabled(False)
+        mc_collapse_combined_bar.setEnabled(False)
+        mc_collapse_per_class_bars.setEnabled(False)
+        mc_hide_per_class_rows.setEnabled(False)
 
         return {
             "timeline_labels_preds": timeline_labels_preds,
@@ -460,6 +503,10 @@ class MenuBuilder:
             "timeline_selected_animal": timeline_selected_animal,
             "timeline_raw_predictions": timeline_raw_predictions,
             "timeline_postprocessed_predictions": timeline_postprocessed_predictions,
+            "mc_collapse_label_bar": mc_collapse_label_bar,
+            "mc_collapse_combined_bar": mc_collapse_combined_bar,
+            "mc_collapse_per_class_bars": mc_collapse_per_class_bars,
+            "mc_hide_per_class_rows": mc_hide_per_class_rows,
         }
 
     def _build_label_overlay_submenu(self, parent_menu: QtWidgets.QMenu) -> dict:

--- a/src/jabs/ui/main_window/menu_builder.py
+++ b/src/jabs/ui/main_window/menu_builder.py
@@ -661,3 +661,8 @@ class MenuBuilder:
         select_all_action.setShortcut(QtGui.QKeySequence.StandardKey.SelectAll)
         select_all_action.triggered.connect(self.handlers.handle_select_all)
         self.main_window.addAction(select_all_action)
+
+        select_bout_action = QtGui.QAction(self.main_window)
+        select_bout_action.setShortcut(QtGui.QKeySequence("Ctrl+Shift+A"))
+        select_bout_action.triggered.connect(self.handlers.handle_select_current_bout)
+        self.main_window.addAction(select_bout_action)

--- a/src/jabs/ui/main_window/menu_builder.py
+++ b/src/jabs/ui/main_window/menu_builder.py
@@ -35,9 +35,10 @@ class MenuReferences:
 
     # App menu actions
     settings_action: QtGui.QAction
-    clear_cache: QtGui.QAction
 
     # File menu actions
+    clear_cache: QtGui.QAction
+    clear_feature_cache: QtGui.QAction
     export_frame: QtGui.QAction
     export_training: QtGui.QAction
     archive_behavior: QtGui.QAction
@@ -184,13 +185,6 @@ class MenuBuilder:
         license_action.triggered.connect(self.handlers.show_license_dialog)
         menu.addAction(license_action)
 
-        # Clear cache action (store as instance variable for later reference)
-        clear_cache = QtGui.QAction("Clear Project Cache", self.main_window)
-        clear_cache.setStatusTip("Clear Project Cache")
-        clear_cache.setEnabled(False)
-        clear_cache.triggered.connect(self.handlers.clear_cache)
-        menu.addAction(clear_cache)
-
         # Quit action
         exit_action = QtGui.QAction(f" &Quit {self.app_name}", self.main_window)
         exit_action.setShortcut(QtGui.QKeySequence("Ctrl+Q"))
@@ -199,7 +193,6 @@ class MenuBuilder:
         menu.addAction(exit_action)
 
         return {
-            "clear_cache": clear_cache,
             "settings_action": settings_action,
         }
 
@@ -257,12 +250,30 @@ class MenuBuilder:
         prune_action.triggered.connect(self.handlers.show_project_pruning_dialog)
         menu.addAction(prune_action)
 
+        menu.addSeparator()
+
+        # Clear pose cache action (was "Clear Project Cache" in the app menu)
+        clear_cache = QtGui.QAction("Clear Pose Cache", self.main_window)
+        clear_cache.setStatusTip("Clear the pose estimation cache for this project")
+        clear_cache.setEnabled(False)
+        clear_cache.triggered.connect(self.handlers.clear_cache)
+        menu.addAction(clear_cache)
+
+        # Clear feature cache action
+        clear_feature_cache = QtGui.QAction("Clear Feature Cache\u2026", self.main_window)
+        clear_feature_cache.setStatusTip("Delete all cached feature files for this project")
+        clear_feature_cache.setEnabled(False)
+        clear_feature_cache.triggered.connect(self.handlers.clear_feature_cache)
+        menu.addAction(clear_feature_cache)
+
         return {
             "open_recent_menu": open_recent_menu,
             "export_frame": export_frame,
             "export_training": export_training,
             "archive_behavior": archive_behavior,
             "prune_action": prune_action,
+            "clear_cache": clear_cache,
+            "clear_feature_cache": clear_feature_cache,
         }
 
     def _build_tool_menu(self, menu: QtWidgets.QMenu) -> dict:

--- a/src/jabs/ui/main_window/menu_handlers.py
+++ b/src/jabs/ui/main_window/menu_handlers.py
@@ -14,7 +14,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QAction
 
 from jabs.core.constants import FINAL_TRAIN_SEED
-from jabs.core.enums import PredictionType
+from jabs.core.enums import ClassifierMode, PredictionType
 from jabs.project import export_training_data
 from jabs.utils import check_for_update
 
@@ -422,6 +422,7 @@ class MenuHandlers:
             mode = StackedTimelineWidget.IdentityMode.ACTIVE
 
         self.window._central_widget.timeline_identity_mode = mode
+        self.update_mc_layout_actions_enabled_state()
 
     def on_timeline_prediction_type_changed(self) -> None:
         """Handle change to the prediction type shown in the timeline (raw vs. postprocessed)."""
@@ -430,6 +431,49 @@ class MenuHandlers:
         else:
             mode = PredictionType.POSTPROCESSED
         self.window._central_widget.prediction_type = mode
+
+    def on_mc_collapse_label_bar_changed(self) -> None:
+        """Handle toggling the 'Collapse Inactive Label Bars' multiclass layout option."""
+        self.window._central_widget.mc_collapse_label_bar = (
+            self.window._menu_refs.mc_collapse_label_bar.isChecked()
+        )
+
+    def on_mc_collapse_combined_bar_changed(self) -> None:
+        """Handle toggling the 'Collapse Inactive Combined Bars' multiclass layout option."""
+        self.window._central_widget.mc_collapse_combined_bar = (
+            self.window._menu_refs.mc_collapse_combined_bar.isChecked()
+        )
+
+    def on_mc_collapse_per_class_bars_changed(self) -> None:
+        """Handle toggling the 'Collapse Inactive Per-class Bars' multiclass layout option."""
+        self.window._central_widget.mc_collapse_per_class_bars = (
+            self.window._menu_refs.mc_collapse_per_class_bars.isChecked()
+        )
+
+    def on_mc_hide_per_class_rows_changed(self) -> None:
+        """Handle toggling the 'Hide Inactive Per-class Rows' multiclass layout option."""
+        self.window._central_widget.mc_hide_per_class_rows = (
+            self.window._menu_refs.mc_hide_per_class_rows.isChecked()
+        )
+
+    def update_mc_layout_actions_enabled_state(self) -> None:
+        """Enable or disable the multi-class layout menu actions based on the current mode.
+
+        The four actions are only meaningful when both multiclass classifier mode and
+        all-animals identity mode are active simultaneously.
+        """
+        refs = self.window._menu_refs
+        project = self.window._central_widget._project
+        is_multiclass = (
+            project is not None
+            and project.settings_manager.classifier_mode == ClassifierMode.MULTICLASS
+        )
+        is_all_animals = refs.timeline_all_animals.isChecked()
+        enabled = is_multiclass and is_all_animals
+        refs.mc_collapse_label_bar.setEnabled(enabled)
+        refs.mc_collapse_combined_bar.setEnabled(enabled)
+        refs.mc_collapse_per_class_bars.setEnabled(enabled)
+        refs.mc_hide_per_class_rows.setEnabled(enabled)
 
     def on_label_overlay_mode_changed(self) -> None:
         """Handle label overlay mode change (None, Labels, or Predictions)."""

--- a/src/jabs/ui/main_window/menu_handlers.py
+++ b/src/jabs/ui/main_window/menu_handlers.py
@@ -227,18 +227,39 @@ class MenuHandlers:
                 )
 
     def clear_cache(self) -> None:
-        """Clear the project's feature cache after user confirmation."""
+        """Clear the project's pose cache after user confirmation."""
         result = MessageDialog.confirm(
             self.window,
-            title="Clear Cache",
-            message="Are you sure you want to clear the project cache?",
+            title="Clear Pose Cache",
+            message="Are you sure you want to clear the project pose cache?",
         )
         if result:
             self.window._project.clear_cache()
             # need to reload the current video to force the pose file to reload
             if self.window._central_widget.loaded_video:
                 self.window._central_widget.load_video(self.window._central_widget.loaded_video)
-            self.window.display_status_message("Cache cleared", duration=3000)
+            self.window.display_status_message("Pose cache cleared", duration=3000)
+
+    def clear_feature_cache(self) -> None:
+        """Clear the project's feature cache after user confirmation."""
+        from jabs.core.enums import CacheFormat
+
+        project = self.window._project
+        hint = ""
+        if project.cache_format == CacheFormat.HDF5:
+            hint = (
+                "\n\nThis project is configured to use HDF5 feature cache. "
+                "To switch to the faster Parquet format, update Cache Format "
+                "in Project Settings before clearing."
+            )
+        result = MessageDialog.confirm(
+            self.window,
+            title="Clear Feature Cache",
+            message=f"Are you sure you want to delete all cached feature files?{hint}",
+        )
+        if result:
+            project.clear_feature_cache()
+            self.window.display_status_message("Feature cache cleared", duration=3000)
 
     # ========== App Menu Handlers ==========
 

--- a/src/jabs/ui/main_window/menu_handlers.py
+++ b/src/jabs/ui/main_window/menu_handlers.py
@@ -562,6 +562,10 @@ class MenuHandlers:
         """Handle Ctrl+A / Cmd+A keyboard shortcut."""
         self.window._central_widget.select_all()
 
+    def handle_select_current_bout(self) -> None:
+        """Handle Ctrl+Shift+A / Cmd+Shift+A keyboard shortcut."""
+        self.window._central_widget.select_current_bout()
+
     def on_bbox_overlay_support_changed(self, supported: bool) -> None:
         """Enable/disable the bounding box overlay menu item based on whether the current pose supports it.
 

--- a/src/jabs/ui/main_window/video_list_widget.py
+++ b/src/jabs/ui/main_window/video_list_widget.py
@@ -56,6 +56,8 @@ class _VideoListWidget(QtWidgets.QListWidget):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        mono_font = QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.SystemFont.FixedFont)
+        self.setFont(mono_font)
         self.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.SingleSelection)
         self.setSortingEnabled(True)
         self.setEditTriggers(QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers)

--- a/src/jabs/ui/main_window/video_list_widget.py
+++ b/src/jabs/ui/main_window/video_list_widget.py
@@ -56,8 +56,6 @@ class _VideoListWidget(QtWidgets.QListWidget):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        mono_font = QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.SystemFont.FixedFont)
-        self.setFont(mono_font)
         self.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.SingleSelection)
         self.setSortingEnabled(True)
         self.setEditTriggers(QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers)

--- a/src/jabs/ui/player_widget/overlays/pose_overlay.py
+++ b/src/jabs/ui/player_widget/overlays/pose_overlay.py
@@ -58,6 +58,9 @@ class PoseOverlay(Overlay):
         if self.parent.pose is None:
             return
 
+        zoom = self.parent.scaled_pix_width / max(crop_rect.width(), 1)
+        keypoint_size = max(1, round(_KEYPOINT_SIZE * zoom**0.8))
+
         # draw the pose estimation skeletons
         for identity in self.parent.pose.identities:
             if not all_identities and identity != self.parent.active_identity:
@@ -121,5 +124,5 @@ class PoseOverlay(Overlay):
                         painter.setBrush(color)
 
                     painter.drawEllipse(
-                        QtCore.QPoint(widget_x, widget_y), _KEYPOINT_SIZE, _KEYPOINT_SIZE
+                        QtCore.QPoint(widget_x, widget_y), keypoint_size, keypoint_size
                     )

--- a/src/jabs/ui/settings_dialog/cache_format_settings_group.py
+++ b/src/jabs/ui/settings_dialog/cache_format_settings_group.py
@@ -1,5 +1,7 @@
 """Cache format settings group for configuring the project's feature cache format."""
 
+import logging
+
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QComboBox, QLabel, QSizePolicy
 
@@ -8,7 +10,9 @@ from jabs.core.enums import CacheFormat
 
 from .settings_group import SettingsGroup
 
-_DEFAULT_CACHE_FORMAT = CacheFormat.HDF5
+logger = logging.getLogger(__name__)
+
+_DEFAULT_CACHE_FORMAT = CacheFormat.PARQUET
 
 _DISPLAY_NAMES: dict[CacheFormat, str] = {
     CacheFormat.HDF5: "HDF5",
@@ -90,4 +94,9 @@ class CacheFormatSettingsGroup(SettingsGroup):
         if index >= 0:
             self._format_combo.setCurrentIndex(index)
         else:
+            logger.error(
+                "Unrecognized cache_format value %r; defaulting to %s",
+                raw,
+                _DEFAULT_CACHE_FORMAT.value,
+            )
             self._format_combo.setCurrentIndex(self._format_combo.findData(_DEFAULT_CACHE_FORMAT))

--- a/src/jabs/ui/settings_dialog/cache_format_settings_group.py
+++ b/src/jabs/ui/settings_dialog/cache_format_settings_group.py
@@ -1,0 +1,93 @@
+"""Cache format settings group for configuring the project's feature cache format."""
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QComboBox, QLabel, QSizePolicy
+
+from jabs.core.constants import CACHE_FORMAT_KEY
+from jabs.core.enums import CacheFormat
+
+from .settings_group import SettingsGroup
+
+_DEFAULT_CACHE_FORMAT = CacheFormat.HDF5
+
+_DISPLAY_NAMES: dict[CacheFormat, str] = {
+    CacheFormat.HDF5: "HDF5",
+    CacheFormat.PARQUET: "Parquet",
+}
+
+
+class CacheFormatSettingsGroup(SettingsGroup):
+    """Settings group for feature cache format configuration.
+
+    Controls whether per-identity feature caches are written as HDF5 files or
+    as Parquet files. The new format takes effect on the next cache miss; use
+    *File > Clear Feature Cache* to force regeneration in the new format.
+    """
+
+    def __init__(self, parent=None):
+        """Initialize the cache format settings group."""
+        super().__init__("Feature Cache Format", parent)
+
+    def _create_controls(self) -> None:
+        """Create the cache format combo box control."""
+        self._format_combo = QComboBox()
+        for fmt in CacheFormat:
+            self._format_combo.addItem(_DISPLAY_NAMES[fmt], fmt)
+        self._format_combo.setCurrentIndex(self._format_combo.findData(_DEFAULT_CACHE_FORMAT))
+        self._format_combo.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
+        self.add_control_row("Cache Format:", self._format_combo)
+
+    def _create_documentation(self) -> QLabel:
+        """Create help text for the cache format setting."""
+        help_label = QLabel(self)
+        help_label.setTextFormat(Qt.TextFormat.RichText)
+        help_label.setWordWrap(True)
+        help_label.setText(
+            """
+            <h3>What is the Feature Cache Format?</h3>
+            <p>JABS pre-computes features and stores them on disk so that
+            subsequent training and classification runs can skip the computation step.
+            This setting controls the file format used for that cache.</p>
+
+            <ul>
+              <li><b>HDF5:</b> The original cache format. Compatible with all versions
+              of JABS.</li>
+              <li><b>Parquet:</b> A columnar storage format that offers faster reads
+              and smaller file sizes.</li>
+            </ul>
+
+            <p><b>Note:</b> Changing this setting takes effect on the next cache miss.
+            Existing cache files are not automatically converted. To regenerate the
+            cache in the new format, use <i>File &gt; Clear Feature Cache&hellip;</i>
+            before training or classifying.</p>
+            """
+        )
+        help_label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
+        return help_label
+
+    def get_values(self) -> dict:
+        """Return the currently selected cache format.
+
+        Returns:
+            Dict with ``CACHE_FORMAT_KEY`` mapped to the selected ``CacheFormat``.
+        """
+        return {CACHE_FORMAT_KEY: self._format_combo.currentData()}
+
+    def set_values(self, values: dict) -> None:
+        """Populate the combo box from a settings dict.
+
+        Args:
+            values: Dict that may contain ``CACHE_FORMAT_KEY``. Unrecognized
+                values fall back to ``_DEFAULT_CACHE_FORMAT``.
+        """
+        raw = values.get(CACHE_FORMAT_KEY, _DEFAULT_CACHE_FORMAT)
+        try:
+            enum_val = CacheFormat(raw) if not isinstance(raw, CacheFormat) else raw
+            index = self._format_combo.findData(enum_val)
+        except ValueError:
+            index = -1
+
+        if index >= 0:
+            self._format_combo.setCurrentIndex(index)
+        else:
+            self._format_combo.setCurrentIndex(self._format_combo.findData(_DEFAULT_CACHE_FORMAT))

--- a/src/jabs/ui/settings_dialog/settings_dialog.py
+++ b/src/jabs/ui/settings_dialog/settings_dialog.py
@@ -17,6 +17,7 @@ from PySide6.QtWidgets import (
 from jabs.core.constants import APP_NAME, ORG_NAME
 from jabs.project.settings_manager import SettingsManager
 
+from .cache_format_settings_group import CacheFormatSettingsGroup
 from .cross_validation_settings_group import CrossValidationSettingsGroup
 from .postprocessing_group import (
     DurationStageSettingsGroup,
@@ -238,6 +239,8 @@ class ProjectSettingsDialog(BaseSettingsDialog):
         """
         cv_group = CrossValidationSettingsGroup(parent)
         self._settings_groups.append(cv_group)
+        cache_format_group = CacheFormatSettingsGroup(parent)
+        self._settings_groups.append(cache_format_group)
 
 
 class PostprocessingSettingsDialog(BaseSettingsDialog):

--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/behavior_probability_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/behavior_probability_widget.py
@@ -1,0 +1,58 @@
+"""Widget that renders a single behavior's probability as a color heatmap."""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+from .predicted_label_widget import PredictedLabelWidget
+
+
+class BehaviorProbabilityWidget(PredictedLabelWidget):
+    """Renders a single behavior's probability as a color heatmap.
+
+    Unlike :class:`PredictedLabelWidget`, which uses a 3-entry LUT to paint a
+    "not this class" color for low-probability frames, this widget always uses
+    the behavior color (LUT index 2) and controls visibility with alpha alone.
+    The result is a white background with the behavior color overlaid at
+    ``alpha = probability`` -- nearly transparent for low-confidence frames,
+    fully opaque for high-confidence frames.  Frames where the animal is absent
+    (LUT index 0) are rendered transparently so the white background shows
+    through unchanged.
+    """
+
+    def _build_frame_colors(
+        self,
+        color_indices: npt.NDArray[np.int16],
+        probs_slice: npt.NDArray[np.floating] | None,
+    ) -> npt.NDArray[np.uint8]:
+        """Build per-frame RGBA using behavior color at probability-based alpha.
+
+        Args:
+            color_indices: LUT index per in-bounds frame, shape ``(n,)``.
+                Index 0 means animal absent; any other index means animal present.
+            probs_slice: Clipped probabilities ``[0, 1]`` for the same frames, or ``None``.
+
+        Returns:
+            RGBA array of shape ``(n, 4)`` with dtype ``uint8``.
+        """
+        n = len(color_indices)
+        colors = np.zeros((n, 4), dtype=np.uint8)
+        present = color_indices != 0
+        if not np.any(present):
+            return colors
+
+        behavior_rgb = self._color_lut[2, :3]
+        colors[present, :3] = behavior_rgb
+
+        if probs_slice is not None:
+            alphas = (probs_slice * 255).astype(np.uint8)
+            # Keep a minimum alpha for present frames with zero probability so
+            # post-processed/interpolated frames remain faintly visible.
+            zero_prob_present = present & (alphas == 0)
+            alphas[zero_prob_present] = 125
+            colors[present, 3] = alphas[present]
+        else:
+            colors[present, 3] = self._color_lut[2, 3]
+
+        return colors

--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/label_overview_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/label_overview_widget.py
@@ -73,15 +73,18 @@ class LabelOverviewWidget(QWidget):
     def sizeHint(self) -> QSize:
         """Return the recommended size for the widget.
 
-        Calculates the preferred size based on the size hints of the timeline and manual label widgets.
+        Calculates the preferred size based on the visible child widgets only, so
+        that hiding the detail bar via :meth:`set_detail_bar_visible` actually
+        shrinks the widget.
 
         Returns:
             QSize: The recommended size for the widget.
         """
         timeline_hint = self._timeline_widget.sizeHint()
-        manual_hint = self._label_widget.sizeHint()
-        width = max(timeline_hint.width(), manual_hint.width())
-        height = timeline_hint.height() + manual_hint.height()
+        width = max(timeline_hint.width(), self._label_widget.sizeHint().width())
+        height = timeline_hint.height()
+        if self._label_widget.isVisible():
+            height += self._label_widget.sizeHint().height()
         return QSize(width, height)
 
     @property
@@ -134,6 +137,26 @@ class LabelOverviewWidget(QWidget):
             raise ValueError(f"lut must have shape (N, 4), got {lut.shape}")
         self._timeline_widget.set_color_lut(lut)
         self._label_widget.set_color_lut(lut)
+
+    def set_detail_bar_visible(self, visible: bool) -> None:
+        """Show or hide the detail (manual-label) bar below the overview strip.
+
+        Used in multi-class + all-animals mode to collapse the detail bar on
+        non-active identities and recover vertical space.  Also tightens the
+        widget's internal margins when collapsed so overview bars pack together
+        with minimal whitespace.
+
+        Args:
+            visible: ``True`` to show the detail bar; ``False`` to hide it.
+        """
+        self._label_widget.setVisible(visible)
+        if visible:
+            self.layout().setContentsMargins(2, 4, 2, 6)
+            self.layout().setSpacing(4)
+        else:
+            self.layout().setContentsMargins(2, 1, 2, 1)
+            self.layout().setSpacing(0)
+        self.updateGeometry()
 
     def set_labels(self, labels: npt.NDArray[np.int16], mask: np.ndarray) -> None:
         """Set the label data for the widget.

--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/label_overview_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/label_overview_widget.py
@@ -27,6 +27,8 @@ class LabelOverviewWidget(QWidget):
     """
 
     def __init__(self, *args, **kwargs) -> None:
+        # need to strip "compact" out of kwargs before calling super
+        compact = kwargs.pop("compact", False)
         super().__init__(*args, **kwargs)
 
         self._num_frames = 0
@@ -38,9 +40,27 @@ class LabelOverviewWidget(QWidget):
         self._container = QWidget(self)
 
         self._timeline_widget = self._timeline_widget_factory(self._container)
-        self._label_widget = self._label_widget_factory(self._container)
+        self._label_widget = self._label_widget_factory(self._container, compact)
 
         self._set_layout()
+
+    @property
+    def compact(self) -> bool:
+        """Whether the label widget is in compact mode.
+
+        Returns:
+            True if compact mode is active, False otherwise.
+        """
+        return self._label_widget.compact
+
+    @compact.setter
+    def compact(self, value: bool) -> None:
+        """Set compact mode on the label widget.
+
+        Args:
+            value: True to enable compact mode, False to disable.
+        """
+        self._label_widget.compact = value
 
     @classmethod
     def _timeline_widget_factory(cls, parent: QWidget) -> TimelineLabelWidget:
@@ -51,12 +71,12 @@ class LabelOverviewWidget(QWidget):
         return TimelineLabelWidget(parent)
 
     @classmethod
-    def _label_widget_factory(cls, parent: QWidget) -> ManualLabelWidget:
+    def _label_widget_factory(cls, parent: QWidget, compact: bool = False) -> ManualLabelWidget:
         """factory method to create the label widget
 
         This is done to make it easier to subclass the widget and swap out the label widget
         """
-        return ManualLabelWidget(parent)
+        return ManualLabelWidget(parent, compact=compact)
 
     def _set_layout(self) -> None:
         """Set up the vertical layout for the widget.

--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/manual_label_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/manual_label_widget.py
@@ -39,6 +39,7 @@ class ManualLabelWidget(QWidget):
     _BORDER_COLOR = QColor(212, 212, 212)
 
     _BAR_HEIGHT = 30
+    _BAR_HEIGHT_COMPACT = 18
     _DEFAULT_WIDTH = 400
     _DEFAULT_WINDOW_SIZE = 100
     _TICK_HEIGHT = 4
@@ -54,6 +55,8 @@ class ManualLabelWidget(QWidget):
     GAP_ALPHA = 128  # semi-transparent for gaps
 
     def __init__(self, *args, **kwargs) -> None:
+        # need to strip "compact" out of kwargs before calling super
+        self._compact = compact = kwargs.pop("compact", False)
         super().__init__(*args, **kwargs)
 
         # allow widget to expand horizontally but maintain fixed vertical size
@@ -80,7 +83,7 @@ class ManualLabelWidget(QWidget):
         # search results to render in the bar
         self._search_results: list[SearchHit] = []
 
-        self._bar_height = self._BAR_HEIGHT
+        self._bar_height = self._BAR_HEIGHT_COMPACT if compact else self._BAR_HEIGHT
 
         # size each frame takes up in the bar in pixels
         self._frame_width = self.size().width() // self._window_frames_total
@@ -91,6 +94,24 @@ class ManualLabelWidget(QWidget):
         self._position_marker_pen = QPen(POSITION_MARKER_COLOR, 1, Qt.PenStyle.SolidLine)
         self._selection_brush = QBrush(SELECTION_COLOR, Qt.BrushStyle.DiagCrossPattern)
         self._padding_brush = QBrush(BACKGROUND_COLOR, Qt.BrushStyle.Dense6Pattern)
+
+    @property
+    def compact(self) -> bool:
+        """Whether the widget is in compact mode.
+
+        Returns:
+            bool: True if the widget is in compact mode, False otherwise.
+        """
+        return self._compact
+
+    @compact.setter
+    def compact(self, value: bool) -> None:
+        """Set compact mode and trigger a layout and repaint update."""
+        if self._compact != value:
+            self._compact = value
+            self._bar_height = self._BAR_HEIGHT_COMPACT if self._compact else self._BAR_HEIGHT
+            self.updateGeometry()
+            self.update()
 
     def sizeHint(self) -> QSize:
         """Return the recommended initial size for the widget.

--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/per_class_prediction_overview_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/per_class_prediction_overview_widget.py
@@ -14,7 +14,7 @@ class PerClassPredictionOverviewWidget(PredictionOverviewWidget):
     Identical to :class:`PredictionOverviewWidget` except the detail bar uses
     :class:`BehaviorProbabilityWidget` instead of :class:`PredictedLabelWidget`.
     That means the bar renders the behavior color at ``alpha = probability``
-    for every present frame, with no "not this class" gray.
+    for every present frame, with no "not behavior" color for probabilities < 0.5
     """
 
     @classmethod

--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/per_class_prediction_overview_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/per_class_prediction_overview_widget.py
@@ -1,0 +1,25 @@
+"""Overview widget for a single behavior's per-class prediction bar."""
+
+from __future__ import annotations
+
+from PySide6.QtWidgets import QWidget
+
+from .behavior_probability_widget import BehaviorProbabilityWidget
+from .prediction_overview_widget import PredictionOverviewWidget
+
+
+class PerClassPredictionOverviewWidget(PredictionOverviewWidget):
+    """Prediction overview for a single behavior class.
+
+    Identical to :class:`PredictionOverviewWidget` except the detail bar uses
+    :class:`BehaviorProbabilityWidget` instead of :class:`PredictedLabelWidget`.
+    That means the bar renders the behavior color at ``alpha = probability``
+    for every present frame, with no "not this class" gray.
+    """
+
+    @classmethod
+    def _label_widget_factory(
+        cls, parent: QWidget, compact: bool = False
+    ) -> BehaviorProbabilityWidget:
+        """Return a BehaviorProbabilityWidget as the detail bar."""
+        return BehaviorProbabilityWidget(parent, compact=compact)

--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/predicted_label_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/predicted_label_widget.py
@@ -138,8 +138,12 @@ class PredictedLabelWidget(ManualLabelWidget):
         self._probabilities = probabilities
         self.update()
 
-    def start_selection(self, start_frame: int) -> None:
-        """Not supported in PredictedLabelWidget"""
+    def start_selection(self, start_frame: int, end_frame: int | None = None) -> None:
+        """Not supported in PredictedLabelWidget.
+
+        Raises:
+            NotImplementedError: Always; selection is not supported on prediction widgets.
+        """
         raise NotImplementedError
 
     def clear_selection(self) -> None:

--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/predicted_label_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/predicted_label_widget.py
@@ -70,23 +70,12 @@ class PredictedLabelWidget(ManualLabelWidget):
         # Draw predictions overlaid on the white background; lower probability = more transparent.
         if self._predictions is not None and n_in_bounds > 0 and in_bounds_px > 0:
             color_indices = self._predictions[slice_start : slice_end + 1]
-
-            # Map to RGBA colors
-            colors = self._color_lut[color_indices]
-
-            # Set alpha from probabilities if available
-            if self._probabilities is not None:
-                probs = np.clip(self._probabilities[slice_start : slice_end + 1], 0.0, 1.0)
-                alphas = (probs * 255).astype(np.uint8)
-
-                # some post-processed predictions may have zero probability, specifically the interpolation stage
-                # which fills in short gaps where there was no prediction. To ensure these interpolated classes
-                # are still visible, set a minimum alpha anywhere there is a prediction but probability is zero
-                # to ensure visibility. Interpolated predictions will show as having a low confidence.
-                mask = (color_indices != 0) & (alphas == 0)
-                alphas[mask] = 125
-
-                colors[:, 3] = alphas
+            probs_slice = (
+                np.clip(self._probabilities[slice_start : slice_end + 1], 0.0, 1.0)
+                if self._probabilities is not None
+                else None
+            )
+            colors = self._build_frame_colors(color_indices, probs_slice)
 
             # Per-frame pixel widths using floating-point positions
             win_indices = np.arange(n_start_pad, n_start_pad + n_in_bounds + 1, dtype=np.float64)
@@ -120,6 +109,32 @@ class PredictedLabelWidget(ManualLabelWidget):
 
         # done drawing
         qp.end()
+
+    def _build_frame_colors(
+        self,
+        color_indices: npt.NDArray[np.int16],
+        probs_slice: npt.NDArray[np.floating] | None,
+    ) -> npt.NDArray[np.uint8]:
+        """Build per-frame RGBA color array from LUT indices and probabilities.
+
+        Subclasses can override this to change how colors are computed without
+        duplicating the full paint pipeline.
+
+        Args:
+            color_indices: LUT index per in-bounds frame, shape ``(n,)``.
+            probs_slice: Clipped probabilities ``[0, 1]`` for the same frames, or ``None``.
+
+        Returns:
+            RGBA array of shape ``(n, 4)`` with dtype ``uint8``.
+        """
+        colors = self._color_lut[color_indices].copy()
+        if probs_slice is not None:
+            alphas = (probs_slice * 255).astype(np.uint8)
+            # Interpolated post-processed frames can have pred!=0 but prob==0; keep them visible.
+            mask = (color_indices != 0) & (alphas == 0)
+            alphas[mask] = 125
+            colors[:, 3] = alphas
+        return colors
 
     def set_labels(
         self,

--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/prediction_overview_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/prediction_overview_widget.py
@@ -1,4 +1,5 @@
 import numpy as np
+from PySide6.QtWidgets import QWidget
 
 from .label_overview_widget import LabelOverviewWidget
 from .predicted_label_widget import PredictedLabelWidget
@@ -18,8 +19,9 @@ class PredictionOverviewWidget(LabelOverviewWidget):
         return TimelinePredictionWidget(parent)
 
     @classmethod
-    def _label_widget_factory(cls, parent):
-        return PredictedLabelWidget(parent)
+    def _label_widget_factory(cls, parent: QWidget, compact: bool = False) -> PredictedLabelWidget:
+        """Create a PredictedLabelWidget as the label widget for this overview."""
+        return PredictedLabelWidget(parent, compact=compact)
 
     def set_labels(self, labels: np.ndarray, probabilities: np.ndarray):
         """set prediction data to display

--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/timeline_label_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/timeline_label_widget.py
@@ -49,8 +49,8 @@ class TimelineLabelWidget(QWidget):
         ],
         dtype=np.uint8,
     )
-    _BAR_HEIGHT = 8  # height of the bar in pixels
-    _BAR_PADDING = 3  # padding around the bar in pixels
+    _BAR_HEIGHT = 7  # height of the bar in pixels
+    _BAR_PADDING = 2  # padding around the bar in pixels
     _WINDOW_SIZE = 100  # number of frames to show on either side of the current frame
 
     def __init__(self, *args, **kwargs) -> None:

--- a/src/jabs/ui/stacked_timeline_widget/label_overview_widget/timeline_label_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/label_overview_widget/timeline_label_widget.py
@@ -7,6 +7,7 @@ import numpy.typing as npt
 from PySide6.QtCore import QSize, Qt, Slot
 from PySide6.QtGui import (
     QBrush,
+    QColor,
     QImage,
     QPainter,
     QPaintEvent,
@@ -213,9 +214,7 @@ class TimelineLabelWidget(QWidget):
         if widget_width <= 0 or self._num_frames == 0:
             return
 
-        if self._labels is not None and (
-            self._pixmap is None or self._pixmap.width() != widget_width
-        ):
+        if self._pixmap is None or self._pixmap.width() != widget_width:
             self._float_bin_size = self._num_frames / widget_width
             self._update_bar()
 
@@ -309,6 +308,7 @@ class TimelineLabelWidget(QWidget):
         """
         self._labels = None
         self._color_lut = self.COLOR_LUT
+        self._pixmap = None
         self._update_scale()
 
     def _update_bar(self) -> None:
@@ -316,15 +316,28 @@ class TimelineLabelWidget(QWidget):
 
         Converts the current labels into a color bar using proportional color blending,
         then updates the internal pixmap for efficient rendering. The pixmap fills the
-        full widget width with no padding.
+        full widget width with no padding. When no labels are loaded, draws a solid
+        background bar so the widget is visible even before predictions are run.
         """
-        if self._labels is None:
-            return
-
         width = self.size().width()
         height = self.size().height()
 
         if width <= 0 or height <= 0:
+            return
+
+        if self._labels is None:
+            self._pixmap = QPixmap(width, height)
+            self._pixmap.fill(Qt.GlobalColor.transparent)
+            bg = self._color_lut[0]
+            painter = QPainter(self._pixmap)
+            painter.fillRect(
+                0,
+                self._bar_padding,
+                width,
+                self._bar_height,
+                QColor(int(bg[0]), int(bg[1]), int(bg[2]), int(bg[3])),
+            )
+            painter.end()
             return
 
         colors = _downsample_to_size(self._labels, self._color_lut, width)

--- a/src/jabs/ui/stacked_timeline_widget/stacked_timeline_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/stacked_timeline_widget.py
@@ -1,9 +1,20 @@
+from __future__ import annotations
+
 from enum import IntEnum
 
 import numpy as np
 import numpy.typing as npt
 from PySide6.QtCore import Slot
-from PySide6.QtWidgets import QApplication, QFrame, QLabel, QSizePolicy, QVBoxLayout, QWidget
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import (
+    QApplication,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
 
 from jabs.behavior_search import (
     BehaviorSearchQuery,
@@ -12,10 +23,57 @@ from jabs.behavior_search import (
     SearchHit,
     TimelineAnnotationSearchQuery,
 )
+from jabs.core.enums import ClassifierMode
 from jabs.pose_estimation import PoseEstimation
 
+from ..colors import (
+    BACKGROUND_COLOR,
+    NOT_BEHAVIOR_COLOR,
+    build_multiclass_color_lut,
+    make_behavior_color_map,
+)
 from .frame_labels_widget import FrameLabelsWidget
 from .label_overview_widget import LabelOverviewWidget, PredictionOverviewWidget
+
+
+class _BehaviorLegendWidget(QWidget):
+    """Horizontal strip showing a color swatch and name for each behavior class.
+
+    Displayed above the per-identity timeline rows in multi-class mode to help
+    readers identify which color corresponds to which behavior.  Always includes a
+    "None" entry (blue) as the first item, matching the None prediction row.
+
+    Args:
+        behavior_names: Ordered list of behavior names to display.
+        color_map: Mapping from behavior name to ``QColor``.
+        *args: Additional positional arguments for QWidget.
+        **kwargs: Additional keyword arguments for QWidget.
+    """
+
+    _SWATCH_SIZE = 14
+
+    def __init__(
+        self,
+        behavior_names: list[str],
+        color_map: dict[str, QColor],
+        *args,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(4, 2, 4, 2)
+        layout.setSpacing(6)
+        # "None" / background class always comes first
+        entries: list[tuple[str, QColor]] = [("None", NOT_BEHAVIOR_COLOR)] + [
+            (name, color_map[name]) for name in behavior_names
+        ]
+        for name, color in entries:
+            swatch = QLabel()
+            swatch.setFixedSize(self._SWATCH_SIZE, self._SWATCH_SIZE)
+            swatch.setStyleSheet(f"background-color: {color.name()}; border: 1px solid #666;")
+            layout.addWidget(swatch)
+            layout.addWidget(QLabel(name))
+        layout.addStretch()
 
 
 class StackedTimelineWidget(QWidget):
@@ -25,6 +83,10 @@ class StackedTimelineWidget(QWidget):
     manages selection transfer between identities, and forwards label and frame updates
     to its child widgets. It is designed for use in multi-identity labeling interfaces,
     such as behavioral video annotation tools.
+
+    In multi-class mode (set via :meth:`set_classifier_mode`), each identity displays a
+    multi-color combined label bar and one :class:`PredictionOverviewWidget` per behavior
+    class.  In binary mode the original single-behavior view is retained.
 
     Properties:
         num_identities (int): Number of identities to display.
@@ -61,10 +123,20 @@ class StackedTimelineWidget(QWidget):
         self._num_frames = 0
         self._framerate = 0
         self._label_overview_widgets: list[LabelOverviewWidget] = []
-        self._prediction_overview_widgets = []
+        self._combined_prediction_widgets: list[PredictionOverviewWidget | None] = []
+        self._prediction_overview_widgets: list[list[PredictionOverviewWidget]] = []
         self._identity_frames = []
         self._frame_labels = FrameLabelsWidget(self)
         self._pose: PoseEstimation | None = None
+
+        self._classifier_mode: ClassifierMode = ClassifierMode.BINARY
+        self._behavior_names: list[str] = []
+        self._behavior_color_map: dict[str, QColor] = {}
+        self._multiclass_color_lut: npt.NDArray[np.uint8] | None = None
+        self._legend_widget: _BehaviorLegendWidget | None = None
+        self._collapse_inactive_label_bar: bool = False
+        self._collapse_inactive_combined_bar: bool = False
+        self._collapse_inactive_per_class_bars: bool = True
 
         self._layout = QVBoxLayout(self)
         self._layout.setContentsMargins(0, 0, 0, 0)
@@ -114,6 +186,51 @@ class StackedTimelineWidget(QWidget):
             self._update_widget_visibility()
 
     @property
+    def collapse_inactive_label_bar(self) -> bool:
+        """Whether the manual-label detail bar is collapsed for non-active identities.
+
+        Only has a visual effect in multi-class + all-animals mode.
+        """
+        return self._collapse_inactive_label_bar
+
+    @collapse_inactive_label_bar.setter
+    def collapse_inactive_label_bar(self, value: bool) -> None:
+        """Set whether non-active identity label bars are collapsed in all-animals mode."""
+        if value != self._collapse_inactive_label_bar:
+            self._collapse_inactive_label_bar = value
+            self._update_widget_visibility()
+
+    @property
+    def collapse_inactive_combined_bar(self) -> bool:
+        """Whether the combined argmax prediction bar is collapsed for non-active identities.
+
+        Only has a visual effect in multi-class + all-animals mode.
+        """
+        return self._collapse_inactive_combined_bar
+
+    @collapse_inactive_combined_bar.setter
+    def collapse_inactive_combined_bar(self, value: bool) -> None:
+        """Set whether non-active combined prediction bars are collapsed in all-animals mode."""
+        if value != self._collapse_inactive_combined_bar:
+            self._collapse_inactive_combined_bar = value
+            self._update_widget_visibility()
+
+    @property
+    def collapse_inactive_per_class_bars(self) -> bool:
+        """Whether per-class prediction detail bars are collapsed for non-active identities.
+
+        Only has a visual effect in multi-class + all-animals mode.
+        """
+        return self._collapse_inactive_per_class_bars
+
+    @collapse_inactive_per_class_bars.setter
+    def collapse_inactive_per_class_bars(self, value: bool) -> None:
+        """Set whether non-active per-class prediction bars are collapsed in all-animals mode."""
+        if value != self._collapse_inactive_per_class_bars:
+            self._collapse_inactive_per_class_bars = value
+            self._update_widget_visibility()
+
+    @property
     def pose(self) -> PoseEstimation | None:
         """Get the PoseEstimation object used by the label overview widgets."""
         return self._pose
@@ -130,6 +247,66 @@ class StackedTimelineWidget(QWidget):
         self._num_frames = pose_est.num_frames
         self._reset_layout()
 
+    def set_classifier_mode(self, mode: ClassifierMode, behavior_names: list[str]) -> None:
+        """Set the classifier mode and rebuild the layout for multi-class or binary display.
+
+        In multi-class mode, each identity gets one :class:`PredictionOverviewWidget` per
+        behavior class, a multi-color label bar, and a behavior legend widget is added
+        above the identity rows.  In binary mode the original single-widget view is used.
+
+        Args:
+            mode: The classifier mode (``BINARY`` or ``MULTICLASS``).
+            behavior_names: Ordered list of project behavior names. Must not include the
+                reserved ``"None"`` behavior.
+        """
+        self._classifier_mode = mode
+        self._behavior_names = list(behavior_names)
+        if mode == ClassifierMode.MULTICLASS and behavior_names:
+            self._behavior_color_map = make_behavior_color_map(behavior_names)
+            self._multiclass_color_lut = build_multiclass_color_lut(
+                behavior_names, self._behavior_color_map
+            )
+        else:
+            self._behavior_color_map = {}
+            self._multiclass_color_lut = None
+        self._reset_layout()
+
+    def _build_none_lut(self) -> npt.NDArray[np.uint8]:
+        """Build a 3-entry binary color LUT for the None/background prediction row.
+
+        Returns:
+            RGBA array of shape ``(3, 4)`` where index 0 = no pose (gray),
+            index 1 = not None class (gray), index 2 = None class predicted (blue).
+        """
+        return np.array(
+            [
+                BACKGROUND_COLOR.getRgb(),
+                BACKGROUND_COLOR.getRgb(),
+                NOT_BEHAVIOR_COLOR.getRgb(),
+            ],
+            dtype=np.uint8,
+        )
+
+    def _build_class_lut(self, behavior_name: str) -> npt.NDArray[np.uint8]:
+        """Build a 3-entry binary color LUT for a single behavior class prediction row.
+
+        Args:
+            behavior_name: Name of the behavior class.
+
+        Returns:
+            RGBA array of shape ``(3, 4)`` where index 0 = no pose (gray),
+            index 1 = not this class (gray), index 2 = this class (behavior color).
+        """
+        color = self._behavior_color_map[behavior_name]
+        return np.array(
+            [
+                BACKGROUND_COLOR.getRgb(),
+                BACKGROUND_COLOR.getRgb(),
+                color.getRgb(),
+            ],
+            dtype=np.uint8,
+        )
+
     def _reset_layout(self) -> None:
         """Recreate the layout and child widgets for all identities.
 
@@ -137,17 +314,31 @@ class StackedTimelineWidget(QWidget):
         label overview widgets, and prediction overview widgets for each identity.
         Updates the internal lists and layout, and sets the active identity index.
 
-        This method is called when the number of identities changes.
+        This method is called when the number of identities changes or when the
+        classifier mode changes.
         """
         # Remove old widgets and frames
         for frame in self._identity_frames:
             self._layout.removeWidget(frame)
             frame.setParent(None)
             frame.deleteLater()
+        if self._legend_widget is not None:
+            self._layout.removeWidget(self._legend_widget)
+            self._legend_widget.setParent(None)
+            self._legend_widget.deleteLater()
+            self._legend_widget = None
         self._layout.removeWidget(self._frame_labels)
         self._label_overview_widgets = []
+        self._combined_prediction_widgets = []
         self._prediction_overview_widgets = []
         self._identity_frames = []
+
+        # Build the legend widget in multi-class mode
+        if self._classifier_mode == ClassifierMode.MULTICLASS and self._behavior_names:
+            self._legend_widget = _BehaviorLegendWidget(
+                self._behavior_names, self._behavior_color_map, self
+            )
+            self._layout.addWidget(self._legend_widget)
 
         # Create new frames and widgets
         for identity_index in range(self._num_identities):
@@ -164,18 +355,48 @@ class StackedTimelineWidget(QWidget):
             vbox.setSpacing(4)
 
             label_widget = self._label_overview_widget_factory(frame)
-            prediction_widget = self._prediction_overview_widget_factory(frame)
             label_widget.setVisible(False)
-            prediction_widget.setVisible(False)
+
+            if (
+                self._classifier_mode == ClassifierMode.MULTICLASS
+                and self._behavior_names
+                and self._multiclass_color_lut is not None
+            ):
+                label_widget.set_color_lut(self._multiclass_color_lut)
+                # Combined argmax prediction bar: uses the full multiclass color LUT
+                combined_pw = self._prediction_overview_widget_factory(frame)
+                combined_pw.set_color_lut(self._multiclass_color_lut)
+                combined_pw.setVisible(False)
+                # Per-class detail bars (collapsible): None row first, then behaviors
+                prediction_widgets: list[PredictionOverviewWidget] = []
+                none_pw = self._prediction_overview_widget_factory(frame)
+                none_pw.set_color_lut(self._build_none_lut())
+                none_pw.setVisible(False)
+                prediction_widgets.append(none_pw)
+                for behavior_name in self._behavior_names:
+                    pw = self._prediction_overview_widget_factory(frame)
+                    pw.set_color_lut(self._build_class_lut(behavior_name))
+                    pw.setVisible(False)
+                    prediction_widgets.append(pw)
+            else:
+                combined_pw = None
+                pw = self._prediction_overview_widget_factory(frame)
+                pw.setVisible(False)
+                prediction_widgets = [pw]
 
             vbox.addWidget(QLabel(f"{identity_display_name}:"))
             vbox.addWidget(label_widget)
-            vbox.addWidget(prediction_widget)
+            if combined_pw is not None:
+                vbox.addWidget(combined_pw)
+            for pw in prediction_widgets:
+                vbox.addWidget(pw)
 
             self._label_overview_widgets.append(label_widget)
-            self._prediction_overview_widgets.append(prediction_widget)
+            self._combined_prediction_widgets.append(combined_pw)
+            self._prediction_overview_widgets.append(prediction_widgets)
             self._identity_frames.append(frame)
             self._layout.addWidget(frame)
+
         self._update_frame_border()
         if self._num_identities > 0:
             self._active_identity_index = 0
@@ -282,6 +503,11 @@ class StackedTimelineWidget(QWidget):
             if widget is not None:
                 widget.hide()
 
+        # Legend goes first in multi-class mode
+        if self._legend_widget is not None:
+            self._layout.addWidget(self._legend_widget)
+            self._legend_widget.show()
+
         # Add only the widgets needed for the current mode
         if self._identity_mode == self.IdentityMode.ALL:
             for i, frame in enumerate(self._identity_frames):
@@ -289,7 +515,9 @@ class StackedTimelineWidget(QWidget):
                 frame.show()
                 self._set_widget_visibility(
                     self._label_overview_widgets[i],
+                    self._combined_prediction_widgets[i],
                     self._prediction_overview_widgets[i],
+                    is_active=(i == self._active_identity_index),
                 )
         elif (
             self._identity_mode == self.IdentityMode.ACTIVE
@@ -301,7 +529,9 @@ class StackedTimelineWidget(QWidget):
             frame.show()
             self._set_widget_visibility(
                 self._label_overview_widgets[idx],
+                self._combined_prediction_widgets[idx],
                 self._prediction_overview_widgets[idx],
+                is_active=True,
             )
 
         # Add FrameLabelsWidget last
@@ -312,35 +542,66 @@ class StackedTimelineWidget(QWidget):
     def _set_widget_visibility(
         self,
         label_widget: LabelOverviewWidget,
-        prediction_widget: PredictionOverviewWidget,
+        combined_widget: PredictionOverviewWidget | None,
+        prediction_widgets: list[PredictionOverviewWidget],
+        is_active: bool = True,
     ) -> None:
         """Set the visibility of label and prediction widgets based on the current view mode.
 
-        Shows or hides the provided label and prediction widgets according to the selected
-        view mode (labels only, predictions only, or both).
+        Shows or hides the provided widgets according to the selected view mode (labels
+        only, predictions only, or both).  In multi-class + all-animals mode the combined
+        prediction bar is always fully expanded while the per-class detail bars are
+        optionally collapsed on non-active identities.
 
         Args:
             label_widget: The LabelOverviewWidget to show or hide.
-            prediction_widget: The PredictionOverviewWidget to show or hide.
+            combined_widget: The combined argmax PredictionOverviewWidget, or ``None`` in
+                binary mode.
+            prediction_widgets: The per-class PredictionOverviewWidgets to show or hide.
+            is_active: Whether this identity is the active one (used for layout compaction).
         """
-        if self._view_mode == self.ViewMode.LABELS_AND_PREDICTIONS:
-            label_widget.setVisible(True)
-            prediction_widget.setVisible(True)
-        elif self._view_mode == self.ViewMode.LABELS:
-            label_widget.setVisible(True)
-            prediction_widget.setVisible(False)
-        elif self._view_mode == self.ViewMode.PREDICTIONS:
-            label_widget.setVisible(False)
-            prediction_widget.setVisible(True)
+        show_labels = self._view_mode in (
+            self.ViewMode.LABELS_AND_PREDICTIONS,
+            self.ViewMode.LABELS,
+        )
+        show_preds = self._view_mode in (
+            self.ViewMode.LABELS_AND_PREDICTIONS,
+            self.ViewMode.PREDICTIONS,
+        )
+        label_widget.setVisible(show_labels)
+        if combined_widget is not None:
+            combined_widget.setVisible(show_preds)
+        for pw in prediction_widgets:
+            pw.setVisible(show_preds)
+
+        # In multi-class + all-animals mode, optionally collapse detail bars on non-active
+        # identities independently for each bar type.
+        if (
+            self._classifier_mode == ClassifierMode.MULTICLASS
+            and self._identity_mode == self.IdentityMode.ALL
+        ):
+            label_widget.set_detail_bar_visible(is_active or not self._collapse_inactive_label_bar)
+            if combined_widget is not None:
+                combined_widget.set_detail_bar_visible(
+                    is_active or not self._collapse_inactive_combined_bar
+                )
+            for pw in prediction_widgets:
+                pw.set_detail_bar_visible(is_active or not self._collapse_inactive_per_class_bars)
 
     @Slot(int)
     def set_current_frame(self, current_frame: int) -> None:
         """Forward current frame to all LabelOverviewWidgets and PredictionOverviewWidgets."""
-        for label_widget, prediction_widget in zip(
-            self._label_overview_widgets, self._prediction_overview_widgets, strict=True
+        for label_widget, combined_widget, pred_widgets in zip(
+            self._label_overview_widgets,
+            self._combined_prediction_widgets,
+            self._prediction_overview_widgets,
+            strict=True,
         ):
             label_widget.set_current_frame(current_frame)
-            prediction_widget.set_current_frame(current_frame)
+            if combined_widget is not None:
+                combined_widget.set_current_frame(current_frame)
+            for pw in pred_widgets:
+                pw.set_current_frame(current_frame)
         self._frame_labels.set_current_frame(current_frame)
 
     def set_labels(
@@ -382,14 +643,20 @@ class StackedTimelineWidget(QWidget):
 
     def set_predictions(
         self,
-        predictions_list: list[npt.NDArray[np.int16]],
-        probabilities_list: list[npt.NDArray[np.floating]],
+        predictions_list: list[list[npt.NDArray[np.int16]]],
+        probabilities_list: list[list[npt.NDArray[np.floating]]],
     ) -> None:
         """Set predictions for all PredictionOverviewWidgets.
 
+        In binary mode, each inner list contains exactly one array.  In multi-class mode,
+        each inner list contains one array per behavior class, matching the number of
+        PredictionOverviewWidgets created by :meth:`set_classifier_mode`.
+
         Args:
-            predictions_list: List of class-index arrays (one per identity).
-            probabilities_list: List of per-frame confidence arrays (one per identity).
+            predictions_list: Nested list of class-index arrays, shape
+                ``(n_identities, n_classes_per_identity)``, each element ``(n_frames,)``.
+            probabilities_list: Nested list of per-frame confidence arrays, matching
+                ``predictions_list`` in shape.
         """
         if len(predictions_list) != self._num_identities:
             raise ValueError(
@@ -398,14 +665,24 @@ class StackedTimelineWidget(QWidget):
             )
         if len(probabilities_list) != self._num_identities:
             raise ValueError(
-                f"Number of probability arrays ({len(predictions_list)}) "
+                f"Number of probability arrays ({len(probabilities_list)}) "
                 f"does not match number of identities ({self._num_identities})."
             )
 
-        for i, widget in enumerate(self._prediction_overview_widgets):
-            widget.num_frames = self.num_frames
-            widget.framerate = self.framerate
-            widget.set_labels(predictions_list[i], probabilities_list[i])
+        for i, pred_widgets in enumerate(self._prediction_overview_widgets):
+            for j, widget in enumerate(pred_widgets):
+                widget.num_frames = self.num_frames
+                widget.framerate = self.framerate
+                widget.set_labels(predictions_list[i][j], probabilities_list[i][j])
+
+            combined_widget = self._combined_prediction_widgets[i]
+            if combined_widget is not None:
+                combined_pred, combined_prob = self._compute_combined_prediction(
+                    predictions_list[i], probabilities_list[i]
+                )
+                combined_widget.num_frames = self.num_frames
+                combined_widget.framerate = self.framerate
+                combined_widget.set_labels(combined_pred, combined_prob)
 
     def set_search_results(
         self, behavior_search_query: BehaviorSearchQuery | None, search_results: list[SearchHit]
@@ -426,15 +703,18 @@ class StackedTimelineWidget(QWidget):
 
             label_overview_widget.set_search_results(curr_search_results)
 
-        for i, prediction_overview_widget in enumerate(self._prediction_overview_widgets):
-            curr_search_results: list[SearchHit] = []
+        for i, pred_widgets in enumerate(self._prediction_overview_widgets):
+            curr_search_results = []
             match behavior_search_query:
                 case PredictionBehaviorSearchQuery() | TimelineAnnotationSearchQuery():
                     for hit in search_results:
                         if hit.identity is None or hit.identity == str(i):
                             curr_search_results.append(hit)
-
-            prediction_overview_widget.set_search_results(curr_search_results)
+            combined_widget = self._combined_prediction_widgets[i]
+            if combined_widget is not None:
+                combined_widget.set_search_results(curr_search_results)
+            for pw in pred_widgets:
+                pw.set_search_results(curr_search_results)
 
     def start_selection(self, starting_frame: int, ending_frame: int | None = None) -> None:
         """Start a selection from the given frame(s) on the active identity's widget.
@@ -475,9 +755,42 @@ class StackedTimelineWidget(QWidget):
         """
         for widget in self._label_overview_widgets:
             widget.reset()
+        for combined_widget in self._combined_prediction_widgets:
+            if combined_widget is not None:
+                combined_widget.reset()
+        for pred_widgets in self._prediction_overview_widgets:
+            for widget in pred_widgets:
+                widget.reset()
 
-        for widget in self._prediction_overview_widgets:
-            widget.reset()
+    @staticmethod
+    def _compute_combined_prediction(
+        per_class_preds: list[npt.NDArray[np.int16]],
+        per_class_probs: list[npt.NDArray[np.floating]],
+    ) -> tuple[npt.NDArray[np.int16], npt.NDArray[np.floating]]:
+        """Derive a combined argmax prediction array from per-class binary arrays.
+
+        For each frame finds the class whose prediction == 2 (this class predicted)
+        and maps it to the multiclass LUT index (class 0 → LUT index 1, class k → k+1).
+        Frames where no class is predicted (no pose) remain at LUT index 0.
+
+        Args:
+            per_class_preds: Per-class binary arrays (0=no pose, 1=not this class, 2=this
+                class), ordered as [None/background, behavior 0, behavior 1, ...].
+            per_class_probs: Per-class probability arrays, same order.
+
+        Returns:
+            Tuple of (combined LUT-index array, combined probability array).
+        """
+        n_frames = per_class_preds[0].shape[0]
+        combined_pred = np.zeros(n_frames, dtype=np.int16)
+        combined_prob = np.zeros(n_frames, dtype=np.float32)
+        for class_idx, (pred, prob) in enumerate(
+            zip(per_class_preds, per_class_probs, strict=True)
+        ):
+            winner_mask = pred == 2
+            combined_pred[winner_mask] = class_idx + 1
+            combined_prob[winner_mask] = prob[winner_mask]
+        return combined_pred, combined_prob
 
     def _on_palette_changed(self) -> None:
         """Handle required updates if app palette changes."""

--- a/src/jabs/ui/stacked_timeline_widget/stacked_timeline_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/stacked_timeline_widget.py
@@ -52,21 +52,21 @@ class StackedTimelineWidget(QWidget):
 
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
-        self._active_identity_index = None
-        self._selection_starting_frame = None
-        self._selection_ending_frame = None
+        self._active_identity_index: int | None = None
+        self._selection_starting_frame: int | None = None
+        self._selection_ending_frame: int | None = None
         self._view_mode = self.ViewMode.LABELS_AND_PREDICTIONS
         self._identity_mode = self.IdentityMode.ACTIVE
         self._num_identities = 0
         self._num_frames = 0
         self._framerate = 0
         self._label_overview_widgets: list[LabelOverviewWidget] = []
-        self._prediction_overview_widgets = []
-        self._identity_frames = []
+        self._prediction_overview_widgets: list[PredictionOverviewWidget] = []
+        self._identity_frames: list[QFrame] = []
         self._frame_labels = FrameLabelsWidget(self)
         self._pose: PoseEstimation | None = None
 
-        self._layout = QVBoxLayout(self)
+        self._layout: QVBoxLayout = QVBoxLayout(self)
         self._layout.setContentsMargins(0, 0, 0, 0)
         self._layout.setSpacing(0)
 
@@ -77,14 +77,16 @@ class StackedTimelineWidget(QWidget):
 
     def _label_overview_widget_factory(self, parent) -> LabelOverviewWidget:
         """Factory method to create a label overview widget."""
-        widget = LabelOverviewWidget(parent)
+        widget = LabelOverviewWidget(parent, compact=self._identity_mode == self.IdentityMode.ALL)
         widget.num_frames = self.num_frames
         widget.framerate = self.framerate
         return widget
 
     def _prediction_overview_widget_factory(self, parent) -> PredictionOverviewWidget:
         """Factory method to create a prediction overview widget."""
-        widget = PredictionOverviewWidget(parent)
+        widget = PredictionOverviewWidget(
+            parent, compact=self._identity_mode == self.IdentityMode.ALL
+        )
         widget.num_frames = self.num_frames
         widget.framerate = self.framerate
         return widget
@@ -231,7 +233,7 @@ class StackedTimelineWidget(QWidget):
         self._framerate = value
 
     @property
-    def active_identity_index(self) -> int:
+    def active_identity_index(self) -> int | None:
         """Get the index of the active identity."""
         return self._active_identity_index
 
@@ -255,7 +257,7 @@ class StackedTimelineWidget(QWidget):
             self._active_identity_index = value
 
             # Transfer selection to new active widget if selection is active
-            if selection_frame is not None:
+            if selection_frame is not None and self._active_identity_index is not None:
                 self._label_overview_widgets[self._active_identity_index].start_selection(
                     selection_frame,
                     self._selection_ending_frame,
@@ -275,12 +277,14 @@ class StackedTimelineWidget(QWidget):
             self._set_active_frame_border(-1)
 
     def _update_widget_visibility(self) -> None:
+        """Rebuild the layout to show only the widgets appropriate for the current modes."""
         # Remove all widgets from the layout
         while self._layout.count():
             item = self._layout.takeAt(0)
-            widget = item.widget()
-            if widget is not None:
-                widget.hide()
+            if item is not None:
+                widget = item.widget()
+                if widget is not None:
+                    widget.hide()
 
         # Add only the widgets needed for the current mode
         if self._identity_mode == self.IdentityMode.ALL:
@@ -291,6 +295,8 @@ class StackedTimelineWidget(QWidget):
                     self._label_overview_widgets[i],
                     self._prediction_overview_widgets[i],
                 )
+                self._label_overview_widgets[i].compact = True
+                self._prediction_overview_widgets[i].compact = True
         elif (
             self._identity_mode == self.IdentityMode.ACTIVE
             and self._active_identity_index is not None
@@ -303,6 +309,8 @@ class StackedTimelineWidget(QWidget):
                 self._label_overview_widgets[idx],
                 self._prediction_overview_widgets[idx],
             )
+            self._label_overview_widgets[idx].compact = False
+            self._prediction_overview_widgets[idx].compact = False
 
         # Add FrameLabelsWidget last
         self._layout.addWidget(self._frame_labels)

--- a/src/jabs/ui/stacked_timeline_widget/stacked_timeline_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/stacked_timeline_widget.py
@@ -34,6 +34,9 @@ from ..colors import (
 )
 from .frame_labels_widget import FrameLabelsWidget
 from .label_overview_widget import LabelOverviewWidget, PredictionOverviewWidget
+from .label_overview_widget.per_class_prediction_overview_widget import (
+    PerClassPredictionOverviewWidget,
+)
 
 
 class _BehaviorLegendWidget(QWidget):
@@ -125,6 +128,7 @@ class StackedTimelineWidget(QWidget):
         self._label_overview_widgets: list[LabelOverviewWidget] = []
         self._combined_prediction_widgets: list[PredictionOverviewWidget | None] = []
         self._prediction_overview_widgets: list[list[PredictionOverviewWidget]] = []
+        self._per_class_separators: list[QFrame | None] = []
         self._identity_frames: list[QFrame] = []
         self._frame_labels = FrameLabelsWidget(self)
         self._pose: PoseEstimation | None = None
@@ -137,6 +141,7 @@ class StackedTimelineWidget(QWidget):
         self._collapse_inactive_label_bar: bool = False
         self._collapse_inactive_combined_bar: bool = False
         self._collapse_inactive_per_class_bars: bool = True
+        self._hide_inactive_per_class_widgets: bool = False
 
         self._layout: QVBoxLayout = QVBoxLayout(self)
         self._layout.setContentsMargins(0, 0, 0, 0)
@@ -230,6 +235,24 @@ class StackedTimelineWidget(QWidget):
         """Set whether non-active per-class prediction bars are collapsed in all-animals mode."""
         if value != self._collapse_inactive_per_class_bars:
             self._collapse_inactive_per_class_bars = value
+            self._update_widget_visibility()
+
+    @property
+    def hide_inactive_per_class_widgets(self) -> bool:
+        """Whether per-class prediction rows are hidden entirely for non-active identities.
+
+        When ``True``, non-active identities show no per-class bars at all (neither
+        the overview strip nor the detail bar), leaving only the label and combined
+        prediction rows visible.  Only has a visual effect in multi-class + all-animals
+        mode.
+        """
+        return self._hide_inactive_per_class_widgets
+
+    @hide_inactive_per_class_widgets.setter
+    def hide_inactive_per_class_widgets(self, value: bool) -> None:
+        """Set whether per-class rows are hidden for non-active identities."""
+        if value != self._hide_inactive_per_class_widgets:
+            self._hide_inactive_per_class_widgets = value
             self._update_widget_visibility()
 
     @property
@@ -333,6 +356,7 @@ class StackedTimelineWidget(QWidget):
         self._label_overview_widgets = []
         self._combined_prediction_widgets = []
         self._prediction_overview_widgets = []
+        self._per_class_separators = []
         self._identity_frames = []
 
         # Build the legend widget in multi-class mode
@@ -369,14 +393,20 @@ class StackedTimelineWidget(QWidget):
                 combined_pw = self._prediction_overview_widget_factory(frame)
                 combined_pw.set_color_lut(self._multiclass_color_lut)
                 combined_pw.setVisible(False)
-                # Per-class detail bars (collapsible): None row first, then behaviors
+                # Per-class detail bars (collapsible): None row first, then behaviors.
+                # Always compact; use PerClassPredictionOverviewWidget so the detail bar
+                # renders behavior color at probability-based alpha (no "not this class" gray).
                 prediction_widgets: list[PredictionOverviewWidget] = []
-                none_pw = self._prediction_overview_widget_factory(frame)
+                none_pw = PerClassPredictionOverviewWidget(frame, compact=True)
+                none_pw.num_frames = self.num_frames
+                none_pw.framerate = self.framerate
                 none_pw.set_color_lut(self._build_none_lut())
                 none_pw.setVisible(False)
                 prediction_widgets.append(none_pw)
                 for behavior_name in self._behavior_names:
-                    pw = self._prediction_overview_widget_factory(frame)
+                    pw = PerClassPredictionOverviewWidget(frame, compact=True)
+                    pw.num_frames = self.num_frames
+                    pw.framerate = self.framerate
                     pw.set_color_lut(self._build_class_lut(behavior_name))
                     pw.setVisible(False)
                     prediction_widgets.append(pw)
@@ -390,12 +420,21 @@ class StackedTimelineWidget(QWidget):
             vbox.addWidget(label_widget)
             if combined_pw is not None:
                 vbox.addWidget(combined_pw)
+            if prediction_widgets and combined_pw is not None:
+                separator = QFrame(frame)
+                separator.setFrameShape(QFrame.Shape.HLine)
+                separator.setFrameShadow(QFrame.Shadow.Sunken)
+                separator.setContentsMargins(0, 2, 0, 0)
+                vbox.addWidget(separator)
+            else:
+                separator = None
             for pw in prediction_widgets:
                 vbox.addWidget(pw)
 
             self._label_overview_widgets.append(label_widget)
             self._combined_prediction_widgets.append(combined_pw)
             self._prediction_overview_widgets.append(prediction_widgets)
+            self._per_class_separators.append(separator)
             self._identity_frames.append(frame)
             self._layout.addWidget(frame)
 
@@ -521,6 +560,7 @@ class StackedTimelineWidget(QWidget):
                     self._label_overview_widgets[i],
                     self._combined_prediction_widgets[i],
                     self._prediction_overview_widgets[i],
+                    self._per_class_separators[i],
                     is_active=(i == self._active_identity_index),
                 )
                 self._label_overview_widgets[i].compact = True
@@ -540,13 +580,13 @@ class StackedTimelineWidget(QWidget):
                 self._label_overview_widgets[idx],
                 self._combined_prediction_widgets[idx],
                 self._prediction_overview_widgets[idx],
+                self._per_class_separators[idx],
                 is_active=True,
             )
             self._label_overview_widgets[idx].compact = False
             if self._combined_prediction_widgets[idx] is not None:
                 self._combined_prediction_widgets[idx].compact = False  # type: ignore[union-attr]
-            for pw in self._prediction_overview_widgets[idx]:
-                pw.compact = False
+            # Per-class bars are always compact regardless of identity view mode.
 
         # Add FrameLabelsWidget last
         self._layout.addWidget(self._frame_labels)
@@ -558,6 +598,7 @@ class StackedTimelineWidget(QWidget):
         label_widget: LabelOverviewWidget,
         combined_widget: PredictionOverviewWidget | None,
         prediction_widgets: list[PredictionOverviewWidget],
+        separator: QFrame | None = None,
         is_active: bool = True,
     ) -> None:
         """Set the visibility of label and prediction widgets based on the current view mode.
@@ -572,6 +613,8 @@ class StackedTimelineWidget(QWidget):
             combined_widget: The combined argmax PredictionOverviewWidget, or ``None`` in
                 binary mode.
             prediction_widgets: The per-class PredictionOverviewWidgets to show or hide.
+            separator: Optional horizontal line separating the combined bar from the
+                per-class bars; shown whenever the per-class bars are shown.
             is_active: Whether this identity is the active one (used for layout compaction).
         """
         show_labels = self._view_mode in (
@@ -585,8 +628,20 @@ class StackedTimelineWidget(QWidget):
         label_widget.setVisible(show_labels)
         if combined_widget is not None:
             combined_widget.setVisible(show_preds)
+
+        # In multi-class + all-animals mode, per-class rows can be hidden entirely for
+        # non-active identities, or selectively collapsed via the detail-bar flags.
+        hide_per_class = (
+            self._classifier_mode == ClassifierMode.MULTICLASS
+            and self._identity_mode == self.IdentityMode.ALL
+            and not is_active
+            and self._hide_inactive_per_class_widgets
+        )
+        show_per_class = show_preds and not hide_per_class
+        if separator is not None:
+            separator.setVisible(show_per_class)
         for pw in prediction_widgets:
-            pw.setVisible(show_preds)
+            pw.setVisible(show_per_class)
 
         # In multi-class + all-animals mode, optionally collapse detail bars on non-active
         # identities independently for each bar type.

--- a/src/jabs/ui/stacked_timeline_widget/stacked_timeline_widget.py
+++ b/src/jabs/ui/stacked_timeline_widget/stacked_timeline_widget.py
@@ -737,6 +737,18 @@ class StackedTimelineWidget(QWidget):
                 f"Number of probability arrays ({len(probabilities_list)}) "
                 f"does not match number of identities ({self._num_identities})."
             )
+        for i, pred_widgets in enumerate(self._prediction_overview_widgets):
+            n_expected = len(pred_widgets)
+            if len(predictions_list[i]) != n_expected:
+                raise ValueError(
+                    f"Identity {i}: expected {n_expected} prediction arrays, "
+                    f"got {len(predictions_list[i])}."
+                )
+            if len(probabilities_list[i]) != n_expected:
+                raise ValueError(
+                    f"Identity {i}: expected {n_expected} probability arrays, "
+                    f"got {len(probabilities_list[i])}."
+                )
 
         for i, pred_widgets in enumerate(self._prediction_overview_widgets):
             for j, widget in enumerate(pred_widgets):

--- a/tests/project/test_initialize_project.py
+++ b/tests/project/test_initialize_project.py
@@ -1,6 +1,7 @@
 from click.testing import CliRunner
 
 import jabs.scripts.initialize_project as initialize_project
+from jabs.core.enums import CacheFormat
 
 
 def test_jabs_init_click_parses_all_existing_options(tmp_path, monkeypatch):
@@ -20,6 +21,7 @@ def test_jabs_init_click_parses_all_existing_options(tmp_path, monkeypatch):
         metadata_path,
         skip_feature_generation,
         project_dir,
+        cache_format,
     ):
         captured.update(
             {
@@ -30,6 +32,7 @@ def test_jabs_init_click_parses_all_existing_options(tmp_path, monkeypatch):
                 "metadata_path": metadata_path,
                 "skip_feature_generation": skip_feature_generation,
                 "project_dir": project_dir,
+                "cache_format": cache_format,
             }
         )
 
@@ -54,6 +57,8 @@ def test_jabs_init_click_parses_all_existing_options(tmp_path, monkeypatch):
             "--metadata",
             str(metadata_path),
             "--skip-feature-generation",
+            "--cache-format",
+            "hdf5",
             str(project_dir),
         ],
     )
@@ -67,6 +72,7 @@ def test_jabs_init_click_parses_all_existing_options(tmp_path, monkeypatch):
         "metadata_path": metadata_path,
         "skip_feature_generation": True,
         "project_dir": project_dir,
+        "cache_format": CacheFormat.HDF5,
     }
 
 
@@ -85,6 +91,7 @@ def test_jabs_init_click_uses_existing_defaults(tmp_path, monkeypatch):
         metadata_path,
         skip_feature_generation,
         project_dir,
+        cache_format,
     ):
         captured.update(
             {
@@ -95,6 +102,7 @@ def test_jabs_init_click_uses_existing_defaults(tmp_path, monkeypatch):
                 "metadata_path": metadata_path,
                 "skip_feature_generation": skip_feature_generation,
                 "project_dir": project_dir,
+                "cache_format": cache_format,
             }
         )
 
@@ -116,6 +124,7 @@ def test_jabs_init_click_uses_existing_defaults(tmp_path, monkeypatch):
         "metadata_path": None,
         "skip_feature_generation": False,
         "project_dir": project_dir,
+        "cache_format": CacheFormat.PARQUET,
     }
 
 

--- a/tests/project/test_initialize_project.py
+++ b/tests/project/test_initialize_project.py
@@ -77,7 +77,7 @@ def test_jabs_init_click_parses_all_existing_options(tmp_path, monkeypatch):
 
 
 def test_jabs_init_click_uses_existing_defaults(tmp_path, monkeypatch):
-    """The Click entrypoint should keep the legacy default option values."""
+    """Check defaults passed by Click entrypoint."""
     project_dir = tmp_path / "project"
 
     captured = {}
@@ -124,7 +124,7 @@ def test_jabs_init_click_uses_existing_defaults(tmp_path, monkeypatch):
         "metadata_path": None,
         "skip_feature_generation": False,
         "project_dir": project_dir,
-        "cache_format": CacheFormat.PARQUET,
+        "cache_format": None,
     }
 
 

--- a/tests/project/test_project_cache_format.py
+++ b/tests/project/test_project_cache_format.py
@@ -41,12 +41,12 @@ def _project_settings(tmp_path: Path) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def test_new_project_defaults_to_hdf5(tmp_path: Path) -> None:
-    """A brand-new project gets cache_format=hdf5 written to project.json."""
+def test_new_project_defaults_to_parquet(tmp_path: Path) -> None:
+    """A brand-new project gets cache_format=parquet written to project.json."""
     project = _make_project(tmp_path)
 
-    assert project.cache_format == CacheFormat.HDF5
-    assert _project_settings(tmp_path).get(CACHE_FORMAT_KEY) == CacheFormat.HDF5.value
+    assert project.cache_format == CacheFormat.PARQUET
+    assert _project_settings(tmp_path).get(CACHE_FORMAT_KEY) == CacheFormat.PARQUET.value
 
 
 def test_existing_project_without_cache_format_migrates_to_hdf5(tmp_path: Path) -> None:
@@ -82,13 +82,12 @@ def test_existing_project_with_cache_format_parquet_is_preserved(tmp_path: Path)
 # ---------------------------------------------------------------------------
 
 
-def test_cache_format_returns_hdf5_enum(tmp_path: Path) -> None:
+def test_cache_format_returns_enum_instance(tmp_path: Path) -> None:
     """cache_format returns a CacheFormat instance, not a bare string."""
     project = _make_project(tmp_path)
 
     result = project.cache_format
     assert isinstance(result, CacheFormat)
-    assert result is CacheFormat.HDF5
 
 
 def test_cache_format_falls_back_to_hdf5_for_unknown_value(tmp_path: Path) -> None:
@@ -155,3 +154,24 @@ def test_clear_feature_cache_no_op_when_feature_dir_empty(tmp_path: Path) -> Non
     # feature_dir is created by Project.__init__; it just has no identity subdirs yet
     assert project.feature_dir.exists()
     project.clear_feature_cache()  # should not raise
+
+
+def test_clear_feature_cache_handles_pose_hash_layout(tmp_path: Path) -> None:
+    """clear_feature_cache removes cache files when pose-hash subdirectory is present.
+
+    Hash layout: features/<video>/<pose_hash>/<identity>/
+    """
+    project = _make_project(tmp_path)
+
+    pose_hash = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"  # 40-char hex
+    identity_dir = project.feature_dir / "video_stem" / pose_hash / "0"
+    identity_dir.mkdir(parents=True)
+    (identity_dir / "metadata.json").write_text("{}")
+    (identity_dir / "per_frame.parquet").write_bytes(b"stub")
+    (identity_dir / "window_5.parquet").write_bytes(b"stub")
+
+    project.clear_feature_cache()
+
+    assert not (identity_dir / "metadata.json").exists()
+    assert not any(identity_dir.glob("*.parquet"))
+    assert identity_dir.exists()  # directories preserved

--- a/tests/project/test_project_cache_format.py
+++ b/tests/project/test_project_cache_format.py
@@ -1,0 +1,157 @@
+"""Tests for Project.cache_format property and related feature cache integration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from jabs.core.constants import CACHE_FORMAT_KEY
+from jabs.core.enums import CacheFormat
+from jabs.project import Project
+
+
+@pytest.fixture(autouse=True, scope="module")
+def patch_session_tracker():
+    """Suppress SessionTracker side effects."""
+    with patch("jabs.project.session_tracker.SessionTracker.__del__", return_value=None):
+        yield
+
+
+def _make_project(tmp_path: Path) -> Project:
+    """Create a minimal Project in tmp_path with no videos or pose files."""
+    return Project(
+        tmp_path,
+        enable_video_check=False,
+        enable_session_tracker=False,
+        validate_project_dir=False,
+    )
+
+
+def _project_settings(tmp_path: Path) -> dict:
+    """Read the settings dict from the project.json on disk."""
+    project_file = tmp_path / "jabs" / "project.json"
+    return json.loads(project_file.read_text()).get("settings", {})
+
+
+# ---------------------------------------------------------------------------
+# Default / migration behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_new_project_defaults_to_hdf5(tmp_path: Path) -> None:
+    """A brand-new project gets cache_format=hdf5 written to project.json."""
+    project = _make_project(tmp_path)
+
+    assert project.cache_format == CacheFormat.HDF5
+    assert _project_settings(tmp_path).get(CACHE_FORMAT_KEY) == CacheFormat.HDF5.value
+
+
+def test_existing_project_without_cache_format_migrates_to_hdf5(tmp_path: Path) -> None:
+    """A project.json that predates cache_format gets hdf5 written on open."""
+    jabs_dir = tmp_path / "jabs"
+    jabs_dir.mkdir(parents=True)
+    project_file = jabs_dir / "project.json"
+    # Write a project.json that has no cache_format key at all.
+    project_file.write_text(json.dumps({"behavior": {}, "window_sizes": [5]}))
+
+    project = _make_project(tmp_path)
+
+    assert project.cache_format == CacheFormat.HDF5
+    assert _project_settings(tmp_path).get(CACHE_FORMAT_KEY) == CacheFormat.HDF5.value
+
+
+def test_existing_project_with_cache_format_parquet_is_preserved(tmp_path: Path) -> None:
+    """Opening a project that already has cache_format=parquet preserves it."""
+    jabs_dir = tmp_path / "jabs"
+    jabs_dir.mkdir(parents=True)
+    project_file = jabs_dir / "project.json"
+    project_file.write_text(
+        json.dumps({"behavior": {}, "settings": {CACHE_FORMAT_KEY: "parquet"}})
+    )
+
+    project = _make_project(tmp_path)
+
+    assert project.cache_format == CacheFormat.PARQUET
+
+
+# ---------------------------------------------------------------------------
+# cache_format property — value handling
+# ---------------------------------------------------------------------------
+
+
+def test_cache_format_returns_hdf5_enum(tmp_path: Path) -> None:
+    """cache_format returns a CacheFormat instance, not a bare string."""
+    project = _make_project(tmp_path)
+
+    result = project.cache_format
+    assert isinstance(result, CacheFormat)
+    assert result is CacheFormat.HDF5
+
+
+def test_cache_format_falls_back_to_hdf5_for_unknown_value(tmp_path: Path) -> None:
+    """An unrecognised cache_format value in project.json falls back to HDF5."""
+    jabs_dir = tmp_path / "jabs"
+    jabs_dir.mkdir(parents=True)
+    project_file = jabs_dir / "project.json"
+    project_file.write_text(
+        json.dumps({"behavior": {}, "settings": {CACHE_FORMAT_KEY: "unknown_format"}})
+    )
+
+    project = _make_project(tmp_path)
+
+    assert project.cache_format == CacheFormat.HDF5
+
+
+def test_clear_feature_cache_removes_hdf5_files(tmp_path: Path) -> None:
+    """clear_feature_cache removes features.h5 from all identity dirs."""
+    project = _make_project(tmp_path)
+
+    identity_dir = project.feature_dir / "video_stem" / "0"
+    identity_dir.mkdir(parents=True)
+    (identity_dir / "features.h5").write_bytes(b"stub")
+
+    project.clear_feature_cache()
+
+    assert not (identity_dir / "features.h5").exists()
+
+
+def test_clear_feature_cache_removes_parquet_files(tmp_path: Path) -> None:
+    """clear_feature_cache removes Parquet cache files from all identity dirs."""
+    project = _make_project(tmp_path)
+
+    identity_dir = project.feature_dir / "video_stem" / "0"
+    identity_dir.mkdir(parents=True)
+    (identity_dir / "metadata.json").write_text("{}")
+    (identity_dir / "per_frame.parquet").write_bytes(b"stub")
+    (identity_dir / "window_5.parquet").write_bytes(b"stub")
+
+    project.clear_feature_cache()
+
+    assert not (identity_dir / "metadata.json").exists()
+    assert not any(identity_dir.glob("*.parquet"))
+
+
+def test_clear_feature_cache_preserves_directory_structure(tmp_path: Path) -> None:
+    """clear_feature_cache removes files but leaves directories intact."""
+    project = _make_project(tmp_path)
+
+    identity_dir = project.feature_dir / "video_stem" / "0"
+    identity_dir.mkdir(parents=True)
+    (identity_dir / "features.h5").write_bytes(b"stub")
+
+    project.clear_feature_cache()
+
+    assert identity_dir.exists()
+    assert (project.feature_dir / "video_stem").exists()
+
+
+def test_clear_feature_cache_no_op_when_feature_dir_empty(tmp_path: Path) -> None:
+    """clear_feature_cache does not raise when the features directory has no cache files."""
+    project = _make_project(tmp_path)
+
+    # feature_dir is created by Project.__init__; it just has no identity subdirs yet
+    assert project.feature_dir.exists()
+    project.clear_feature_cache()  # should not raise

--- a/tests/ui/test_menu_handlers.py
+++ b/tests/ui/test_menu_handlers.py
@@ -194,6 +194,24 @@ def test_export_frame_restores_existing_directory(monkeypatch, tmp_path, handler
     assert captured["initial_path"] == str(tmp_path / "video_frame000042.png")
 
 
+def test_handle_select_all_delegates_to_central_widget():
+    """handle_select_all() calls select_all() on the central widget."""
+    central = SimpleNamespace(select_all=MagicMock())
+    window = SimpleNamespace(_central_widget=central)
+    handler = MenuHandlers(window)
+    handler.handle_select_all()
+    central.select_all.assert_called_once_with()
+
+
+def test_handle_select_current_bout_delegates_to_central_widget():
+    """handle_select_current_bout() calls select_current_bout() on the central widget."""
+    central = SimpleNamespace(select_current_bout=MagicMock())
+    window = SimpleNamespace(_central_widget=central)
+    handler = MenuHandlers(window)
+    handler.handle_select_current_bout()
+    central.select_current_bout.assert_called_once_with()
+
+
 def test_export_frame_missing_directory_falls_back(monkeypatch, handler_setup):
     """A missing saved directory falls back to the bare suggested filename."""
     handler, window, player = handler_setup


### PR DESCRIPTION
Sorry for the monster PR.  This also merges upstream changes from main since I needed the new "compact" mode for `ManualLabelWidget` and `PredictedLabelWidget`. I probably should have done a "merge main into feature/multiclass" pull request first so that didn't get mixed with my changes. 


## Description of new functionality that wasn't merged from main
This PR extends StackedTimelineWidget (stacked_timeline_widget.py) and its surrounding infrastructure to support multiclass classifier visualization. In multiclass mode the widget builds an entirely different per-identity layout: a combined argmax bar (PredictionOverviewWidget) that shows the winning class color across all frames, followed by one per-class row per behavior (PerClassPredictionOverviewWidget). The per-class rows use the new BehaviorProbabilityWidget (behavior_probability_widget.py) — a subclass of PredictedLabelWidget that overrides _build_frame_colors to render the behavior color at alpha = probability rather than toggling a hard "not-this-class" gray. A _BehaviorLegendWidget strip at the top maps colors to behavior names.  PredictedLabelWidget was refactored to extract _build_frame_colors as an overridable hook to make that subclassing clean; reviewers should check that the base behavior is unchanged. The multiclass LUT and color map are built via build_multiclass_color_lut and make_behavior_color_map in colors.py and propagated down to each sub-widget via set_color_lut.                                                                                                      
                                                                                                                                                             
The wiring into the main window lives in central_widget.py, which detects classifier mode and routes prediction arrays to the appropriate widget structure  — it also explicitly blocks binary prediction data from flowing into the multiclass layout (and vice versa). Four new checkable Timeline menu actions  (menu_builder.py / menu_handlers.py) let users collapse or hide inactive-identity rows in all-animals mode; they are disabled until both multiclass mode and all-animals identity mode are simultaneously active. One additional fix worth noting: TimelineLabelWidget._update_bar previously produced no pixmap when _labels was None, causing the overview bar to be invisible before predictions were first run in multiclass mode; it now renders a solid background-color bar in that state to match binary mode's behavior. (in binary mode we got around this by generating a numpy array with no predictions to pass in so a blank bar was displayed -- now the widget handles this itself for multi-class)

As I was working on integrating the multi-class view options into the app, I found several things that needed to be changed/fixed (even though a previous PR tried to lay the foundation for multi-class in the StackedTimelineWidget, there are some things I missed or decided to go a different direction after seeing the result in practice)




I also added a script `dev/preview_multi_class_timeline.py` that lets you play with this and the various view options I added using fake data. 

For multi-class, all animals mode, there are 4 different view options that you can toggle on/off independently

Demo script showing single animal view:
<img width="1402" height="690" alt="Screenshot 2026-04-24 at 8 16 44 PM" src="https://github.com/user-attachments/assets/de05aceb-d766-4839-856a-45d30ffdaddc" />

bars are
1. label overview
2. labels detailed view
3. predictions (combined) overview
4. predictions (combined) detailed view

then prediction overview and details for each class separately 


----

shot of it being used in JABS. Showing all animals, but with inactive animals set to only show the label and combined prediction overviews (not detail bars, no per-class bars). 
<img width="1800" height="1441" alt="Screenshot 2026-04-24 at 9 04 36 PM" src="https://github.com/user-attachments/assets/2bb7bbae-3fa1-4d34-b73b-4c85782bdadf" />


I would recommend playing with the demo app. 

Note: this has only been tested in JABS for **labeling** in multi-class mode. Viewing actual predictions hasn't been tested yet (only simulated values in the demo app). 
