### PR TITLE
Feature/export training data thread

### DIFF
--- a/src/jabs/project/export_training.py
+++ b/src/jabs/project/export_training.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -74,9 +75,11 @@ def export_training_data(
         out_h5.create_dataset("label", data=features["labels"])
 
         # store the video/identity to group mapping in the h5 file
+        # identity is None when VIDEO grouping strategy is used; store -1 as a sentinel
         for group in group_mapping:
             dset = out_h5.create_dataset(f"group_mapping/{group}/identity", (1,), dtype=np.int64)
-            dset[:] = group_mapping[group]["identity"]
+            identity = group_mapping[group]["identity"]
+            dset[:] = identity if identity is not None else -1
             dset = out_h5.create_dataset(
                 f"group_mapping/{group}/video_name", (1,), dtype=string_type
             )
@@ -101,5 +104,9 @@ def write_project_settings(
     for key, val in settings.items():
         if type(val) is dict:
             write_project_settings(current_group, val, key)
+        elif isinstance(val, list):
+            # Lists (e.g. postprocessing stage configs) have no direct HDF5 equivalent;
+            # store as a JSON string so the data round-trips without loss.
+            current_group.create_dataset(key, data=json.dumps(val))
         else:
             current_group.create_dataset(key, data=val)

--- a/src/jabs/ui/export_training_thread.py
+++ b/src/jabs/ui/export_training_thread.py
@@ -1,0 +1,71 @@
+"""Background thread for exporting classifier training data."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from PySide6.QtCore import QThread, Signal
+from PySide6.QtWidgets import QWidget
+
+from jabs.core.constants import FINAL_TRAIN_SEED
+from jabs.core.enums import ClassifierType
+from jabs.project import export_training_data
+
+if TYPE_CHECKING:
+    from jabs.project import Project
+
+
+class ExportTrainingDataThread(QThread):
+    """Thread for exporting classifier training data without blocking the GUI.
+
+    Signals:
+        export_complete: Emitted with the output file path on success.
+        error_callback: Emitted with the raised exception on failure.
+        current_status: Emitted with a status string for the status bar.
+    """
+
+    export_complete: Signal = Signal(Path)
+    error_callback: Signal = Signal(Exception)
+    current_status: Signal = Signal(str)
+
+    def __init__(
+        self,
+        project: Project,
+        behavior: str,
+        pose_version: int,
+        classifier_type: ClassifierType,
+        training_seed: int = FINAL_TRAIN_SEED,
+        parent: QWidget | None = None,
+    ) -> None:
+        """Initialize the export thread.
+
+        Args:
+            project: The JABS project to export training data from.
+            behavior: Name of the behavior to export.
+            pose_version: Minimum required pose version for the classifier.
+            classifier_type: Classifier algorithm type for the export metadata.
+            training_seed: Random seed for reproducible training splits.
+            parent: Optional parent widget.
+        """
+        super().__init__(parent=parent)
+        self._project = project
+        self._behavior = behavior
+        self._pose_version = pose_version
+        self._classifier_type = classifier_type
+        self._training_seed = training_seed
+
+    def run(self) -> None:
+        """Run the export in the background thread."""
+        try:
+            self.current_status.emit("Exporting training data...")
+            out_path = export_training_data(
+                self._project,
+                self._behavior,
+                self._pose_version,
+                self._classifier_type,
+                self._training_seed,
+            )
+            self.export_complete.emit(out_path)
+        except Exception as e:
+            self.error_callback.emit(e)

--- a/src/jabs/ui/main_window/menu_handlers.py
+++ b/src/jabs/ui/main_window/menu_handlers.py
@@ -5,6 +5,7 @@ This module contains all the callback methods for menu actions, extracted from
 MainWindow to improve code organization and maintainability.
 """
 
+import traceback
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -198,6 +199,7 @@ class MenuHandlers:
             self.window,
             "Export Failed",
             f"Unable to export training data:\n{error}",
+            details="".join(traceback.format_exception(error)),
         )
 
     def _cleanup_export_thread(self) -> None:

--- a/src/jabs/ui/main_window/menu_handlers.py
+++ b/src/jabs/ui/main_window/menu_handlers.py
@@ -5,7 +5,6 @@ This module contains all the callback methods for menu actions, extracted from
 MainWindow to improve code organization and maintainability.
 """
 
-import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -15,7 +14,6 @@ from PySide6.QtGui import QAction
 
 from jabs.core.constants import FINAL_TRAIN_SEED
 from jabs.core.enums import PredictionType
-from jabs.project import export_training_data
 from jabs.utils import check_for_update
 
 from ..dialogs import (
@@ -28,6 +26,8 @@ from ..dialogs import (
     UpdateCheckDialog,
     UserGuideDialog,
 )
+from ..dialogs.progress_dialog import create_progress_dialog
+from ..export_training_thread import ExportTrainingDataThread
 from ..player_widget import PlayerWidget
 from ..settings_dialog import (
     JabsSettingsDialog,
@@ -77,6 +77,8 @@ class MenuHandlers:
             main_window: The MainWindow instance that owns these handlers
         """
         self.window = main_window
+        self._export_thread: ExportTrainingDataThread | None = None
+        self._export_progress_dialog = None
 
     # ========== File Menu Handlers ==========
 
@@ -151,9 +153,8 @@ class MenuHandlers:
         self.window.display_status_message(f"Frame exported: {save_path}", 5000)
 
     def export_training_data(self) -> None:
-        """Export training data for the current classifier."""
+        """Export training data for the current classifier in a background thread."""
         if not self.window._central_widget.classify_button_enabled:
-            # Classify button disabled, don't allow exporting training data
             MessageDialog.warning(
                 self.window,
                 "Unable to export training data",
@@ -163,17 +164,54 @@ class MenuHandlers:
             )
             return
 
-        try:
-            out_path = export_training_data(
-                self.window._project,
-                self.window._central_widget.behavior,
-                self.window._project.feature_manager.min_pose_version,
-                self.window._central_widget.classifier_type,
-                FINAL_TRAIN_SEED,
-            )
-            self.window.display_status_message(f"Training data exported: {out_path}", 5000)
-        except OSError as e:
-            print(f"Unable to export training data: {e}", file=sys.stderr)
+        self._export_thread = ExportTrainingDataThread(
+            project=self.window._project,
+            behavior=self.window._central_widget.behavior,
+            pose_version=self.window._project.feature_manager.min_pose_version,
+            classifier_type=self.window._central_widget.classifier_type,
+            training_seed=FINAL_TRAIN_SEED,
+            parent=self.window,
+        )
+        self._export_thread.export_complete.connect(self._on_export_complete)
+        self._export_thread.error_callback.connect(self._on_export_error)
+        self._export_thread.current_status.connect(
+            lambda m: self.window.display_status_message(m, 0)
+        )
+        self._export_thread.finished.connect(self._cleanup_export_thread)
+
+        self._export_progress_dialog = create_progress_dialog(
+            self.window, "Exporting training data...", 0
+        )
+        self._export_progress_dialog.show()
+
+        self._export_thread.start()
+
+    def _on_export_complete(self, out_path: Path) -> None:
+        """Handle successful export completion."""
+        self._cleanup_export_progress_dialog()
+        self.window.display_status_message(f"Training data exported: {out_path}", 5000)
+
+    def _on_export_error(self, error: Exception) -> None:
+        """Handle export failure."""
+        self._cleanup_export_progress_dialog()
+        MessageDialog.error(
+            self.window,
+            "Export Failed",
+            f"Unable to export training data:\n{error}",
+        )
+
+    def _cleanup_export_thread(self) -> None:
+        """Clean up the export thread after it finishes."""
+        if self._export_thread:
+            self._export_thread.deleteLater()
+            self._export_thread = None
+
+    def _cleanup_export_progress_dialog(self) -> None:
+        """Close and destroy the export progress dialog."""
+        if self._export_progress_dialog:
+            self._export_progress_dialog.close()
+            self._export_progress_dialog.deleteLater()
+            self._export_progress_dialog = None
 
     def open_archive_behavior_dialog(self) -> None:
         """Open dialog to archive a behavior and its labels."""


### PR DESCRIPTION
Implements KLAUS-152 (moves training data export into its own QThread to prevent stalling the UI thread. 

also fixes two bugs related to exporting training data if user has post processing pipeline configured for project or is using the video (not default by identity) cross validation grouping 

### AI Summary follows:

This pull request introduces significant improvements to the process of exporting classifier training data in the JABS application. The main enhancement is the refactoring of the export functionality to run in a background thread, which prevents the GUI from freezing during long-running operations. Additionally, the export logic has been made more robust, with better handling of special data types and improved user feedback in case of errors.

**GUI Responsiveness and Export Workflow Improvements:**

* Refactored the training data export process to run in a background thread using the new `ExportTrainingDataThread` class, ensuring the GUI remains responsive during export operations. This includes progress dialog updates and proper cleanup after completion or error. [[1]](diffhunk://#diff-6b8f8b6e031fb2162207cfa8164197c5615903d534215bc95238636a8407c0efR1-R71) [[2]](diffhunk://#diff-b9f2b82c689ec281ae882ae4bd4c084a3cfffbffcccf34045f79309d5fba144aR81-R82) [[3]](diffhunk://#diff-b9f2b82c689ec281ae882ae4bd4c084a3cfffbffcccf34045f79309d5fba144aL154-L156) [[4]](diffhunk://#diff-b9f2b82c689ec281ae882ae4bd4c084a3cfffbffcccf34045f79309d5fba144aL166-R216) [[5]](diffhunk://#diff-b9f2b82c689ec281ae882ae4bd4c084a3cfffbffcccf34045f79309d5fba144aR30-R31)
* Added error handling and user feedback for export failures, displaying error dialogs with detailed tracebacks to assist in debugging. [[1]](diffhunk://#diff-b9f2b82c689ec281ae882ae4bd4c084a3cfffbffcccf34045f79309d5fba144aL166-R216) [[2]](diffhunk://#diff-b9f2b82c689ec281ae882ae4bd4c084a3cfffbffcccf34045f79309d5fba144aL8-R8)

**Export Data Robustness:**

* Updated the export logic to store `None` identities as `-1` in the HDF5 group mapping, ensuring consistency when the VIDEO grouping strategy is used.
* Improved handling of list-type project settings by serializing them as JSON strings before storing in HDF5, preserving data integrity for round-tripping.
* Added missing import of `json` required for serializing lists in project settings.