### PR TITLE
Fix sync-versions.sh to update versions in pyproject.toml

### DIFF
--- a/dev/sync-versions.sh
+++ b/dev/sync-versions.sh
@@ -47,10 +47,20 @@ if [ -n "$DRY_RUN" ]; then
         | sed "s/^/    /" \
         || echo "    (no matching lines found)"
 else
-    sed -i.bak -E \
-        's/"(jabs-behavior|jabs-core|jabs-io)(==[^"]*)?"$/"\1=='"${ROOT_VERSION}"'",/' \
-        pyproject.toml
-    rm -f pyproject.toml.bak
+    python3 - "${ROOT_VERSION}" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+version = sys.argv[1]
+path = Path("pyproject.toml")
+packages = "jabs-behavior|jabs-core|jabs-io"
+pattern = re.compile(rf'^(\s*")({packages})(?:==[^"]*)?("\s*,?\s*)$', re.MULTILINE)
+
+contents = path.read_text()
+updated = pattern.sub(rf"\g<1>\g<2>=={version}\g<3>", contents)
+path.write_text(updated)
+PY
     echo "  pyproject.toml updated."
 fi
 

--- a/dev/sync-versions.sh
+++ b/dev/sync-versions.sh
@@ -58,26 +58,23 @@ packages = "jabs-behavior|jabs-core|jabs-io"
 pattern = re.compile(rf'^(\s*")({packages})(?:==[^"]*)?("\s*,?\s*)$', re.MULTILINE)
 
 contents = path.read_text(encoding="utf-8")
-updated = pattern.sub(rf"\g<1>\g<2>=={version}\g<3>", contents)
-path.write_text(updated, encoding="utf-8")
-PY
-    python3 - "${ROOT_VERSION}" <<'PY'
-import sys
-from pathlib import Path
+updated, count = pattern.subn(rf"\g<1>\g<2>=={version}\g<3>", contents)
+if count > 0:
+    path.write_text(updated, encoding="utf-8")
+    print(f"  pyproject.toml updated ({count} substitution(s)).")
+else:
+    print("  pyproject.toml: no lines matched — verifying pins are already correct.")
 
-version = sys.argv[1]
-contents = Path("pyproject.toml").read_text(encoding="utf-8")
 missing = [
     package
     for package in ("jabs-behavior", "jabs-core", "jabs-io")
-    if f'"{package}=={version}"' not in contents
+    if f'"{package}=={version}"' not in updated
 ]
 if missing:
     raise SystemExit(
         "Root pyproject.toml is missing updated pins for: " + ", ".join(missing)
     )
 PY
-    echo "  pyproject.toml updated."
 fi
 
 if [ -n "$UPDATE_README" ]; then

--- a/dev/sync-versions.sh
+++ b/dev/sync-versions.sh
@@ -57,9 +57,25 @@ path = Path("pyproject.toml")
 packages = "jabs-behavior|jabs-core|jabs-io"
 pattern = re.compile(rf'^(\s*")({packages})(?:==[^"]*)?("\s*,?\s*)$', re.MULTILINE)
 
-contents = path.read_text()
+contents = path.read_text(encoding="utf-8")
 updated = pattern.sub(rf"\g<1>\g<2>=={version}\g<3>", contents)
-path.write_text(updated)
+path.write_text(updated, encoding="utf-8")
+PY
+    python3 - "${ROOT_VERSION}" <<'PY'
+import sys
+from pathlib import Path
+
+version = sys.argv[1]
+contents = Path("pyproject.toml").read_text(encoding="utf-8")
+missing = [
+    package
+    for package in ("jabs-behavior", "jabs-core", "jabs-io")
+    if f'"{package}=={version}"' not in contents
+]
+if missing:
+    raise SystemExit(
+        "Root pyproject.toml is missing updated pins for: " + ", ".join(missing)
+    )
 PY
     echo "  pyproject.toml updated."
 fi


### PR DESCRIPTION
This pull request refactors the way version numbers are updated in the `pyproject.toml` file by replacing a `sed` command with a Python script. This makes the version synchronization process more robust and easier to maintain.

**Version synchronization improvements:**

* Replaced the `sed` command that updated package versions in `pyproject.toml` with a Python script using regular expressions for more reliable and readable version updates. (`dev/sync-versions.sh`)