### PR TITLE
add Copy Vide Name action to the video list context menu

### DIFF
--- a/src/jabs/ui/main_window/video_list_widget.py
+++ b/src/jabs/ui/main_window/video_list_widget.py
@@ -180,10 +180,13 @@ class VideoListDockWidget(QtWidgets.QDockWidget):
         # create and show the context menu at the mouse position
         menu = QtWidgets.QMenu(self)
         get_info_action = menu.addAction("Get Info")
+        copy_filename_action = menu.addAction("Copy Video Name")
         action = menu.exec(self._file_list.mapToGlobal(pos))
 
         if action == get_info_action:
             self._show_video_info(item.data(QtCore.Qt.ItemDataRole.UserRole))
+        elif action == copy_filename_action:
+            QtWidgets.QApplication.clipboard().setText(item.data(QtCore.Qt.ItemDataRole.UserRole))
 
     def _show_video_info(self, video_name: str) -> None:
         """Open the VideoInfoDialog for the given video.

--- a/src/jabs/ui/main_window/video_list_widget.py
+++ b/src/jabs/ui/main_window/video_list_widget.py
@@ -180,12 +180,12 @@ class VideoListDockWidget(QtWidgets.QDockWidget):
         # create and show the context menu at the mouse position
         menu = QtWidgets.QMenu(self)
         get_info_action = menu.addAction("Get Info")
-        copy_filename_action = menu.addAction("Copy Video Name")
+        copy_video_name_action = menu.addAction("Copy Video Name")
         action = menu.exec(self._file_list.mapToGlobal(pos))
 
         if action == get_info_action:
             self._show_video_info(item.data(QtCore.Qt.ItemDataRole.UserRole))
-        elif action == copy_filename_action:
+        elif action == copy_video_name_action:
             QtWidgets.QApplication.clipboard().setText(item.data(QtCore.Qt.ItemDataRole.UserRole))
 
     def _show_video_info(self, video_name: str) -> None:


### PR DESCRIPTION
This pull request adds a small but useful feature to the video list context menu in the `video_list_widget.py` file. Now, in addition to "Get Info", users can copy the video name directly from the context menu.

- **UI Enhancement:**
  * Added a "Copy Video Name" option to the context menu in the video list widget, allowing users to copy the video name to the clipboard.