### PR TITLE
Check for conflicting labels in binary to multiclass migration

### DIFF
--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -16,7 +16,7 @@ import numpy as np
 import pandas as pd
 
 import jabs.feature_extraction as fe
-from jabs.core.constants import CACHE_FORMAT_KEY
+from jabs.core.constants import CACHE_FORMAT_KEY, MULTICLASS_NONE_BEHAVIOR
 from jabs.core.enums import CacheFormat, CrossValidationGroupingStrategy, ProjectDistanceUnit
 from jabs.pose_estimation import PoseEstimation, open_pose_file
 
@@ -27,6 +27,7 @@ from .project_paths import ProjectPaths
 from .project_utils import to_safe_name
 from .session_tracker import SessionTracker
 from .settings_manager import SettingsManager
+from .track_labels import TrackLabels
 from .video_labels import VideoLabels
 from .video_manager import VideoManager
 
@@ -525,6 +526,37 @@ class Project:
 
         # update app version saved in project metadata if necessary
         self._settings_manager.update_version()
+
+    def get_overlapping_behavior_label_videos(self) -> list[str]:
+        """Return filenames of videos containing frames labeled with multiple behaviors.
+
+        Scans every video in the project for annotation conflicts where a single
+        identity has the same frame labeled BEHAVIOR for two or more behaviors
+        simultaneously, including the reserved "None" behavior.
+
+        Returns:
+            Sorted list of video filenames containing at least one overlap.
+            An empty list means no conflicts exist.
+        """
+        conflicting: list[str] = []
+        for video in self._video_manager.videos:
+            pose = self.load_pose_est(self._video_manager.video_path(video))
+            labels = self._video_manager.load_video_labels(video, pose)
+            if labels is None:
+                continue
+            identities = {identity for identity, _, _ in labels.iter_identity_behavior_labels()}
+            for identity in identities:
+                behavior_arrays = [
+                    track.get_labels() == TrackLabels.Label.BEHAVIOR
+                    for behavior, track in labels.iter_behavior_labels(identity)
+                    if behavior != MULTICLASS_NONE_BEHAVIOR
+                ]
+                if len(behavior_arrays) >= 2:
+                    stacked = np.stack(behavior_arrays)
+                    if np.any(stacked.sum(axis=0) > 1):
+                        conflicting.append(video)
+                        break
+        return sorted(conflicting)
 
     def archive_behavior(self, behavior: str):
         """Archive a behavior.

--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -16,7 +16,7 @@ import numpy as np
 import pandas as pd
 
 import jabs.feature_extraction as fe
-from jabs.core.constants import CACHE_FORMAT_KEY, MULTICLASS_NONE_BEHAVIOR
+from jabs.core.constants import CACHE_FORMAT_KEY
 from jabs.core.enums import CacheFormat, CrossValidationGroupingStrategy, ProjectDistanceUnit
 from jabs.pose_estimation import PoseEstimation, open_pose_file
 
@@ -532,7 +532,8 @@ class Project:
 
         Scans every video in the project for annotation conflicts where a single
         identity has the same frame labeled BEHAVIOR for two or more behaviors
-        simultaneously, including the reserved "None" behavior.
+        simultaneously. Includes the reserved "None" behavior track, consistent
+        with how MultiClassClassifier.merge_labels() detects conflicts at training time.
 
         Returns:
             Sorted list of video filenames containing at least one overlap.
@@ -548,8 +549,7 @@ class Project:
             for identity in identities:
                 behavior_arrays = [
                     track.get_labels() == TrackLabels.Label.BEHAVIOR
-                    for behavior, track in labels.iter_behavior_labels(identity)
-                    if behavior != MULTICLASS_NONE_BEHAVIOR
+                    for _, track in labels.iter_behavior_labels(identity)
                 ]
                 if len(behavior_arrays) >= 2:
                     stacked = np.stack(behavior_arrays)

--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 import h5py
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 
 import jabs.feature_extraction as fe
@@ -546,16 +547,23 @@ class Project:
             if labels is None:
                 continue
             identities = {identity for identity, _, _ in labels.iter_identity_behavior_labels()}
+            video_has_conflict = False
             for identity in identities:
-                behavior_arrays = [
-                    track.get_labels() == TrackLabels.Label.BEHAVIOR
-                    for _, track in labels.iter_behavior_labels(identity)
-                ]
-                if len(behavior_arrays) >= 2:
-                    stacked = np.stack(behavior_arrays)
-                    if np.any(stacked.sum(axis=0) > 1):
-                        conflicting.append(video)
-                        break
+                behavior_counts: npt.NDArray[np.intp] | None = None
+                for _, track in labels.iter_behavior_labels(identity):
+                    behavior_mask = (track.get_labels() == TrackLabels.Label.BEHAVIOR).astype(
+                        np.intp
+                    )
+                    if behavior_counts is None:
+                        behavior_counts = behavior_mask
+                    else:
+                        behavior_counts = behavior_counts + behavior_mask
+                        if np.any(behavior_counts > 1):
+                            video_has_conflict = True
+                            break
+                if video_has_conflict:
+                    conflicting.append(video)
+                    break
         return sorted(conflicting)
 
     def archive_behavior(self, behavior: str):

--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -542,9 +542,7 @@ class Project:
         """
         conflicting: list[str] = []
         for video in self._video_manager.videos:
-            pose = self.load_pose_est(self._video_manager.video_path(video))
-            labels = self._video_manager.load_video_labels(video, pose)
-            if labels is None:
+            if (labels := self._video_manager.load_video_labels(video)) is None:
                 continue
             identities = {identity for identity, _, _ in labels.iter_identity_behavior_labels()}
             video_has_conflict = False
@@ -591,13 +589,10 @@ class Project:
         # archive labels and unfragmented_labels
         archived_labels = {}
         for video in self._video_manager.videos:
-            pose = self.load_pose_est(self._video_manager.video_path(video))
-            labels = self._video_manager.load_video_labels(video, pose)
-
-            # if no labels for video skip it
-            if labels is None:
+            if (labels := self._video_manager.load_video_labels(video)) is None:
                 continue
 
+            pose = self.load_pose_est(self._video_manager.video_path(video))
             annotations = labels.as_dict(pose)
 
             # ensure archive structure exists for this video:

--- a/src/jabs/ui/main_window/menu_handlers.py
+++ b/src/jabs/ui/main_window/menu_handlers.py
@@ -273,7 +273,9 @@ class MenuHandlers:
 
     def open_project_settings_dialog(self) -> None:
         """Open the project settings dialog."""
-        settings_dialog = ProjectSettingsDialog(self.window._project.settings_manager, self.window)
+        settings_dialog = ProjectSettingsDialog(
+            self.window._project.settings_manager, self.window._project, self.window
+        )
         settings_dialog.settings_changed.connect(self.window.on_project_settings_changed)
         settings_dialog.exec()
 

--- a/src/jabs/ui/settings_dialog/settings_dialog.py
+++ b/src/jabs/ui/settings_dialog/settings_dialog.py
@@ -17,7 +17,7 @@ from PySide6.QtWidgets import (
 
 from jabs.core.constants import APP_NAME, CLASSIFIER_MODE_KEY, ORG_NAME
 from jabs.core.enums import ClassifierMode
-from jabs.project.project import Project
+from jabs.project import Project
 from jabs.project.settings_manager import SettingsManager
 from jabs.ui.dialogs.message_dialog import MessageDialog
 
@@ -36,6 +36,7 @@ class _OverlapCheckThread(QThread):
     """Background thread that scans for conflicting behavior annotations."""
 
     check_complete = Signal(list)
+    check_failed = Signal(Exception)
 
     def __init__(self, project: Project) -> None:
         super().__init__()
@@ -43,7 +44,10 @@ class _OverlapCheckThread(QThread):
 
     def run(self) -> None:
         """Run the overlap check and emit the result."""
-        self.check_complete.emit(self._project.get_overlapping_behavior_label_videos())
+        try:
+            self.check_complete.emit(self._project.get_overlapping_behavior_label_videos())
+        except Exception as error:
+            self.check_failed.emit(error)
 
 
 class BaseSettingsDialog(QDialog):
@@ -307,6 +311,11 @@ class ProjectSettingsDialog(BaseSettingsDialog):
         self._overlap_check_thread = thread
         current_mode = self._settings_manager.classifier_mode
 
+        def _restore_mode() -> None:
+            for group in self._settings_groups:
+                if isinstance(group, ClassifierModeSettingsGroup):
+                    group.set_values({CLASSIFIER_MODE_KEY: current_mode})
+
         def _on_check_complete(conflicting: list[str]) -> None:
             progress.close()
             if conflicting:
@@ -320,15 +329,28 @@ class ProjectSettingsDialog(BaseSettingsDialog):
                     ),
                     details="\n".join(conflicting),
                 )
-                for group in self._settings_groups:
-                    if isinstance(group, ClassifierModeSettingsGroup):
-                        group.set_values({CLASSIFIER_MODE_KEY: current_mode})
+                _restore_mode()
             else:
                 self._warn_and_save(ClassifierMode.MULTICLASS)
-            thread.deleteLater()
-            self._overlap_check_thread = None
+
+        def _on_check_failed(error: Exception) -> None:
+            progress.close()
+            _restore_mode()
+            MessageDialog.error(
+                self,
+                title="Validation Error",
+                message=(
+                    "Unable to validate labels before switching to multi-class mode. "
+                    "The classifier mode was not changed."
+                ),
+                details=f"{type(error).__name__}: {error}",
+            )
 
         thread.check_complete.connect(_on_check_complete)
+        thread.check_failed.connect(_on_check_failed)
+        thread.finished.connect(progress.close)
+        thread.finished.connect(thread.deleteLater)
+        thread.finished.connect(lambda: setattr(self, "_overlap_check_thread", None))
         thread.start()
 
     def _warn_and_save(self, new_mode: ClassifierMode) -> None:

--- a/src/jabs/ui/settings_dialog/settings_dialog.py
+++ b/src/jabs/ui/settings_dialog/settings_dialog.py
@@ -1,5 +1,5 @@
 from PySide6 import QtCore
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtCore import Qt, QThread, Signal
 from PySide6.QtGui import QResizeEvent, QShowEvent
 from PySide6.QtWidgets import (
     QAbstractScrollArea,
@@ -8,14 +8,18 @@ from PySide6.QtWidgets import (
     QFrame,
     QLabel,
     QLayout,
+    QProgressDialog,
     QScrollArea,
     QSizePolicy,
     QVBoxLayout,
     QWidget,
 )
 
-from jabs.core.constants import APP_NAME, ORG_NAME
+from jabs.core.constants import APP_NAME, CLASSIFIER_MODE_KEY, ORG_NAME
+from jabs.core.enums import ClassifierMode
+from jabs.project.project import Project
 from jabs.project.settings_manager import SettingsManager
+from jabs.ui.dialogs.message_dialog import MessageDialog
 
 from .cache_format_settings_group import CacheFormatSettingsGroup
 from .classifier_mode_settings_group import ClassifierModeSettingsGroup
@@ -26,6 +30,20 @@ from .postprocessing_group import (
     StitchingStageSettingsGroup,
 )
 from .session_tracking_group import SessionTrackingSettingsGroup
+
+
+class _OverlapCheckThread(QThread):
+    """Background thread that scans for conflicting behavior annotations."""
+
+    check_complete = Signal(list)
+
+    def __init__(self, project: Project) -> None:
+        super().__init__()
+        self._project = project
+
+    def run(self) -> None:
+        """Run the overlap check and emit the result."""
+        self.check_complete.emit(self._project.get_overlapping_behavior_label_videos())
 
 
 class BaseSettingsDialog(QDialog):
@@ -227,7 +245,14 @@ class BaseSettingsDialog(QDialog):
 class ProjectSettingsDialog(BaseSettingsDialog):
     """Dialog for changing *project* settings (previously `SettingsDialog`)."""
 
-    def __init__(self, settings_manager: SettingsManager, parent: QWidget | None = None) -> None:
+    def __init__(
+        self,
+        settings_manager: SettingsManager,
+        project: Project,
+        parent: QWidget | None = None,
+    ) -> None:
+        self._project = project
+        self._overlap_check_thread: _OverlapCheckThread | None = None
         super().__init__(
             settings_manager=settings_manager, title="Project Settings", parent=parent
         )
@@ -244,6 +269,91 @@ class ProjectSettingsDialog(BaseSettingsDialog):
         self._settings_groups.append(cv_group)
         cache_format_group = CacheFormatSettingsGroup(parent)
         self._settings_groups.append(cache_format_group)
+
+    def _on_save(self) -> None:
+        """Save settings, with mode-change warnings when the classifier mode changes.
+
+        - Binary -> Multi-class: validates labels are mutually exclusive, then
+          warns that Not Behavior labels will be inactive but preserved.
+        - Multi-class -> Binary: warns that None labels will be inactive but preserved.
+        - No mode change: saves immediately.
+        """
+        all_new_settings: dict = {}
+        for group in self._settings_groups:
+            all_new_settings.update(group.get_values())
+
+        new_mode = all_new_settings.get(CLASSIFIER_MODE_KEY)
+        current_mode = self._settings_manager.classifier_mode
+
+        if new_mode == ClassifierMode.MULTICLASS and current_mode != ClassifierMode.MULTICLASS:
+            self._run_overlap_check()
+        elif new_mode == ClassifierMode.BINARY and current_mode != ClassifierMode.BINARY:
+            self._warn_and_save(ClassifierMode.BINARY)
+        else:
+            super()._on_save()
+
+    def _run_overlap_check(self) -> None:
+        """Validate mutual exclusivity in a background thread, then warn and save."""
+        progress = QProgressDialog(
+            "Validating labels are mutually exclusive for multi-class...", None, 0, 0, self
+        )
+        progress.setWindowTitle("Validating Settings")
+        progress.setWindowModality(Qt.WindowModality.WindowModal)
+        progress.setMinimumDuration(0)
+        progress.setValue(0)
+        progress.setCancelButton(None)
+
+        thread = _OverlapCheckThread(self._project)
+        self._overlap_check_thread = thread
+        current_mode = self._settings_manager.classifier_mode
+
+        def _on_check_complete(conflicting: list[str]) -> None:
+            progress.close()
+            if conflicting:
+                MessageDialog.warning(
+                    self,
+                    message=(
+                        "Cannot switch to multi-class mode. One or more videos have "
+                        "frames labeled with multiple behaviors simultaneously. "
+                        "Resolve overlapping labels before switching modes. "
+                        "See Details below for a complete list of videos."
+                    ),
+                    details="\n".join(conflicting),
+                )
+                for group in self._settings_groups:
+                    if isinstance(group, ClassifierModeSettingsGroup):
+                        group.set_values({CLASSIFIER_MODE_KEY: current_mode})
+            else:
+                self._warn_and_save(ClassifierMode.MULTICLASS)
+            thread.deleteLater()
+            self._overlap_check_thread = None
+
+        thread.check_complete.connect(_on_check_complete)
+        thread.start()
+
+    def _warn_and_save(self, new_mode: ClassifierMode) -> None:
+        """Inform the user that inactive labels are preserved, then save."""
+        if new_mode == ClassifierMode.MULTICLASS:
+            message = (
+                "Not Behavior labels will not be used in multi-class mode. "
+                "They will be preserved and restored if you switch back to binary mode. "
+                "Continue?"
+            )
+        else:
+            message = (
+                "None labels will not be used in binary mode. "
+                "They will be preserved and restored if you switch back to multi-class mode. "
+                "Continue?"
+            )
+
+        if not MessageDialog.confirm(self, message=message):
+            current_mode = self._settings_manager.classifier_mode
+            for group in self._settings_groups:
+                if isinstance(group, ClassifierModeSettingsGroup):
+                    group.set_values({CLASSIFIER_MODE_KEY: current_mode})
+            return
+
+        BaseSettingsDialog._on_save(self)
 
 
 class PostprocessingSettingsDialog(BaseSettingsDialog):

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -315,11 +315,11 @@ def test_overlapping_labels_conflict_detected(tmp_path: Path) -> None:
     assert project.get_overlapping_behavior_label_videos() == ["video1.avi"]
 
 
-def test_overlapping_labels_none_behavior_not_a_conflict(tmp_path: Path) -> None:
-    """A behavior and the None behavior sharing a frame is NOT a conflict.
+def test_overlapping_labels_none_behavior_is_a_conflict(tmp_path: Path) -> None:
+    """A behavior and the None behavior sharing a BEHAVIOR-labeled frame is a conflict.
 
-    None labels are dropped on mode transition anyway, so they are excluded
-    from overlap detection.
+    This keeps the validator consistent with MultiClassClassifier.merge_labels(),
+    which raises ValueError for the same condition at training time.
     """
     labels = VideoLabels("video1.avi", 100)
     track_none = labels.get_track_labels("0", "None")
@@ -327,7 +327,7 @@ def test_overlapping_labels_none_behavior_not_a_conflict(tmp_path: Path) -> None
     track_walk = labels.get_track_labels("0", "Walk")
     track_walk.label_behavior(15, 25)  # overlaps frames 15-20 with None
     project = _make_project_with_mock_vm(tmp_path, {"video1.avi": labels})
-    assert project.get_overlapping_behavior_label_videos() == []
+    assert project.get_overlapping_behavior_label_videos() == ["video1.avi"]
 
 
 def test_overlapping_labels_multiple_videos_sorted(tmp_path: Path) -> None:

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -242,3 +242,112 @@ def test_rename_behavior_raises_if_new_name_exists(tmp_path) -> None:
     names = set(project.settings_manager.behavior_names)
     assert "Existing" in names
     assert "Old" in names
+
+
+# ---------------------------------------------------------------------------
+# get_overlapping_behavior_label_videos
+# ---------------------------------------------------------------------------
+
+
+def _make_project_with_mock_vm(tmp_path: Path, videos_and_labels: dict) -> Project:
+    """Return a Project whose VideoManager is replaced by a mock.
+
+    Args:
+        tmp_path: Temporary directory for the project.
+        videos_and_labels: Mapping of video filename → VideoLabels | None.
+    """
+    project = Project(
+        tmp_path,
+        enable_video_check=False,
+        enable_session_tracker=False,
+        validate_project_dir=False,
+    )
+    mock_vm = MagicMock()
+    mock_vm.videos = list(videos_and_labels.keys())
+    mock_vm.video_path.side_effect = lambda v: tmp_path / v
+    mock_vm.load_video_labels.side_effect = lambda v, pose: videos_and_labels[v]
+    project._video_manager = mock_vm
+    project.load_pose_est = MagicMock(return_value=MagicMock())
+    project.save_annotations = MagicMock()
+    return project
+
+
+def test_overlapping_labels_no_videos(tmp_path: Path) -> None:
+    """Returns empty list when the project has no videos."""
+    project = _make_project_with_mock_vm(tmp_path, {})
+    assert project.get_overlapping_behavior_label_videos() == []
+
+
+def test_overlapping_labels_none_labels(tmp_path: Path) -> None:
+    """Returns empty list when load_video_labels returns None."""
+    project = _make_project_with_mock_vm(tmp_path, {"video1.avi": None})
+    assert project.get_overlapping_behavior_label_videos() == []
+
+
+def test_overlapping_labels_single_behavior(tmp_path: Path) -> None:
+    """Single behavior per identity - no conflict possible."""
+    labels = VideoLabels("video1.avi", 100)
+    track = labels.get_track_labels("0", "Walk")
+    track.label_behavior(10, 20)
+    project = _make_project_with_mock_vm(tmp_path, {"video1.avi": labels})
+    assert project.get_overlapping_behavior_label_videos() == []
+
+
+def test_overlapping_labels_no_conflict(tmp_path: Path) -> None:
+    """Two behaviors on the same identity but on different frames - no conflict."""
+    labels = VideoLabels("video1.avi", 100)
+    track_a = labels.get_track_labels("0", "Walk")
+    track_a.label_behavior(10, 20)
+    track_b = labels.get_track_labels("0", "Run")
+    track_b.label_behavior(30, 40)
+    project = _make_project_with_mock_vm(tmp_path, {"video1.avi": labels})
+    assert project.get_overlapping_behavior_label_videos() == []
+
+
+def test_overlapping_labels_conflict_detected(tmp_path: Path) -> None:
+    """Two behaviors share a labeled frame on the same identity - conflict detected."""
+    labels = VideoLabels("video1.avi", 100)
+    track_a = labels.get_track_labels("0", "Walk")
+    track_a.label_behavior(10, 30)
+    track_b = labels.get_track_labels("0", "Run")
+    track_b.label_behavior(20, 40)  # overlaps frames 20-30
+    project = _make_project_with_mock_vm(tmp_path, {"video1.avi": labels})
+    assert project.get_overlapping_behavior_label_videos() == ["video1.avi"]
+
+
+def test_overlapping_labels_none_behavior_not_a_conflict(tmp_path: Path) -> None:
+    """A behavior and the None behavior sharing a frame is NOT a conflict.
+
+    None labels are dropped on mode transition anyway, so they are excluded
+    from overlap detection.
+    """
+    labels = VideoLabels("video1.avi", 100)
+    track_none = labels.get_track_labels("0", "None")
+    track_none.label_behavior(10, 20)
+    track_walk = labels.get_track_labels("0", "Walk")
+    track_walk.label_behavior(15, 25)  # overlaps frames 15-20 with None
+    project = _make_project_with_mock_vm(tmp_path, {"video1.avi": labels})
+    assert project.get_overlapping_behavior_label_videos() == []
+
+
+def test_overlapping_labels_multiple_videos_sorted(tmp_path: Path) -> None:
+    """Conflicting filenames are returned sorted."""
+
+    def _conflicting_labels(name: str) -> VideoLabels:
+        lbl = VideoLabels(name, 100)
+        lbl.get_track_labels("0", "Walk").label_behavior(10, 30)
+        lbl.get_track_labels("0", "Run").label_behavior(20, 40)
+        return lbl
+
+    clean = VideoLabels("aaa.avi", 100)
+    clean.get_track_labels("0", "Walk").label_behavior(10, 20)
+
+    project = _make_project_with_mock_vm(
+        tmp_path,
+        {
+            "zzz.avi": _conflicting_labels("zzz.avi"),
+            "aaa.avi": clean,
+            "mmm.avi": _conflicting_labels("mmm.avi"),
+        },
+    )
+    assert project.get_overlapping_behavior_label_videos() == ["mmm.avi", "zzz.avi"]

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
+from jabs.core.constants import MULTICLASS_NONE_BEHAVIOR
 from jabs.core.utils import hide_stderr
 from jabs.project import Project, VideoLabels
 
@@ -322,7 +323,7 @@ def test_overlapping_labels_none_behavior_is_a_conflict(tmp_path: Path) -> None:
     which raises ValueError for the same condition at training time.
     """
     labels = VideoLabels("video1.avi", 100)
-    track_none = labels.get_track_labels("0", "None")
+    track_none = labels.get_track_labels("0", MULTICLASS_NONE_BEHAVIOR)
     track_none.label_behavior(10, 20)
     track_walk = labels.get_track_labels("0", "Walk")
     track_walk.label_behavior(15, 25)  # overlaps frames 15-20 with None

--- a/tests/ui/test_settings_dialog.py
+++ b/tests/ui/test_settings_dialog.py
@@ -1,0 +1,66 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+try:
+    from PySide6.QtWidgets import QApplication
+
+    from jabs.ui.settings_dialog.settings_dialog import _OverlapCheckThread
+
+    SKIP_UI_TESTS = False
+    SKIP_REASON = None
+except ImportError as e:
+    SKIP_UI_TESTS = True
+    SKIP_REASON = f"Qt/UI dependencies not available: {e}"
+
+pytestmark = pytest.mark.skipif(
+    SKIP_UI_TESTS,
+    reason=SKIP_REASON if SKIP_UI_TESTS else "",
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def qapp():
+    """Ensure a QApplication exists for UI-related tests."""
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    yield app
+
+
+def test_overlap_check_thread_emits_complete() -> None:
+    """Successful overlap checks emit the conflicting video list."""
+    project = SimpleNamespace(
+        get_overlapping_behavior_label_videos=MagicMock(return_value=["video1.avi"])
+    )
+    emitted_results = []
+    emitted_errors = []
+
+    thread = _OverlapCheckThread(project)
+    thread.check_complete.connect(emitted_results.append)
+    thread.check_failed.connect(emitted_errors.append)
+
+    thread.run()
+
+    assert emitted_results == [["video1.avi"]]
+    assert emitted_errors == []
+
+
+def test_overlap_check_thread_emits_error_on_exception() -> None:
+    """Failed overlap checks emit an error instead of silently ending the thread."""
+    expected_error = RuntimeError("pose load failed")
+    project = SimpleNamespace(
+        get_overlapping_behavior_label_videos=MagicMock(side_effect=expected_error)
+    )
+    emitted_results = []
+    emitted_errors = []
+
+    thread = _OverlapCheckThread(project)
+    thread.check_complete.connect(emitted_results.append)
+    thread.check_failed.connect(emitted_errors.append)
+
+    thread.run()
+
+    assert emitted_results == []
+    assert emitted_errors == [expected_error]


### PR DESCRIPTION
This pull request introduces a robust validation mechanism to ensure that, when switching a project to multi-class classification mode, no video contains overlapping behavior labels for the same identity and frame. The changes include both backend logic for detecting these overlaps and UI enhancements to warn users and block mode changes if conflicts exist. Comprehensive tests are also added to guarantee correct behavior.

A future enhancement could be to introduce a graphical conflict resolution strategy, but that is out of scope for this pull request. Instead, mode switching is blocked and the user is presented with a list of videos that contain conflicting behavior labels. 

**Validation and Conflict Detection for Multi-class Mode:**

* Added a `get_overlapping_behavior_label_videos` method to the `Project` class to scan all videos and identify those with frames labeled with multiple behaviors for the same identity. Returns a sorted list of conflicting video filenames.
* Introduced a background thread (`_OverlapCheckThread`) in the settings dialog to perform the overlap check asynchronously, keeping the UI responsive.

**User Interface Enhancements:**

* Updated the `ProjectSettingsDialog` to use the new overlap check when switching to multi-class mode. If conflicts are found, a warning dialog blocks the mode change and lists the problematic videos; otherwise, the user is warned about label preservation before proceeding.
* Modified the settings dialog instantiation to pass the `Project` object, enabling access to project-level validation methods. 

**Testing:**

* Added a suite of unit tests for `get_overlapping_behavior_label_videos`, covering edge cases (no videos, no labels, no conflicts, conflicts, multiple videos, and special handling for "None" behavior).

**Dependency and Import Updates:**

* Updated imports in relevant modules to support new functionality and dependencies, including constants, enums, and dialog components.