### PR TITLE
update some packages

### DIFF
--- a/packages/jabs-behavior/pyproject.toml
+++ b/packages/jabs-behavior/pyproject.toml
@@ -24,7 +24,7 @@ dev = [
   "pre-commit>=4.2.0,<5.0.0",
 ]
 test = [
-  "pytest>=8.3.4,<9.0.0",
+  "pytest>=9.0.3",
   "pytest-cov>=7.0.0",
 ]
 lint = [

--- a/packages/jabs-core/pyproject.toml
+++ b/packages/jabs-core/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
   "matplotlib>=3.9.3,<4.0.0",
 ]
 test = [
-  "pytest>=8.3.4,<9.0.0",
+  "pytest>=9.0.3",
   "pytest-cov>=7.0.0",
 ]
 lint = [

--- a/packages/jabs-io/pyproject.toml
+++ b/packages/jabs-io/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
   "matplotlib>=3.9.3,<4.0.0",
 ]
 test = [
-  "pytest>=8.3.4,<9.0.0",
+  "pytest>=9.0.3",
   "pytest-cov>=7.0.0",
 ]
 lint = [

--- a/packages/jabs-vision/pyproject.toml
+++ b/packages/jabs-vision/pyproject.toml
@@ -52,7 +52,7 @@ dev = [
   "matplotlib>=3.9.3,<4.0.0",
 ]
 test = [
-  "pytest>=8.3.4,<9.0.0",
+  "pytest>=9.0.3",
   "pytest-cov>=7.0.0",
 ]
 lint = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dev = [
   "matplotlib>=3.9.3,<4.0.0",
 ]
 test = [
-  "pytest>=8.3.4,<9.0.0",
+  "pytest>=9.0.3",
   "pytest-cov>=7.0.0",
 ]
 lint = [

--- a/uv.lock
+++ b/uv.lock
@@ -1438,13 +1438,13 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = ">=4.2.0,<5.0.0" },
-    { name = "pytest", specifier = ">=8.3.4,<9.0.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.11.5,<0.12.0" },
 ]
 lint = [{ name = "ruff", specifier = ">=0.11.5,<0.12.0" }]
 test = [
-    { name = "pytest", specifier = ">=8.3.4,<9.0.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
 ]
 
@@ -1546,7 +1546,7 @@ provides-extras = ["nwb", "yaml"]
 dev = [
     { name = "matplotlib", specifier = ">=3.9.3,<4.0.0" },
     { name = "pre-commit", specifier = ">=4.2.0,<5.0.0" },
-    { name = "pytest", specifier = ">=8.3.4,<9.0.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.11.5,<0.12.0" },
 ]
@@ -1556,7 +1556,7 @@ docs = [
 ]
 lint = [{ name = "ruff", specifier = ">=0.11.5,<0.12.0" }]
 test = [
-    { name = "pytest", specifier = ">=8.3.4,<9.0.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
 ]
 
@@ -1607,14 +1607,14 @@ dev = [
     { name = "matplotlib", specifier = ">=3.9.3,<4.0.0" },
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "pre-commit", specifier = ">=4.2.0,<5.0.0" },
-    { name = "pytest", specifier = ">=8.3.4,<9.0.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.11.5,<0.12.0" },
 ]
 docs = [{ name = "mkdocs", specifier = ">=1.6.1" }]
 lint = [{ name = "ruff", specifier = ">=0.11.5,<0.12.0" }]
 test = [
-    { name = "pytest", specifier = ">=8.3.4,<9.0.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
 ]
 
@@ -1676,14 +1676,14 @@ dev = [
     { name = "matplotlib", specifier = ">=3.9.3,<4.0.0" },
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "pre-commit", specifier = ">=4.2.0,<5.0.0" },
-    { name = "pytest", specifier = ">=8.3.4,<9.0.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.11.5,<0.12.0" },
 ]
 docs = [{ name = "mkdocs", specifier = ">=1.6.1" }]
 lint = [{ name = "ruff", specifier = ">=0.11.5,<0.12.0" }]
 test = [
-    { name = "pytest", specifier = ">=8.3.4,<9.0.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
 ]
 
@@ -1755,13 +1755,13 @@ provides-extras = ["plot", "mlflow", "wandb", "submitit", "timm", "hrnet-msfork"
 dev = [
     { name = "matplotlib", specifier = ">=3.9.3,<4.0.0" },
     { name = "pre-commit", specifier = ">=4.2.0,<5.0.0" },
-    { name = "pytest", specifier = ">=8.3.4,<9.0.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.11.5,<0.12.0" },
 ]
 lint = [{ name = "ruff", specifier = ">=0.11.5,<0.12.0" }]
 test = [
-    { name = "pytest", specifier = ">=8.3.4,<9.0.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
 ]
 
@@ -3354,7 +3354,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -3365,9 +3365,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request updates the testing dependencies across multiple packages to require a newer version of `pytest`. The version constraint for `pytest` is changed from `>=8.3.4,<9.0.0` to `>=9.0.3`, ensuring all packages use at least version 9.0.3 and removing the upper version limit.

Dependency updates:

* Updated the `pytest` dependency in the `[test]` section of the following `pyproject.toml` files to require `pytest>=9.0.3`:
  - `pyproject.toml`
  - `packages/jabs-behavior/pyproject.toml`
  - `packages/jabs-core/pyproject.toml`
  - `packages/jabs-io/pyproject.toml`
  - `packages/jabs-vision/pyproject.toml`