### PR TITLE
parallelize project load

### DIFF
--- a/src/jabs/pose_estimation/pose_est_v8.py
+++ b/src/jabs/pose_estimation/pose_est_v8.py
@@ -59,22 +59,11 @@ class PoseEstimationV8(PoseEstimationV7):
 
             bboxes = ds[:]
 
-            # Load identity mapping arrays, needed to reorganize bboxes by identity
+            # Load identity mapping arrays, needed to reorganize bboxes by identity.
+            # _num_identities was already set correctly by PoseEstimationV4.__init__
+            # via super().__init__(); no need to re-derive it here.
             instance_embed_id = pose_h5["poseest/instance_embed_id"][:]
             id_mask = pose_h5["poseest/id_mask"][:]
-
-            # Determine number of identities the same way v4 does: mask out invalids and take max
-            if instance_embed_id.shape[1] > 0:
-                valid = id_mask == 0
-                if valid.any():
-                    # instance_embed_id is 1-based; take max over valid entries
-                    self._num_identities = int(instance_embed_id[valid].max())
-                else:
-                    print(f"Warning: All identities masked in pose file: {self._path}")
-                    self._num_identities = 0
-            else:
-                print(f"Warning: No identities found in pose file: {self._path}")
-                self._num_identities = 0
 
             # Prepare an array grouped by identity, matching the v4 keypoint transform logic.
             # Shapes:

--- a/src/jabs/project/feature_manager.py
+++ b/src/jabs/project/feature_manager.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import jabs.feature_extraction as feature_extraction
 from jabs.core.enums import ProjectDistanceUnit
 from jabs.pose_estimation import (
@@ -10,6 +12,9 @@ from jabs.pose_estimation import (
 
 from .project_paths import ProjectPaths
 from .video_manager import VideoManager
+
+if TYPE_CHECKING:
+    from .parallel_workers import VideoScanResult
 
 
 class FeatureManager:
@@ -30,13 +35,14 @@ class FeatureManager:
         project_paths: ProjectPaths,
         videos: list[str],
         video_manager: VideoManager | None = None,
+        scan_results: "dict[str, VideoScanResult] | None" = None,
     ):
         """Initialize the FeatureManager."""
         self._lixit_keypoints = 0
 
         self._project_paths = project_paths
         self._video_manager = video_manager
-        self.__initialize_pose_data(videos)
+        self.__initialize_pose_data(videos, scan_results)
 
         # determine if this project can use social features or not
         # social data is available for V3+
@@ -47,14 +53,22 @@ class FeatureManager:
 
         self._extended_features = self.__initialize_extended_features()
 
-    def __initialize_pose_data(self, videos: list[str]):
+    def __initialize_pose_data(
+        self,
+        videos: list[str],
+        scan_results: "dict[str, VideoScanResult] | None" = None,
+    ) -> None:
         """Initialize pose version, static object, distance unit, and lixit data.
 
-        Consolidates all pose file metadata gathering into a single pass through videos
-        to minimize file I/O operations.
+        When ``scan_results`` is provided, all per-video HDF5 opens are skipped
+        and metadata is taken directly from the pre-loaded scan results.
+        Without scan results, each pose file is opened to collect the needed
+        metadata (legacy path).
 
         Args:
             videos: List of video filenames to process for metadata extraction.
+            scan_results: Pre-loaded per-video metadata from a parallel scan,
+                keyed by video filename. When provided, file I/O is skipped.
         """
         pose_versions = []
         static_object_sets = []
@@ -72,23 +86,29 @@ class FeatureManager:
                     self._project_paths.pose_dir,
                 )
 
-            # Get pose version
+            # Get pose version (filename regex — no I/O)
             pose_versions.append(get_pose_file_major_version(pose_path))
 
-            # Get static objects
-            static_objs = get_static_objects_in_file(pose_path)
-            static_object_sets.append(set(static_objs))
-
-            # Get lixit keypoints if lixit is present in this video
-            if "lixit" in static_objs:
-                lixit_keypoints.append(get_points_per_lixit(pose_path))
-
-            # Check distance unit - if any video lacks cm_per_pixel, use pixels
-            if distance_unit_valid:
-                attrs = PoseEstimation.get_pose_file_attributes(pose_path)
-                cm_per_pixel = attrs["poseest"].get("cm_per_pixel", None)
-                if cm_per_pixel is None:
+            if scan_results is not None and vid in scan_results:
+                # Use pre-loaded scan results to avoid redundant HDF5 opens.
+                result = scan_results[vid]
+                static_objs = result["static_objects"]
+                if "lixit" in static_objs:
+                    lixit_keypoints.append(result["lixit_keypoints"])
+                if distance_unit_valid and not result["has_cm_per_pixel"]:
                     distance_unit_valid = False
+            else:
+                # Fallback: open HDF5 files directly.
+                static_objs = get_static_objects_in_file(pose_path)
+                if "lixit" in static_objs:
+                    lixit_keypoints.append(get_points_per_lixit(pose_path))
+                if distance_unit_valid:
+                    attrs = PoseEstimation.get_pose_file_attributes(pose_path)
+                    cm_per_pixel = attrs["poseest"].get("cm_per_pixel", None)
+                    if cm_per_pixel is None:
+                        distance_unit_valid = False
+
+            static_object_sets.append(set(static_objs))
 
         # Set pose version to minimum across all videos
         self._min_pose_version = min(pose_versions) if pose_versions else 0

--- a/src/jabs/project/feature_manager.py
+++ b/src/jabs/project/feature_manager.py
@@ -22,9 +22,16 @@ class FeatureManager:
     units, and extended feature support, ensuring consistency across the project.
 
     Args:
-        project_paths (ProjectPaths): Paths object for the project.
-        videos (list[str]): List of video filenames in the project.
-        video_manager: Optional VideoManager instance to use for cached pose path lookups.
+        project_paths: Paths object for the project.
+        videos: List of video filenames in the project.
+        video_manager: Optional VideoManager instance used for cached pose path
+            lookups. When ``None``, pose paths are resolved directly from
+            ``project_paths``.
+        scan_results: Per-video metadata collected by
+            :func:`~jabs.project.parallel_workers.scan_video_metadata`, keyed
+            by video filename. Every entry in ``videos`` must have a
+            corresponding key. Required fields: ``static_objects``,
+            ``lixit_keypoints``, ``has_cm_per_pixel``.
     """
 
     def __init__(

--- a/src/jabs/project/feature_manager.py
+++ b/src/jabs/project/feature_manager.py
@@ -3,11 +3,8 @@ from typing import TYPE_CHECKING
 import jabs.feature_extraction as feature_extraction
 from jabs.core.enums import ProjectDistanceUnit
 from jabs.pose_estimation import (
-    PoseEstimation,
-    get_points_per_lixit,
     get_pose_file_major_version,
     get_pose_path,
-    get_static_objects_in_file,
 )
 
 from .project_paths import ProjectPaths
@@ -35,7 +32,8 @@ class FeatureManager:
         project_paths: ProjectPaths,
         videos: list[str],
         video_manager: VideoManager | None = None,
-        scan_results: "dict[str, VideoScanResult] | None" = None,
+        *,
+        scan_results: "dict[str, VideoScanResult]",
     ):
         """Initialize the FeatureManager."""
         self._lixit_keypoints = 0
@@ -56,19 +54,14 @@ class FeatureManager:
     def __initialize_pose_data(
         self,
         videos: list[str],
-        scan_results: "dict[str, VideoScanResult] | None" = None,
+        scan_results: "dict[str, VideoScanResult]",
     ) -> None:
         """Initialize pose version, static object, distance unit, and lixit data.
 
-        When ``scan_results`` is provided, all per-video HDF5 opens are skipped
-        and metadata is taken directly from the pre-loaded scan results.
-        Without scan results, each pose file is opened to collect the needed
-        metadata (legacy path).
-
         Args:
             videos: List of video filenames to process for metadata extraction.
-            scan_results: Pre-loaded per-video metadata from a parallel scan,
-                keyed by video filename. When provided, file I/O is skipped.
+            scan_results: Per-video metadata from the project scan, keyed by
+                video filename.
         """
         pose_versions = []
         static_object_sets = []
@@ -89,24 +82,12 @@ class FeatureManager:
             # Get pose version (filename regex — no I/O)
             pose_versions.append(get_pose_file_major_version(pose_path))
 
-            if scan_results is not None and vid in scan_results:
-                # Use pre-loaded scan results to avoid redundant HDF5 opens.
-                result = scan_results[vid]
-                static_objs = result["static_objects"]
-                if "lixit" in static_objs:
-                    lixit_keypoints.append(result["lixit_keypoints"])
-                if distance_unit_valid and not result["has_cm_per_pixel"]:
-                    distance_unit_valid = False
-            else:
-                # Fallback: open HDF5 files directly.
-                static_objs = get_static_objects_in_file(pose_path)
-                if "lixit" in static_objs:
-                    lixit_keypoints.append(get_points_per_lixit(pose_path))
-                if distance_unit_valid:
-                    attrs = PoseEstimation.get_pose_file_attributes(pose_path)
-                    cm_per_pixel = attrs["poseest"].get("cm_per_pixel", None)
-                    if cm_per_pixel is None:
-                        distance_unit_valid = False
+            result = scan_results[vid]
+            static_objs = result["static_objects"]
+            if "lixit" in static_objs:
+                lixit_keypoints.append(result["lixit_keypoints"])
+            if distance_unit_valid and not result["has_cm_per_pixel"]:
+                distance_unit_valid = False
 
             static_object_sets.append(set(static_objs))
 

--- a/src/jabs/project/parallel_workers.py
+++ b/src/jabs/project/parallel_workers.py
@@ -1,8 +1,8 @@
 """parallel_workers.py
 
 Provides stateless, picklable worker functions for parallel feature extraction
-across multiple videos. These functions are designed to
-be executed by ProcessPoolExecutor workers, managed by Project.get_labeled_features().
+and per-video metadata scanning. These functions are designed to
+be executed by ProcessPoolExecutor workers, managed by Project.
 """
 
 import json
@@ -12,12 +12,14 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 
+import h5py
 import numpy as np
 import pandas as pd
 
 import jabs.feature_extraction as fe
 from jabs.core.enums import CacheFormat
 from jabs.pose_estimation import open_pose_file
+from jabs.video_reader import VideoReader
 from jabs.video_reader.utilities import get_fps
 
 from .track_labels import TrackLabels
@@ -54,6 +56,120 @@ class CollectFeatureLoadResult(TypedDict):
     window: list[pd.DataFrame]
     labels: list[np.ndarray]
     group_keys: list[tuple[str, int]]
+
+
+class VideoScanJobSpec(TypedDict):
+    """Specification for a single-video metadata scan job.
+
+    All fields needed by :func:`scan_video_metadata` to open one HDF5 file
+    and collect everything :class:`~jabs.project.video_manager.VideoManager`
+    and :class:`~jabs.project.feature_manager.FeatureManager` require at
+    project-load time.
+    """
+
+    video: str
+    video_path: Path
+    pose_path: Path
+    pose_major_version: int
+    scan_frame_counts: bool
+
+
+class VideoScanResult(TypedDict):
+    """Per-video metadata collected by :func:`scan_video_metadata`."""
+
+    video: str
+    hdf5_frame_count: int
+    video_frame_count: int | None
+    identity_count: int
+    static_objects: list[str]
+    lixit_keypoints: int
+    has_cm_per_pixel: bool
+
+
+def _get_identity_count(pose_h5: "h5py.File", major_version: int) -> int:
+    """Read identity count from an open HDF5 file without loading keypoint data.
+
+    Args:
+        pose_h5: Open h5py File object for a pose estimation HDF5 file.
+        major_version: Pose file major version (from filename).
+
+    Returns:
+        Number of identities encoded in the pose file.
+    """
+    if major_version <= 2:
+        return 1
+    pose_grp = pose_h5["poseest"]
+    if major_version == 3:
+        # Shape is (n_frames, n_instances, n_keypoints, 2); shape read only.
+        return pose_grp["points"].shape[1]
+    # V4+: prefer instance_id_center (shape attribute only, no data load).
+    if "instance_id_center" in pose_grp:
+        return pose_grp["instance_id_center"].shape[0]
+    # Fallback: compute max identity from instance_embed_id (smaller dataset).
+    if "instance_embed_id" in pose_grp and "id_mask" in pose_grp:
+        id_mask = pose_grp["id_mask"][:]
+        instance_embed_id = pose_grp["instance_embed_id"][:]
+        if instance_embed_id.shape[1] > 0:
+            valid = id_mask == 0
+            if valid.any():
+                return int(instance_embed_id[valid].max())
+    return 0
+
+
+def scan_video_metadata(job: VideoScanJobSpec) -> VideoScanResult:
+    """Collect per-video metadata by opening each HDF5 pose file exactly once.
+
+    Reads everything :class:`~jabs.project.video_manager.VideoManager` and
+    :class:`~jabs.project.feature_manager.FeatureManager` need at project-load
+    time — frame counts, identity count, static objects, lixit keypoints, and
+    distance-unit attributes — in a single ``h5py.File`` open.
+
+    This function is stateless and picklable so it can be dispatched to
+    :class:`~jabs.core.utils.process_pool_manager.ProcessPoolManager` workers.
+
+    Args:
+        job: Scan job specification, including paths and options.
+
+    Returns:
+        Per-video metadata collected from the pose HDF5 file (and optionally
+        the video file when ``scan_frame_counts`` is ``True``).
+    """
+    video = job["video"]
+    video_path = job["video_path"]
+    pose_path = job["pose_path"]
+    major_version = job["pose_major_version"]
+    scan_frame_counts = job["scan_frame_counts"]
+
+    with h5py.File(pose_path, "r") as pose_h5:
+        hdf5_frame_count: int = pose_h5["poseest"]["points"].shape[0]
+        identity_count: int = _get_identity_count(pose_h5, major_version)
+
+        # Static objects are only present in V5+.
+        static_objects: list[str] = []
+        if major_version >= 5 and "static_objects" in pose_h5:
+            static_objects = list(pose_h5["static_objects"].keys())
+
+        # Lixit keypoint count (0 if no lixit present).
+        lixit_keypoints: int = 0
+        if "lixit" in static_objects:
+            lixit_keypoints = 3 if pose_h5["static_objects"]["lixit"].ndim == 3 else 1
+
+        # Distance unit: check for cm_per_pixel in poseest group attributes.
+        has_cm_per_pixel: bool = pose_h5["poseest"].attrs.get("cm_per_pixel") is not None
+
+    video_frame_count: int | None = None
+    if scan_frame_counts:
+        video_frame_count = VideoReader.get_nframes_from_file(video_path)
+
+    return VideoScanResult(
+        video=video,
+        hdf5_frame_count=hdf5_frame_count,
+        video_frame_count=video_frame_count,
+        identity_count=identity_count,
+        static_objects=static_objects,
+        lixit_keypoints=lixit_keypoints,
+        has_cm_per_pixel=has_cm_per_pixel,
+    )
 
 
 def _load_video_labels(annotations_path: Path, pose_est: "PoseEstimation") -> VideoLabels | None:

--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -18,10 +18,21 @@ import pandas as pd
 import jabs.feature_extraction as fe
 from jabs.core.constants import CACHE_FORMAT_KEY
 from jabs.core.enums import CacheFormat, CrossValidationGroupingStrategy, ProjectDistanceUnit
-from jabs.pose_estimation import PoseEstimation, open_pose_file
+from jabs.pose_estimation import (
+    PoseEstimation,
+    get_pose_file_major_version,
+    get_pose_path,
+    open_pose_file,
+)
 
 from .feature_manager import FeatureManager
-from .parallel_workers import FeatureLoadJobSpec, collect_labeled_features
+from .parallel_workers import (
+    FeatureLoadJobSpec,
+    VideoScanJobSpec,
+    VideoScanResult,
+    collect_labeled_features,
+    scan_video_metadata,
+)
 from .prediction_manager import PredictionManager
 from .project_paths import ProjectPaths
 from .project_utils import to_safe_name
@@ -104,9 +115,15 @@ class Project:
         is_new_project = not self._paths.project_file.exists()
 
         self._settings_manager = SettingsManager(self._paths)
-        self._video_manager = VideoManager(self._paths, self._settings_manager, enable_video_check)
+        scan_results = self._run_video_scan(enable_video_check, process_pool)
+        self._video_manager = VideoManager(
+            self._paths, self._settings_manager, enable_video_check, scan_results=scan_results
+        )
         self._feature_manager = FeatureManager(
-            self._paths, self._video_manager.videos, self._video_manager
+            self._paths,
+            self._video_manager.videos,
+            self._video_manager,
+            scan_results=scan_results,
         )
         self._prediction_manager = PredictionManager(self)
         self._session_tracker = SessionTracker(self, tracking_enabled=enable_session_tracker)
@@ -130,6 +147,68 @@ class Project:
         # Since the session has a reference to the Project, the Project should be fully initialized before starting
         # the session tracker.
         self._session_tracker.start_session()
+
+    def _run_video_scan(
+        self,
+        enable_video_check: bool,
+        process_pool: "ProcessPoolManager | None",
+    ) -> dict[str, VideoScanResult]:
+        """Collect per-video metadata via a parallel scan of all pose HDF5 files.
+
+        Discovers videos and their pose files, then dispatches one
+        :func:`~jabs.project.parallel_workers.scan_video_metadata` worker per
+        video. Workers open each HDF5 file exactly once and return everything
+        :class:`VideoManager` and :class:`FeatureManager` need at load time.
+
+        When ``process_pool`` is ``None`` (e.g. CLI scripts), workers run
+        sequentially — still reduces HDF5 opens compared to the legacy path.
+
+        Videos whose pose file cannot be located are skipped here;
+        :class:`VideoManager` will raise the appropriate error during its own
+        ``_validate_pose_files`` check.
+
+        Args:
+            enable_video_check: When ``True``, workers also read video frame
+                counts (mirrors the ``enable_video_check`` flag).
+            process_pool: Optional shared process pool for parallel execution.
+
+        Returns:
+            Mapping from video filename to scan result.
+        """
+        videos = sorted(VideoManager.get_videos(self._paths.video_dir))
+        jobs: list[VideoScanJobSpec] = []
+        for video in videos:
+            video_path = self._paths.video_dir / video
+            try:
+                pose_path = get_pose_path(video_path, self._paths.pose_dir)
+            except ValueError:
+                # Missing pose file — VideoManager._validate_pose_files will report it.
+                continue
+            major_version = get_pose_file_major_version(pose_path)
+            jobs.append(
+                VideoScanJobSpec(
+                    video=video,
+                    video_path=video_path,
+                    pose_path=pose_path,
+                    pose_major_version=major_version,
+                    scan_frame_counts=enable_video_check,
+                )
+            )
+
+        if not jobs:
+            return {}
+
+        if process_pool is not None:
+            future_to_video = {
+                process_pool.submit(scan_video_metadata, job): job["video"] for job in jobs
+            }
+            results: dict[str, VideoScanResult] = {}
+            for future in as_completed(future_to_video):
+                result: VideoScanResult = future.result()
+                results[result["video"]] = result
+            return results
+
+        return {job["video"]: scan_video_metadata(job) for job in jobs}
 
     def _validate_pose_files(self):
         """Ensure all videos have corresponding pose files."""

--- a/src/jabs/project/settings_manager.py
+++ b/src/jabs/project/settings_manager.py
@@ -111,11 +111,8 @@ class SettingsManager:
 
         Returns:
             Dictionary of metadata for the specified video, or empty dict if none exists.
-
-        Raises:
-            KeyError: If the specified video is not found in the project.
         """
-        return self._project_info["video_files"][video].get("metadata", {})
+        return self._project_info.get("video_files", {}).get(video, {}).get("metadata", {})
 
     def remove_video_from_project_file(self, video_name: str, sync=True) -> None:
         """Remove a video entry from the project if it exists.

--- a/src/jabs/project/video_manager.py
+++ b/src/jabs/project/video_manager.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from jabs.pose_estimation import (
     PoseEstimation,
@@ -13,6 +14,9 @@ from jabs.video_reader import VideoReader
 from .project_paths import ProjectPaths
 from .settings_manager import SettingsManager
 from .video_labels import VideoLabels
+
+if TYPE_CHECKING:
+    from .parallel_workers import VideoScanResult
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +41,7 @@ class VideoManager:
         paths: ProjectPaths,
         settings_manager: SettingsManager,
         enable_video_check: bool = True,
+        scan_results: "dict[str, VideoScanResult] | None" = None,
     ):
         self._paths = paths
         self._settings_manager = settings_manager
@@ -45,18 +50,22 @@ class VideoManager:
         self._total_project_identities = 0
         self._pose_path_cache = {}  # Cache mapping video names to their pose file paths to avoid repeated lookups
 
-        self._initialize_videos(enable_video_check)
+        self._initialize_videos(enable_video_check, scan_results)
 
-    def _initialize_videos(self, enable_video_check):
+    def _initialize_videos(
+        self,
+        enable_video_check: bool,
+        scan_results: "dict[str, VideoScanResult] | None" = None,
+    ) -> None:
         """Initialize video-related data and perform checks."""
         self._videos = self.get_videos(self._paths.video_dir)
         self._videos.sort()
 
         self._validate_pose_files()
         if enable_video_check:
-            self._validate_video_frame_counts()
+            self._validate_video_frame_counts(scan_results)
 
-        self._load_video_metadata()
+        self._load_video_metadata(scan_results)
 
     @property
     def videos(self):
@@ -165,8 +174,28 @@ class VideoManager:
             self._pose_path_cache[video_name] = get_pose_path(video_path, self._paths.pose_dir)
         return self._pose_path_cache[video_name]
 
-    def _load_video_metadata(self):
-        """Load metadata for each video and calculate total identities."""
+    def _load_video_metadata(
+        self, scan_results: "dict[str, VideoScanResult] | None" = None
+    ) -> None:
+        """Load metadata for each video and calculate total identities.
+
+        When ``scan_results`` is provided, identity counts are read directly
+        from the pre-loaded scan data with no file I/O. Without scan results,
+        the legacy path reads from ``project.json`` (cached) or opens each
+        pose file as a fallback.
+
+        Args:
+            scan_results: Pre-loaded per-video metadata from a parallel scan,
+                keyed by video filename. When provided, file I/O is skipped.
+        """
+        if scan_results is not None:
+            for video in self._videos:
+                nidentities = scan_results[video]["identity_count"]
+                self._video_identity_count[video] = nidentities
+                self._total_project_identities += nidentities
+            return
+
+        # Legacy fallback: read from project.json or open pose file.
         video_metadata = self._settings_manager.project_settings.get("video_files", {})
         flush = False
         for video in self._videos:
@@ -185,13 +214,28 @@ class VideoManager:
         if flush:
             self._settings_manager.save_project_file({"video_files": video_metadata})
 
-    def _validate_video_frame_counts(self):
-        """Ensure video and pose file frame counts match."""
+    def _validate_video_frame_counts(
+        self, scan_results: "dict[str, VideoScanResult] | None" = None
+    ) -> None:
+        """Ensure video and pose file frame counts match.
+
+        When ``scan_results`` is provided, frame counts are taken from the
+        pre-loaded scan data with no file I/O. Without scan results, each
+        pose HDF5 and video file is opened to read frame counts.
+
+        Args:
+            scan_results: Pre-loaded per-video metadata from a parallel scan,
+                keyed by video filename. When provided, file I/O is skipped.
+        """
         err = False
         for v in self._videos:
-            path = self.get_cached_pose_path(v)
-            pose_frames = get_frames_from_file(path)
-            vid_frames = VideoReader.get_nframes_from_file(self.video_path(v))
+            if scan_results is not None and v in scan_results:
+                pose_frames = scan_results[v]["hdf5_frame_count"]
+                vid_frames = scan_results[v]["video_frame_count"]
+            else:
+                path = self.get_cached_pose_path(v)
+                pose_frames = get_frames_from_file(path)
+                vid_frames = VideoReader.get_nframes_from_file(self.video_path(v))
             if pose_frames != vid_frames:
                 logger.error(
                     "%s: video and pose file have different number of frames (video=%s, pose=%s)",

--- a/src/jabs/project/video_manager.py
+++ b/src/jabs/project/video_manager.py
@@ -29,9 +29,18 @@ class VideoManager:
     information required for project processing.
 
     Args:
-        paths (ProjectPaths): Object containing project directory paths.
-        settings_manager (SettingsManager): Manages project settings and metadata.
-        enable_video_check (bool, optional): Whether to validate video frame counts. Defaults to True.
+        paths: Object containing project directory paths.
+        settings_manager: Manages project settings and metadata.
+        enable_video_check: Whether to validate that video and pose file frame
+            counts match. Defaults to True.
+        scan_results: Per-video metadata collected by
+            :func:`~jabs.project.parallel_workers.scan_video_metadata`, keyed
+            by video filename. Every video in the project directory must have an
+            entry. Required fields for all callers: ``identity_count``,
+            ``hdf5_frame_count``, ``static_objects``, ``lixit_keypoints``,
+            ``has_cm_per_pixel``. When ``enable_video_check=True``,
+            ``video_frame_count`` must also be populated (i.e. the scan job
+            must have been run with ``scan_frame_counts=True``).
     """
 
     def __init__(
@@ -197,6 +206,11 @@ class VideoManager:
         for v in self._videos:
             pose_frames = scan_results[v]["hdf5_frame_count"]
             vid_frames = scan_results[v]["video_frame_count"]
+            if vid_frames is None:
+                raise ValueError(
+                    f"{v}: video_frame_count is missing from scan_results — "
+                    "re-run the scan with scan_frame_counts=True"
+                )
             if pose_frames != vid_frames:
                 logger.error(
                     "%s: video and pose file have different number of frames (video=%s, pose=%s)",

--- a/src/jabs/project/video_manager.py
+++ b/src/jabs/project/video_manager.py
@@ -5,11 +5,9 @@ from typing import TYPE_CHECKING
 
 from jabs.pose_estimation import (
     PoseEstimation,
-    get_frames_from_file,
     get_pose_path,
     open_pose_file,
 )
-from jabs.video_reader import VideoReader
 
 from .project_paths import ProjectPaths
 from .settings_manager import SettingsManager
@@ -41,7 +39,8 @@ class VideoManager:
         paths: ProjectPaths,
         settings_manager: SettingsManager,
         enable_video_check: bool = True,
-        scan_results: "dict[str, VideoScanResult] | None" = None,
+        *,
+        scan_results: "dict[str, VideoScanResult]",
     ):
         self._paths = paths
         self._settings_manager = settings_manager
@@ -55,7 +54,7 @@ class VideoManager:
     def _initialize_videos(
         self,
         enable_video_check: bool,
-        scan_results: "dict[str, VideoScanResult] | None" = None,
+        scan_results: "dict[str, VideoScanResult]",
     ) -> None:
         """Initialize video-related data and perform checks."""
         self._videos = self.get_videos(self._paths.video_dir)
@@ -174,68 +173,30 @@ class VideoManager:
             self._pose_path_cache[video_name] = get_pose_path(video_path, self._paths.pose_dir)
         return self._pose_path_cache[video_name]
 
-    def _load_video_metadata(
-        self, scan_results: "dict[str, VideoScanResult] | None" = None
-    ) -> None:
-        """Load metadata for each video and calculate total identities.
-
-        When ``scan_results`` is provided, identity counts are read directly
-        from the pre-loaded scan data with no file I/O. Without scan results,
-        the legacy path reads from ``project.json`` (cached) or opens each
-        pose file as a fallback.
+    def _load_video_metadata(self, scan_results: "dict[str, VideoScanResult]") -> None:
+        """Load identity counts from pre-scanned metadata.
 
         Args:
-            scan_results: Pre-loaded per-video metadata from a parallel scan,
-                keyed by video filename. When provided, file I/O is skipped.
+            scan_results: Per-video metadata from the project scan, keyed by
+                video filename.
         """
-        if scan_results is not None:
-            for video in self._videos:
-                nidentities = scan_results[video]["identity_count"]
-                self._video_identity_count[video] = nidentities
-                self._total_project_identities += nidentities
-            return
-
-        # Legacy fallback: read from project.json or open pose file.
-        video_metadata = self._settings_manager.project_settings.get("video_files", {})
-        flush = False
         for video in self._videos:
-            vinfo = video_metadata.get(video, {})
-            nidentities = vinfo.get("identities")
-
-            if not nidentities:
-                pose_file = open_pose_file(self.get_cached_pose_path(video), self._paths.cache_dir)
-                nidentities = pose_file.num_identities
-                vinfo["identities"] = nidentities
-                flush = True
-
+            nidentities = scan_results[video]["identity_count"]
             self._video_identity_count[video] = nidentities
             self._total_project_identities += nidentities
-            video_metadata[video] = vinfo
-        if flush:
-            self._settings_manager.save_project_file({"video_files": video_metadata})
 
-    def _validate_video_frame_counts(
-        self, scan_results: "dict[str, VideoScanResult] | None" = None
-    ) -> None:
+    def _validate_video_frame_counts(self, scan_results: "dict[str, VideoScanResult]") -> None:
         """Ensure video and pose file frame counts match.
 
-        When ``scan_results`` is provided, frame counts are taken from the
-        pre-loaded scan data with no file I/O. Without scan results, each
-        pose HDF5 and video file is opened to read frame counts.
-
         Args:
-            scan_results: Pre-loaded per-video metadata from a parallel scan,
-                keyed by video filename. When provided, file I/O is skipped.
+            scan_results: Per-video metadata from the project scan, keyed by
+                video filename. Must include ``hdf5_frame_count`` and
+                ``video_frame_count`` (i.e. scanned with ``scan_frame_counts=True``).
         """
         err = False
         for v in self._videos:
-            if scan_results is not None and v in scan_results:
-                pose_frames = scan_results[v]["hdf5_frame_count"]
-                vid_frames = scan_results[v]["video_frame_count"]
-            else:
-                path = self.get_cached_pose_path(v)
-                pose_frames = get_frames_from_file(path)
-                vid_frames = VideoReader.get_nframes_from_file(self.video_path(v))
+            pose_frames = scan_results[v]["hdf5_frame_count"]
+            vid_frames = scan_results[v]["video_frame_count"]
             if pose_frames != vid_frames:
                 logger.error(
                     "%s: video and pose file have different number of frames (video=%s, pose=%s)",

--- a/tests/project/test_parallel_workers.py
+++ b/tests/project/test_parallel_workers.py
@@ -1,0 +1,325 @@
+"""Tests for parallel_workers — scan_video_metadata and _get_identity_count."""
+
+import shutil
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from jabs.project.parallel_workers import (
+    VideoScanJobSpec,
+    VideoScanResult,
+    _get_identity_count,
+    scan_video_metadata,
+)
+
+
+def _h5_like(pose_grp_dict: dict) -> dict:
+    """Wrap a pose group dict in a minimal h5-like file dict."""
+    return {"poseest": pose_grp_dict}
+
+
+class TestGetIdentityCount:
+    """Tests for _get_identity_count."""
+
+    def test_v2_always_returns_one(self):
+        """V2 is single-identity regardless of HDF5 contents."""
+        assert _get_identity_count(_h5_like({}), major_version=2) == 1
+
+    def test_v1_returns_one(self):
+        """Any version below 3 returns 1."""
+        assert _get_identity_count(_h5_like({}), major_version=1) == 1
+
+    def test_v3_uses_points_shape(self):
+        """V3 reads identity count from points.shape[1]."""
+        points_mock = MagicMock()
+        points_mock.shape = (500, 3, 12, 2)
+        pose_grp = {"points": points_mock}
+        assert _get_identity_count(_h5_like(pose_grp), major_version=3) == 3
+
+    def test_v4_uses_instance_id_center(self):
+        """V4+ with instance_id_center reads identity count from its shape[0]."""
+        id_center_mock = MagicMock()
+        id_center_mock.shape = (4,)
+        pose_grp = {"instance_id_center": id_center_mock}
+        assert _get_identity_count(_h5_like(pose_grp), major_version=4) == 4
+
+    def test_v5_uses_instance_id_center(self):
+        """V5 behaves the same as V4 when instance_id_center is present."""
+        id_center_mock = MagicMock()
+        id_center_mock.shape = (2,)
+        pose_grp = {"instance_id_center": id_center_mock}
+        assert _get_identity_count(_h5_like(pose_grp), major_version=5) == 2
+
+    def test_v4_fallback_no_instance_id_center_returns_zero(self):
+        """V4+ without instance_id_center or embed_id data returns 0."""
+        assert _get_identity_count(_h5_like({}), major_version=4) == 0
+
+    def test_v4_fallback_embed_id(self):
+        """V4+ without instance_id_center falls back to instance_embed_id max."""
+        id_mask = np.array([[0, 0], [0, 1]])  # 0 = valid
+        embed_id = np.array([[1, 2], [1, 0]])  # 1-based; max valid = 2
+        embed_mock = MagicMock()
+        embed_mock.shape = embed_id.shape
+        embed_mock.__getitem__ = lambda self_inner, s: embed_id[s]
+        embed_mock[...] = embed_id
+
+        id_mask_mock = MagicMock()
+        id_mask_mock.__getitem__ = lambda self_inner, s: id_mask[s]
+        id_mask_mock[...] = id_mask
+
+        pose_grp = {"instance_embed_id": embed_id, "id_mask": id_mask}
+        assert _get_identity_count(_h5_like(pose_grp), major_version=4) == 2
+
+
+# ---------------------------------------------------------------------------
+# scan_video_metadata — integration test with real pose files
+# ---------------------------------------------------------------------------
+
+DATA_DIR = Path(__file__).parent.parent / "data"
+
+
+@pytest.mark.parametrize(
+    ("pose_filename", "expected_major_version"),
+    [
+        ("sample_pose_est_v3.h5", 3),
+        ("sample_pose_est_v6.h5", 6),
+    ],
+)
+def test_scan_video_metadata_returns_correct_types(
+    tmp_path, pose_filename, expected_major_version
+):
+    """scan_video_metadata returns a VideoScanResult with correct field types."""
+    pose_src = DATA_DIR / pose_filename
+    if not pose_src.exists():
+        pytest.skip(f"Test data file not found: {pose_filename}")
+
+    video_name = "test_video.mp4"
+    video_path = tmp_path / video_name
+    video_path.touch()
+    pose_path = tmp_path / pose_filename
+    shutil.copy(pose_src, pose_path)
+
+    job = VideoScanJobSpec(
+        video=video_name,
+        video_path=video_path,
+        pose_path=pose_path,
+        pose_major_version=expected_major_version,
+        scan_frame_counts=False,
+    )
+
+    result = scan_video_metadata(job)
+
+    assert result["video"] == video_name
+    assert isinstance(result["hdf5_frame_count"], int)
+    assert result["hdf5_frame_count"] > 0
+    assert result["video_frame_count"] is None  # scan_frame_counts=False
+    assert isinstance(result["identity_count"], int)
+    assert result["identity_count"] >= 0
+    assert isinstance(result["static_objects"], list)
+    assert isinstance(result["lixit_keypoints"], int)
+    assert isinstance(result["has_cm_per_pixel"], bool)
+
+
+def test_scan_video_metadata_static_objects_v3(tmp_path):
+    """V3 pose files have no static objects (feature is V5+)."""
+    pose_src = DATA_DIR / "sample_pose_est_v3.h5"
+    if not pose_src.exists():
+        pytest.skip("V3 test data file not found")
+
+    video_path = tmp_path / "vid.mp4"
+    video_path.touch()
+    pose_path = tmp_path / "vid_pose_est_v3.h5"
+    shutil.copy(pose_src, pose_path)
+
+    job = VideoScanJobSpec(
+        video="vid.mp4",
+        video_path=video_path,
+        pose_path=pose_path,
+        pose_major_version=3,
+        scan_frame_counts=False,
+    )
+    result = scan_video_metadata(job)
+
+    assert result["static_objects"] == []
+    assert result["lixit_keypoints"] == 0
+
+
+# ---------------------------------------------------------------------------
+# VideoManager with pre-loaded scan_results — no I/O for metadata/frame check
+# ---------------------------------------------------------------------------
+
+
+def test_video_manager_with_scan_results_no_pose_open(tmp_path):
+    """VideoManager._load_video_metadata uses scan_results without opening pose files."""
+    from jabs.project.project_paths import ProjectPaths
+    from jabs.project.settings_manager import SettingsManager
+    from jabs.project.video_manager import VideoManager
+
+    paths = ProjectPaths(base_path=tmp_path)
+    paths.create_directories(validate=False)
+
+    data_dir = Path(__file__).parent.parent / "data"
+    (tmp_path / "video1.avi").touch()
+    shutil.copy(data_dir / "sample_pose_est_v3.h5", tmp_path / "video1_pose_est_v3.h5")
+
+    sm = SettingsManager(paths)
+
+    scan_results: dict[str, VideoScanResult] = {
+        "video1.avi": VideoScanResult(
+            video="video1.avi",
+            hdf5_frame_count=100,
+            video_frame_count=None,
+            identity_count=2,
+            static_objects=[],
+            lixit_keypoints=0,
+            has_cm_per_pixel=False,
+        )
+    }
+
+    with patch("jabs.project.video_manager.open_pose_file") as mock_open:
+        vm = VideoManager(paths, sm, enable_video_check=False, scan_results=scan_results)
+
+    mock_open.assert_not_called()
+    assert vm.get_video_identity_count("video1.avi") == 2
+    assert vm.total_project_identities == 2
+
+
+def test_video_manager_with_scan_results_frame_count_validation(tmp_path):
+    """VideoManager._validate_video_frame_counts uses scan_results frame counts."""
+    from jabs.project.project_paths import ProjectPaths
+    from jabs.project.settings_manager import SettingsManager
+    from jabs.project.video_manager import VideoManager
+
+    paths = ProjectPaths(base_path=tmp_path)
+    paths.create_directories(validate=False)
+
+    data_dir = Path(__file__).parent.parent / "data"
+    (tmp_path / "video1.avi").touch()
+    shutil.copy(data_dir / "sample_pose_est_v3.h5", tmp_path / "video1_pose_est_v3.h5")
+
+    sm = SettingsManager(paths)
+    scan_results: dict[str, VideoScanResult] = {
+        "video1.avi": VideoScanResult(
+            video="video1.avi",
+            hdf5_frame_count=100,
+            video_frame_count=100,
+            identity_count=1,
+            static_objects=[],
+            lixit_keypoints=0,
+            has_cm_per_pixel=True,
+        )
+    }
+
+    with (
+        patch("jabs.project.video_manager.get_frames_from_file") as mock_hdf5,
+        patch("jabs.project.video_manager.VideoReader.get_nframes_from_file") as mock_vid,
+    ):
+        vm = VideoManager(paths, sm, enable_video_check=True, scan_results=scan_results)
+
+    mock_hdf5.assert_not_called()
+    mock_vid.assert_not_called()
+    assert vm.videos == ["video1.avi"]
+
+
+def test_video_manager_scan_results_frame_mismatch_raises(tmp_path):
+    """Frame count mismatch in scan_results triggers ValueError."""
+    from jabs.project.project_paths import ProjectPaths
+    from jabs.project.settings_manager import SettingsManager
+    from jabs.project.video_manager import VideoManager
+
+    paths = ProjectPaths(base_path=tmp_path)
+    paths.create_directories(validate=False)
+
+    data_dir = Path(__file__).parent.parent / "data"
+    (tmp_path / "video1.avi").touch()
+    shutil.copy(data_dir / "sample_pose_est_v3.h5", tmp_path / "video1_pose_est_v3.h5")
+
+    sm = SettingsManager(paths)
+    scan_results: dict[str, VideoScanResult] = {
+        "video1.avi": VideoScanResult(
+            video="video1.avi",
+            hdf5_frame_count=100,
+            video_frame_count=99,  # mismatch
+            identity_count=1,
+            static_objects=[],
+            lixit_keypoints=0,
+            has_cm_per_pixel=True,
+        )
+    }
+
+    with pytest.raises(ValueError, match="frame counts differ"):
+        VideoManager(paths, sm, enable_video_check=True, scan_results=scan_results)
+
+
+# ---------------------------------------------------------------------------
+# FeatureManager with pre-loaded scan_results — no HDF5 opens
+# ---------------------------------------------------------------------------
+
+
+def test_feature_manager_with_scan_results_no_hdf5_open(tmp_path):
+    """FeatureManager.__initialize_pose_data skips HDF5 opens when scan_results provided."""
+    from jabs.project.feature_manager import FeatureManager
+    from jabs.project.project_paths import ProjectPaths
+
+    paths = ProjectPaths(base_path=tmp_path)
+    paths.create_directories(validate=False)
+
+    data_dir = Path(__file__).parent.parent / "data"
+    (tmp_path / "video1.avi").touch()
+    shutil.copy(data_dir / "sample_pose_est_v3.h5", tmp_path / "video1_pose_est_v3.h5")
+
+    scan_results: dict[str, VideoScanResult] = {
+        "video1.avi": VideoScanResult(
+            video="video1.avi",
+            hdf5_frame_count=100,
+            video_frame_count=None,
+            identity_count=3,
+            static_objects=[],
+            lixit_keypoints=0,
+            has_cm_per_pixel=True,
+        )
+    }
+
+    with (
+        patch("jabs.project.feature_manager.get_static_objects_in_file") as mock_so,
+        patch("jabs.project.feature_manager.get_points_per_lixit") as mock_lixit,
+        patch(
+            "jabs.project.feature_manager.PoseEstimation.get_pose_file_attributes"
+        ) as mock_attrs,
+    ):
+        fm = FeatureManager(paths, ["video1.avi"], scan_results=scan_results)
+
+    mock_so.assert_not_called()
+    mock_lixit.assert_not_called()
+    mock_attrs.assert_not_called()
+    assert fm.is_cm_unit
+
+
+def test_feature_manager_scan_results_no_cm_per_pixel(tmp_path):
+    """FeatureManager detects pixel-only project from scan_results."""
+    from jabs.project.feature_manager import FeatureManager
+    from jabs.project.project_paths import ProjectPaths
+
+    paths = ProjectPaths(base_path=tmp_path)
+    paths.create_directories(validate=False)
+
+    data_dir = Path(__file__).parent.parent / "data"
+    (tmp_path / "video1.avi").touch()
+    shutil.copy(data_dir / "sample_pose_est_v3.h5", tmp_path / "video1_pose_est_v3.h5")
+
+    scan_results: dict[str, VideoScanResult] = {
+        "video1.avi": VideoScanResult(
+            video="video1.avi",
+            hdf5_frame_count=100,
+            video_frame_count=None,
+            identity_count=1,
+            static_objects=[],
+            lixit_keypoints=0,
+            has_cm_per_pixel=False,
+        )
+    }
+
+    fm = FeatureManager(paths, ["video1.avi"], scan_results=scan_results)
+    assert not fm.is_cm_unit

--- a/tests/project/test_parallel_workers.py
+++ b/tests/project/test_parallel_workers.py
@@ -212,14 +212,7 @@ def test_video_manager_with_scan_results_frame_count_validation(tmp_path):
         )
     }
 
-    with (
-        patch("jabs.project.video_manager.get_frames_from_file") as mock_hdf5,
-        patch("jabs.project.video_manager.VideoReader.get_nframes_from_file") as mock_vid,
-    ):
-        vm = VideoManager(paths, sm, enable_video_check=True, scan_results=scan_results)
-
-    mock_hdf5.assert_not_called()
-    mock_vid.assert_not_called()
+    vm = VideoManager(paths, sm, enable_video_check=True, scan_results=scan_results)
     assert vm.videos == ["video1.avi"]
 
 
@@ -282,18 +275,7 @@ def test_feature_manager_with_scan_results_no_hdf5_open(tmp_path):
         )
     }
 
-    with (
-        patch("jabs.project.feature_manager.get_static_objects_in_file") as mock_so,
-        patch("jabs.project.feature_manager.get_points_per_lixit") as mock_lixit,
-        patch(
-            "jabs.project.feature_manager.PoseEstimation.get_pose_file_attributes"
-        ) as mock_attrs,
-    ):
-        fm = FeatureManager(paths, ["video1.avi"], scan_results=scan_results)
-
-    mock_so.assert_not_called()
-    mock_lixit.assert_not_called()
-    mock_attrs.assert_not_called()
+    fm = FeatureManager(paths, ["video1.avi"], scan_results=scan_results)
     assert fm.is_cm_unit
 
 

--- a/tests/project/test_parallel_workers.py
+++ b/tests/project/test_parallel_workers.py
@@ -60,14 +60,6 @@ class TestGetIdentityCount:
         """V4+ without instance_id_center falls back to instance_embed_id max."""
         id_mask = np.array([[0, 0], [0, 1]])  # 0 = valid
         embed_id = np.array([[1, 2], [1, 0]])  # 1-based; max valid = 2
-        embed_mock = MagicMock()
-        embed_mock.shape = embed_id.shape
-        embed_mock.__getitem__ = lambda self_inner, s: embed_id[s]
-        embed_mock[...] = embed_id
-
-        id_mask_mock = MagicMock()
-        id_mask_mock.__getitem__ = lambda self_inner, s: id_mask[s]
-        id_mask_mock[...] = id_mask
 
         pose_grp = {"instance_embed_id": embed_id, "id_mask": id_mask}
         assert _get_identity_count(_h5_like(pose_grp), major_version=4) == 2

--- a/tests/project/test_video_manager.py
+++ b/tests/project/test_video_manager.py
@@ -1,4 +1,3 @@
-import json
 import shutil
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -22,15 +21,6 @@ def project_paths(tmp_path):
 @pytest.fixture
 def settings_manager(project_paths):
     """Fixture to create a SettingsManager instance."""
-    # Create a project.json file with a "video_files" field
-    project_json_path = project_paths.project_file
-    video_files = {
-        "video1.avi": {"identities": 3},
-        "video2.mp4": {"identities": 5},
-    }
-    with project_json_path.open("w") as f:
-        json.dump({"video_files": video_files}, f)
-
     return SettingsManager(project_paths)
 
 
@@ -54,7 +44,29 @@ def video_manager(project_paths, settings_manager):
     shutil.copy(pose1_src, pose1_dst)
     shutil.copy(pose2_src, pose2_dst)
 
-    return VideoManager(project_paths, settings_manager, enable_video_check=False)
+    scan_results = {
+        "video1.avi": {
+            "video": "video1.avi",
+            "hdf5_frame_count": 100,
+            "video_frame_count": None,
+            "identity_count": 3,
+            "static_objects": [],
+            "lixit_keypoints": 0,
+            "has_cm_per_pixel": False,
+        },
+        "video2.mp4": {
+            "video": "video2.mp4",
+            "hdf5_frame_count": 100,
+            "video_frame_count": None,
+            "identity_count": 5,
+            "static_objects": [],
+            "lixit_keypoints": 0,
+            "has_cm_per_pixel": False,
+        },
+    }
+    return VideoManager(
+        project_paths, settings_manager, enable_video_check=False, scan_results=scan_results
+    )
 
 
 def test_get_videos(video_manager, project_paths):
@@ -100,15 +112,25 @@ def test_video_manager_uses_custom_video_and_pose_dirs(tmp_path):
     paths = ProjectPaths(base_path=project_root, video_dir=video_dir, pose_dir=pose_dir)
     paths.create_directories(validate=False)
 
-    with paths.project_file.open("w") as f:
-        json.dump({"video_files": {"video1.avi": {"identities": 2}}}, f)
-
     (video_dir / "video1.avi").touch()
 
     data_dir = Path(__file__).parent.parent / "data"
     shutil.copy(data_dir / "sample_pose_est_v6.h5", pose_dir / "video1_pose_est_v6.h5")
 
-    manager = VideoManager(paths, SettingsManager(paths), enable_video_check=False)
+    scan_results = {
+        "video1.avi": {
+            "video": "video1.avi",
+            "hdf5_frame_count": 100,
+            "video_frame_count": None,
+            "identity_count": 2,
+            "static_objects": [],
+            "lixit_keypoints": 0,
+            "has_cm_per_pixel": False,
+        },
+    }
+    manager = VideoManager(
+        paths, SettingsManager(paths), enable_video_check=False, scan_results=scan_results
+    )
 
     assert manager.videos == ["video1.avi"]
     assert manager.video_path("video1.avi") == video_dir / "video1.avi"


### PR DESCRIPTION
## Parallelize project loading; remove per-video sequential HDF5 scans

### Problem

Opening a project in the GUI performed O(N) sequential file I/O operations for every video in the
project — three independent serial loops, each opening the same HDF5 pose files:

**Loop 1 — `VideoManager._validate_video_frame_counts()`**
Called on every GUI project open (`enable_video_check=True`). For each video, it opened the pose
HDF5 file to read `poseest/points.shape[0]` and also opened the video file via OpenCV to read the
frame count. These N pairs of file opens happened one at a time, blocking project load for the full
duration.

**Loop 2 — `FeatureManager.__initialize_pose_data()`**
Also ran on every open. For each video, it opened the pose HDF5 file *2–3 additional times* in
separate `with h5py.File(...)` calls:
- `get_static_objects_in_file()` — one open
- `get_points_per_lixit()` — a second open (if lixit present)
- `PoseEstimation.get_pose_file_attributes()` — a third open for `cm_per_pixel`

**Loop 3 — `VideoManager._load_video_metadata()`**
On first open, this created a full `PoseEstimation` object per video to read `num_identities`.
That constructor loads the entire keypoints array into memory (all frames × all keypoints × 2
coordinates), then discards the object after reading one number. For V6 files this also loads all
segmentation data. After first open, the result was cached under
`video_files[video]["identities"]` in `project.json` — but the FeatureManager loops still ran
regardless.

**The stale-cache problem with `video_files.identities`**
The `project.json` caching of identity counts was also fragile: if a pose file was re-exported
(e.g. ghost detections cleaned up), the identity count could change but the stale cached value
would continue to be used on subsequent loads.

---

### Solution

**One parallel scan pass replaces all three serial loops.**

A new module-level worker function `scan_video_metadata()` in `parallel_workers.py` opens each
HDF5 file exactly once and returns everything both `VideoManager` and `FeatureManager` need: frame
count, identity count, static objects, lixit keypoints, and whether `cm_per_pixel` is present. If
`enable_video_check=True`, it also reads the video frame count in the same call.

`Project.__init__()` runs this scan via the application-scoped `ProcessPoolManager` (up to 6
workers, already warm at startup) immediately after `SettingsManager` init. Results are collected
into a `dict[str, VideoScanResult]` and injected into both `VideoManager` and `FeatureManager`,
which skip their per-video I/O entirely when pre-loaded data is available.

When `process_pool` is `None` (CLI scripts), the same workers run sequentially — no functional
difference from before, but still 3–5× fewer HDF5 opens per video.

**Identity count without loading keypoints.**
The new `_get_identity_count()` helper reads identity count from an already-open `h5py.File`
using shape-attribute reads only:
- V2: returns 1 (from filename, no HDF5 access at all)
- V3: `poseest/points.shape[1]` — shape attribute only
- V4–V8: `poseest/instance_id_center.shape[0]` if the dataset exists — shape attribute only
- V4–V8 fallback: max of `poseest/instance_embed_id[id_mask==0]` — loads a small integer array, not the full keypoints

No `PoseEstimation` object is created. No keypoints are loaded into memory during project init.

**`video_files.identities` caching removed.**
Since identity count is now always read from the HDF5 on every open (fast, combined with the
existing scan), there is no need to cache it. This eliminates the stale-cache risk. Existing
`project.json` files that still contain the key are unaffected — the value is simply ignored.

**`SettingsManager.video_metadata()` bug fixed.**
This method previously did `self._project_info["video_files"][video]` — a hard dict access that
raises `KeyError` if the `video_files` section is absent, contradicting its own docstring which
says "empty dict if none exists". Since we no longer guarantee `video_files` is written at
project-init time, this bug was exposed and fixed: the method now uses `.get()` at every level.

**`PoseEstimationV8` cleanup.**
`_load_from_h5()` was redundantly re-deriving `_num_identities` from `instance_embed_id` despite
`super().__init__()` (V4's init) having already computed it correctly via `instance_id_center`.
Verified across 139 real V8 files that both methods always agree. The redundant block was removed,
making V8 consistent with V4–V7.

---

### Areas requiring extra reviewer attention

#### 1. `_get_identity_count()` — version-specific identity count logic

This is the highest-risk new code. It replicates logic that lives across several `PoseEstimation`
subclasses without using those classes. 

#### 2. `scan_video_metadata()` — pickling and worker safety

This function runs in a forked/spawned subprocess. Reviewers should confirm:

- No references to non-picklable state (class instances, open file handles, closures). All arguments are paths, primitives, or ints.
- `h5py.File` is opened fresh inside the worker (not inherited from the parent process). HDF5 is safe to use in forked workers as long as no file handle is shared across the fork boundary.
- The macOS fork/LAPACK guard from `collect_labeled_features` is intentionally omitted here — `scan_video_metadata` uses only h5py and OpenCV, neither of which has the Accelerate/LAPACK fork issue. If that assessment is wrong, the guard should be added.

#### 3. `SettingsManager.video_metadata()` behavioral change

The old implementation raised `KeyError` for any project that had never had video metadata saved.
The fix changes it to return `{}` in all missing-key cases. The method's docstring already
documented the `{}` return, so this is a bug fix — but reviewers should confirm no caller depends
on the `KeyError` being raised (e.g. to detect whether a video exists in the project):

