### PR TITLE
Fix exception on project switch from multiclass to binary classifier

### DIFF
--- a/src/jabs/ui/main_window/main_window.py
+++ b/src/jabs/ui/main_window/main_window.py
@@ -457,12 +457,15 @@ class MainWindow(QtWidgets.QMainWindow):
         """
         # changing the settings can affect training thresholds, so the train button state needs to be updated
         self._central_widget.set_train_button_enabled_state()
+        # Rebuild the timeline layout before updating the controls mode.
+        # controls.set_classifier_mode emits behavior_changed → _on_behavior_changed →
+        # _set_prediction_vis, which validates against the stacked timeline layout.
+        # The layout must match the new mode before that signal fires.
+        self._central_widget.update_classifier_mode_display()
         # classifier mode change is reflected immediately on the labeling buttons
         self._central_widget.controls.set_classifier_mode(
             self._project.settings_manager.classifier_mode
         )
-        # rebuild the timeline layout and refresh labels for the new mode
-        self._central_widget.update_classifier_mode_display()
         self.menu_handlers.update_mc_layout_actions_enabled_state()
 
     def on_app_settings_changed(self) -> None:


### PR DESCRIPTION
This pull request updates the order of operations in the `on_project_settings_changed` method to ensure the timeline layout is rebuilt before updating the classifier mode. This change prevents validation issues that can occur when signals are emitted before the layout matches the new mode.

**Timeline and classifier mode update sequence:**

* [`src/jabs/ui/main_window/main_window.py`](diffhunk://#diff-9e7641ec4065d3a1335955e459bcf0b596c906b1408e324a2ca476df01aaadcfR460-L465): Moved the call to `update_classifier_mode_display()` before setting the classifier mode on controls, ensuring the timeline layout is rebuilt before signals are emitted and validation occurs.