### PR TITLE
fix a couple bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ docs/notes.txt
 docs/work_history.md
 docs/drafts/
 site/
+scratch/

--- a/src/jabs/project/prediction_manager.py
+++ b/src/jabs/project/prediction_manager.py
@@ -111,12 +111,12 @@ class PredictionManager:
             .get(video, {})
             .get("identities")
         )
-        if nident is None:
+        if nident is None or nident <= 0:
             nident = self._project.video_manager.get_video_identity_count(video)
 
         try:
             pred = io.load(path, BehaviorPrediction, behavior=behavior)
-            if nident is None:
+            if nident is None or nident <= 0:
                 nident = pred.predicted_class.shape[0]
             assert pred.predicted_class.shape[0] == nident
 

--- a/src/jabs/project/prediction_manager.py
+++ b/src/jabs/project/prediction_manager.py
@@ -118,7 +118,9 @@ class PredictionManager:
             pred = io.load(path, BehaviorPrediction, behavior=behavior)
             if nident is None or nident <= 0:
                 nident = pred.predicted_class.shape[0]
-            assert pred.predicted_class.shape[0] == nident
+            if pred.predicted_class.shape[0] != nident or pred.probabilities.shape[0] != nident:
+                print(f"unable to open saved inferences for {video}", file=sys.stderr)
+                return {}, {}, {}
 
             for i in range(nident):
                 predictions[i] = pred.predicted_class[i]
@@ -129,7 +131,4 @@ class PredictionManager:
         except (KeyError, FileNotFoundError):
             # no saved predictions for this behavior for this video
             pass
-        except AssertionError:
-            print(f"unable to open saved inferences for {video}", file=sys.stderr)
-
         return predictions, probabilities, postprocessed_predictions

--- a/src/jabs/project/prediction_manager.py
+++ b/src/jabs/project/prediction_manager.py
@@ -106,12 +106,18 @@ class PredictionManager:
         file_base = Path(video).with_suffix("").name + ".h5"
         path = self._project.project_paths.prediction_dir / file_base
 
-        nident = self._project.settings_manager.project_settings["video_files"][video][
-            "identities"
-        ]
+        nident = (
+            self._project.settings_manager.project_settings.get("video_files", {})
+            .get(video, {})
+            .get("identities")
+        )
+        if nident is None:
+            nident = self._project.video_manager.get_video_identity_count(video)
 
         try:
             pred = io.load(path, BehaviorPrediction, behavior=behavior)
+            if nident is None:
+                nident = pred.predicted_class.shape[0]
             assert pred.predicted_class.shape[0] == nident
 
             for i in range(nident):

--- a/src/jabs/project/project_merge.py
+++ b/src/jabs/project/project_merge.py
@@ -1,8 +1,9 @@
 import enum
 import shutil
+from pathlib import Path
 from typing import TYPE_CHECKING
 
-from jabs.pose_estimation import open_pose_file
+from jabs.pose_estimation import get_pose_path, open_pose_file
 
 if TYPE_CHECKING:
     from .project import Project
@@ -95,8 +96,9 @@ def merge_projects(destination: "Project", source: "Project", strategy: MergeStr
                     destination.video_manager.video_path(video)
                 )
             except ValueError:
+                destination_video_path = destination.project_paths.video_dir / Path(video).name
                 destination_pose = open_pose_file(
-                    destination.video_manager.get_cached_pose_path(video),
+                    get_pose_path(destination_video_path, destination.project_paths.pose_dir),
                     destination.project_paths.cache_dir,
                 )
             destination_labels = None

--- a/src/jabs/project/project_merge.py
+++ b/src/jabs/project/project_merge.py
@@ -2,6 +2,8 @@ import enum
 import shutil
 from typing import TYPE_CHECKING
 
+from jabs.pose_estimation import open_pose_file
+
 if TYPE_CHECKING:
     from .project import Project
 
@@ -84,13 +86,29 @@ def merge_projects(destination: "Project", source: "Project", strategy: MergeStr
             continue
 
         source_pose = source.load_pose_est(source.video_manager.video_path(video))
-        destination_pose = destination.load_pose_est(destination.video_manager.video_path(video))
+        if video in videos_unique_to_source:
+            # This video was just copied from source -> destination during this merge run.
+            # Destination's in-memory VideoManager inventory has not been refreshed yet,
+            # so check_video_name-based load paths may fail.
+            try:
+                destination_pose = destination.load_pose_est(
+                    destination.video_manager.video_path(video)
+                )
+            except ValueError:
+                destination_pose = open_pose_file(
+                    destination.video_manager.get_cached_pose_path(video),
+                    destination.project_paths.cache_dir,
+                )
+            destination_labels = None
+        else:
+            destination_pose = destination.load_pose_est(
+                destination.video_manager.video_path(video)
+            )
+            destination_labels = destination.video_manager.load_video_labels(video)
 
         if source_pose.hash != destination_pose.hash:
             print(f"WARNING: Pose hash mismatch for video {video}. Skipping annotation merge.")
             continue
-
-        destination_labels = destination.video_manager.load_video_labels(video)
 
         if destination_labels is None:
             # destination project does not have annotations for this video, so we can just copy the source annotations

--- a/tests/project/test_prediction_manager.py
+++ b/tests/project/test_prediction_manager.py
@@ -19,6 +19,7 @@ class MockProject:
     def __init__(self, base_path):
         self.project_paths = MockProjectPaths(base_path)
         self.settings_manager = MockSettingsManager()
+        self.video_manager = MockVideoManager()
 
 
 class MockSettingsManager:
@@ -26,6 +27,17 @@ class MockSettingsManager:
 
     def __init__(self):
         self.project_settings = {"video_files": {"test_video.avi": {"identities": 2}}}
+
+
+class MockVideoManager:
+    """Class to simulate video manager identity counts."""
+
+    @staticmethod
+    def get_video_identity_count(video_name: str) -> int:
+        """Return the identity count for the given video name."""
+        if video_name == "test_video.avi":
+            return 2
+        return 0
 
 
 @pytest.fixture
@@ -138,3 +150,31 @@ def test_load_predictions_invalid_file(prediction_manager, mock_project):
     # Assert that an exception is raised when trying to load predictions
     with pytest.raises(OSError):
         prediction_manager.load_predictions(video, "Walking")
+
+
+def test_load_predictions_without_video_files_metadata(
+    prediction_manager,
+    mock_project,
+):
+    """Missing project_settings['video_files'][video] falls back to video manager counts."""
+    video = "test_video.avi"
+    behavior = "Walking"
+    prediction_file = mock_project.project_paths.prediction_dir / "test_video.h5"
+    mock_project.settings_manager.project_settings = {"video_files": {}}
+
+    with h5py.File(prediction_file, "w") as h5:
+        h5.attrs["version"] = 2
+        h5.attrs["pose_file"] = "test_pose.h5"
+        h5.attrs["pose_hash"] = "testhash"
+        prediction_group = h5.create_group("predictions")
+        behavior_group = prediction_group.create_group(behavior)
+        behavior_group.attrs["classifier_file"] = "test_classifier.pkl"
+        behavior_group.attrs["classifier_hash"] = "clshash"
+        behavior_group.attrs["app_version"] = "1.0.0"
+        behavior_group.attrs["prediction_date"] = "2025-01-01"
+        behavior_group.create_dataset("predicted_class", data=[[1, 0, -1], [0, 1, -1]])
+        behavior_group.create_dataset("probabilities", data=[[0.9, 0.8, -1], [0.7, 0.6, -1]])
+
+    predictions, probabilities, _ = prediction_manager.load_predictions(video, behavior)
+    assert np.array_equal(predictions[0], [1, 0, -1])
+    assert np.array_equal(probabilities[1], [0.7, 0.6, -1])

--- a/tests/project/test_prediction_manager.py
+++ b/tests/project/test_prediction_manager.py
@@ -178,3 +178,33 @@ def test_load_predictions_without_video_files_metadata(
     predictions, probabilities, _ = prediction_manager.load_predictions(video, behavior)
     assert np.array_equal(predictions[0], [1, 0, -1])
     assert np.array_equal(probabilities[1], [0.7, 0.6, -1])
+
+
+def test_load_predictions_infers_identity_count_when_unknown(
+    prediction_manager,
+    mock_project,
+):
+    """If metadata is missing and video manager returns 0, infer identities from prediction shape."""
+    video = "unknown_video.avi"
+    behavior = "Walking"
+    prediction_file = mock_project.project_paths.prediction_dir / "unknown_video.h5"
+    mock_project.settings_manager.project_settings = {"video_files": {}}
+
+    with h5py.File(prediction_file, "w") as h5:
+        h5.attrs["version"] = 2
+        h5.attrs["pose_file"] = "test_pose.h5"
+        h5.attrs["pose_hash"] = "testhash"
+        prediction_group = h5.create_group("predictions")
+        behavior_group = prediction_group.create_group(behavior)
+        behavior_group.attrs["classifier_file"] = "test_classifier.pkl"
+        behavior_group.attrs["classifier_hash"] = "clshash"
+        behavior_group.attrs["app_version"] = "1.0.0"
+        behavior_group.attrs["prediction_date"] = "2025-01-01"
+        behavior_group.create_dataset("predicted_class", data=[[1, 0, -1], [0, 1, -1]])
+        behavior_group.create_dataset("probabilities", data=[[0.9, 0.8, -1], [0.7, 0.6, -1]])
+
+    predictions, probabilities, _ = prediction_manager.load_predictions(video, behavior)
+    assert np.array_equal(predictions[0], [1, 0, -1])
+    assert np.array_equal(predictions[1], [0, 1, -1])
+    assert np.array_equal(probabilities[0], [0.9, 0.8, -1])
+    assert np.array_equal(probabilities[1], [0.7, 0.6, -1])

--- a/tests/project/test_project_merge.py
+++ b/tests/project/test_project_merge.py
@@ -188,8 +188,8 @@ def test_merge_projects_copies_unique_video_and_pose_to_split_dirs(tmp_path):
     )
 
 
-def test_merge_projects_unique_labeled_video_does_not_call_destination_load_pose_est(tmp_path):
-    """Unique labeled videos should fallback when destination load_pose_est rejects stale inventory."""
+def test_merge_projects_unique_labeled_video_falls_back_to_direct_pose_path(tmp_path):
+    """Unique labeled videos should recover from stale destination inventory via direct pose path."""
     dest = MagicMock()
     src = MagicMock()
 
@@ -218,9 +218,7 @@ def test_merge_projects_unique_labeled_video_does_not_call_destination_load_pose
     src.video_manager.get_cached_pose_path.side_effect = (
         lambda v: src.project_paths.pose_dir / f"{Path(v).stem}_pose_est_v6.h5"
     )
-    dest.video_manager.get_cached_pose_path.side_effect = (
-        lambda v: dest.project_paths.pose_dir / f"{Path(v).stem}_pose_est_v6.h5"
-    )
+    dest.video_manager.get_cached_pose_path.side_effect = ValueError("video2.mp4 not in project")
 
     dest.settings_manager.behavior_names = []
     src.settings_manager.behavior_names = []
@@ -242,4 +240,5 @@ def test_merge_projects_unique_labeled_video_does_not_call_destination_load_pose
         merge_projects(dest, src, MergeStrategy.DESTINATION_WINS)
 
     dest.load_pose_est.assert_called_once()
+    dest.video_manager.get_cached_pose_path.assert_not_called()
     dest.save_annotations.assert_called_once_with(src_labels, dest_pose)

--- a/tests/project/test_project_merge.py
+++ b/tests/project/test_project_merge.py
@@ -186,3 +186,60 @@ def test_merge_projects_copies_unique_video_and_pose_to_split_dirs(tmp_path):
     assert (dest.project_paths.pose_dir / "video2_pose_est_v6.h5").read_bytes() == (
         b"dummy pose content"
     )
+
+
+def test_merge_projects_unique_labeled_video_does_not_call_destination_load_pose_est(tmp_path):
+    """Unique labeled videos should fallback when destination load_pose_est rejects stale inventory."""
+    dest = MagicMock()
+    src = MagicMock()
+
+    dest.project_paths.project_dir = tmp_path / "dest"
+    dest.project_paths.video_dir = dest.project_paths.project_dir / "videos"
+    dest.project_paths.pose_dir = dest.project_paths.project_dir / "poses"
+    dest.project_paths.cache_dir = dest.project_paths.project_dir / "cache"
+    src.project_paths.project_dir = tmp_path / "src"
+    src.project_paths.video_dir = src.project_paths.project_dir / "videos"
+    src.project_paths.pose_dir = src.project_paths.project_dir / "poses"
+
+    for path in (
+        dest.project_paths.video_dir,
+        dest.project_paths.pose_dir,
+        src.project_paths.video_dir,
+        src.project_paths.pose_dir,
+    ):
+        path.mkdir(parents=True)
+
+    (src.project_paths.video_dir / "video2.mp4").write_bytes(b"dummy video content")
+    (src.project_paths.pose_dir / "video2_pose_est_v6.h5").write_bytes(b"dummy pose content")
+
+    dest.video_manager.videos = []
+    src.video_manager.videos = ["video2.mp4"]
+    src.video_manager.video_path.side_effect = lambda v: src.project_paths.video_dir / v
+    src.video_manager.get_cached_pose_path.side_effect = (
+        lambda v: src.project_paths.pose_dir / f"{Path(v).stem}_pose_est_v6.h5"
+    )
+    dest.video_manager.get_cached_pose_path.side_effect = (
+        lambda v: dest.project_paths.pose_dir / f"{Path(v).stem}_pose_est_v6.h5"
+    )
+
+    dest.settings_manager.behavior_names = []
+    src.settings_manager.behavior_names = []
+
+    src_labels = VideoLabels("video2.mp4", 100)
+    src_labels.get_track_labels("0", "foo").label_behavior(1, 10)
+    src.video_manager.load_video_labels.return_value = src_labels
+
+    src_pose = MagicMock()
+    src_pose.hash = "hash1"
+    src.load_pose_est.return_value = src_pose
+
+    # Destination check_video_name-gated path can fail for unique videos.
+    dest.load_pose_est.side_effect = ValueError("video2.mp4 not in project")
+
+    dest_pose = MagicMock()
+    dest_pose.hash = "hash1"
+    with patch("jabs.project.project_merge.open_pose_file", return_value=dest_pose):
+        merge_projects(dest, src, MergeStrategy.DESTINATION_WINS)
+
+    dest.load_pose_est.assert_called_once()
+    dest.save_annotations.assert_called_once_with(src_labels, dest_pose)


### PR DESCRIPTION
This pull request improves robustness in handling missing or stale project metadata during prediction loading and project merging, and adds comprehensive tests to cover these edge cases. The main focus is on ensuring fallback mechanisms work correctly when expected metadata or inventory is unavailable, both in the core logic and in the test suite.

**Robustness improvements for missing metadata and inventory:**

* Updated `load_predictions` in `prediction_manager.py` to gracefully handle missing `identities` metadata in `project_settings['video_files']` by falling back to `video_manager.get_video_identity_count(video)`. If still unavailable, it attempts to infer the count from the prediction file itself.
* In `merge_projects` in `project_merge.py`, added logic to handle cases where a video unique to the source project has just been copied and the destination's in-memory inventory is stale. If loading pose estimation fails, it falls back to opening the pose file directly from the cache.
* Imported `open_pose_file` in `project_merge.py` to support the new fallback logic.

**Test coverage enhancements:**

* Added `MockVideoManager` to the test suite and updated `MockProject` to include it, enabling simulation of video identity count fallback scenarios. [[1]](diffhunk://#diff-0aefe70afa578bfc763610b98817feecd9d27b6c0bdc7db3da3fd602ad310b3bR22) [[2]](diffhunk://#diff-0aefe70afa578bfc763610b98817feecd9d27b6c0bdc7db3da3fd602ad310b3bR32-R42)
* Added a new test to `test_prediction_manager.py` verifying that `load_predictions` falls back to `video_manager` when `video_files` metadata is missing.
* Added a new test to `test_project_merge.py` to ensure that merging unique labeled videos correctly falls back when the destination's inventory is stale and `load_pose_est` fails.