### PR TITLE
Feature/t13 multiclass export

### DIFF
--- a/src/jabs/classifier/multi_class_classifier.py
+++ b/src/jabs/classifier/multi_class_classifier.py
@@ -44,17 +44,17 @@ class MultiClassClassifier:
     """Multi-class behavior classifier for simultaneous classification of N behaviors.
 
     Trains a single classifier over all annotated behaviors, outputting one of N
-    behavior classes (or background) per frame. Per-behavior TrackLabels arrays are
-    merged into a single class-index array before training.
+    behavior classes (or ``MULTICLASS_NONE_BEHAVIOR``) per frame. Per-behavior
+    TrackLabels arrays are merged into a single class-index array before training.
 
-    The background class (index 0) is the multi-class analog of the binary
-    classifier's "not {behavior}" class, except that it represents the absence of
-    *all* annotated behaviors rather than the negation of a single one. It is
+    The ``MULTICLASS_NONE_BEHAVIOR`` class (index 0) is the multi-class analog of the
+    binary classifier's "not {behavior}" class, except that it represents the absence
+    of *all* annotated behaviors rather than the negation of a single one. It is
     populated exclusively via explicit ``MULTICLASS_NONE_BEHAVIOR`` labels; frames
     that are simply unlabeled are excluded from training entirely.
 
     Merging rules:
-        - BEHAVIOR in ``MULTICLASS_NONE_BEHAVIOR`` TrackLabels → class 0 (background)
+        - BEHAVIOR in ``MULTICLASS_NONE_BEHAVIOR`` TrackLabels → class 0
         - BEHAVIOR in behavior X's TrackLabels → class X's 1-based index
         - All other frames → excluded from training
 
@@ -84,8 +84,8 @@ class MultiClassClassifier:
 
         Args:
             behavior_names: Ordered list of behavior names to classify (must not include
-                ``MULTICLASS_NONE_BEHAVIOR``). Class index 0 is reserved for background;
-                ``behavior_names[i]`` maps to class index ``i + 1``.
+                ``MULTICLASS_NONE_BEHAVIOR``). Class index 0 is reserved for
+                ``MULTICLASS_NONE_BEHAVIOR``; ``behavior_names[i]`` maps to class index ``i + 1``.
             classifier_type: Underlying algorithm to use.
             n_jobs: Number of parallel jobs for training and inference.
 
@@ -124,7 +124,7 @@ class MultiClassClassifier:
 
     @property
     def behavior_names(self) -> list[str]:
-        """Ordered list of behavior names (does not include background)."""
+        """Ordered list of behavior names (does not include ``MULTICLASS_NONE_BEHAVIOR``)."""
         return list(self._behavior_names)
 
     @property
@@ -340,7 +340,7 @@ class MultiClassClassifier:
 
         Returns:
             Float array of shape ``(n_frames, N+1)`` where N is the number of
-            behaviors. Column 0 is the background class.
+            behaviors. Column 0 is the ``MULTICLASS_NONE_BEHAVIOR`` class.
         """
         cleaned = self._get_features_to_classify(
             classifier_utils.clean_features(features, self._classifier_type)
@@ -535,7 +535,7 @@ class MultiClassClassifier:
 
         Merging rules:
             - ``TrackLabels.Label.BEHAVIOR`` in ``MULTICLASS_NONE_BEHAVIOR`` entry
-              → class 0 (background)
+              → class 0
             - ``TrackLabels.Label.BEHAVIOR`` in behavior X's entry
               → class index (1-based, by position in ``behavior_names``)
             - All other frames → excluded (not in the returned mask)
@@ -585,7 +585,7 @@ class MultiClassClassifier:
 
         class_indices = np.full(n_frames, -1, dtype=np.intp)
 
-        # MULTICLASS_NONE_BEHAVIOR BEHAVIOR frames → class 0 (explicit background)
+        # MULTICLASS_NONE_BEHAVIOR BEHAVIOR frames → class 0
         if MULTICLASS_NONE_BEHAVIOR in labels_by_behavior:
             none_arr = labels_by_behavior[MULTICLASS_NONE_BEHAVIOR]
             class_indices[none_arr == TrackLabels.Label.BEHAVIOR] = 0

--- a/src/jabs/classifier/multi_class_classifier.py
+++ b/src/jabs/classifier/multi_class_classifier.py
@@ -17,7 +17,7 @@ from sklearn.exceptions import InconsistentVersionWarning
 from jabs.core.constants import MULTICLASS_NONE_BEHAVIOR
 from jabs.core.enums import ClassifierType
 from jabs.core.utils import hash_file
-from jabs.project import TrackLabels
+from jabs.project import TrackLabels, load_multiclass_training_data
 
 from . import classifier_utils
 from .factories import (
@@ -173,9 +173,9 @@ class MultiClassClassifier:
         """Return the ordered list of class names for this classifier.
 
         Returns:
-            List with ``"background"`` at index 0 followed by behavior names.
+            List with ``MULTICLASS_NONE_BEHAVIOR`` at index 0 followed by behavior names.
         """
-        return ["background", *self._behavior_names]
+        return [MULTICLASS_NONE_BEHAVIOR, *self._behavior_names]
 
     @staticmethod
     def combine_data(per_frame: pd.DataFrame, window: pd.DataFrame) -> pd.DataFrame:
@@ -416,6 +416,41 @@ class MultiClassClassifier:
             self._classifier_source = "pickle"
 
         logger.info("MultiClassClassifier loaded from %s", path)
+
+    @classmethod
+    def from_training_file(cls, path: Path) -> MultiClassClassifier:
+        """Train a new MultiClassClassifier from an exported training file.
+
+        Args:
+            path: Path to a multi-class training HDF5 file produced by
+                ``export_training_data_multiclass()``.
+
+        Returns:
+            A freshly trained ``MultiClassClassifier`` instance.
+
+        Raises:
+            ValueError: If the file is not a valid multi-class training export or
+                the stored classifier type is unsupported in the current environment.
+        """
+        loaded, _ = load_multiclass_training_data(path)
+
+        classifier = cls(
+            behavior_names=loaded["behavior_names"],
+            classifier_type=loaded["classifier_type"],
+        )
+        classifier.set_dict_settings(loaded["settings"])
+        classifier.train(
+            {
+                "per_frame": loaded["per_frame"],
+                "window": loaded["window"],
+                "labels_by_behavior": loaded["labels_by_behavior"],
+            },
+            random_seed=loaded["training_seed"],
+        )
+        classifier._classifier_file = Path(path).name
+        classifier._classifier_hash = hash_file(Path(path))
+        classifier._classifier_source = "training_file"
+        return classifier
 
     @staticmethod
     def leave_one_group_out(

--- a/src/jabs/project/__init__.py
+++ b/src/jabs/project/__init__.py
@@ -3,7 +3,7 @@
 from .export_training import export_training_data, export_training_data_multiclass
 from .project import Project
 from .project_pruning import get_videos_to_prune
-from .read_training import load_training_data
+from .read_training import load_multiclass_training_data, load_training_data
 from .timeline_annotations import TimelineAnnotations
 from .track_labels import TrackLabels
 from .video_labels import VideoLabels
@@ -16,5 +16,6 @@ __all__ = [
     "export_training_data",
     "export_training_data_multiclass",
     "get_videos_to_prune",
+    "load_multiclass_training_data",
     "load_training_data",
 ]

--- a/src/jabs/project/__init__.py
+++ b/src/jabs/project/__init__.py
@@ -1,6 +1,6 @@
 """jabs project module"""
 
-from .export_training import export_training_data
+from .export_training import export_training_data, export_training_data_multiclass
 from .project import Project
 from .project_pruning import get_videos_to_prune
 from .read_training import load_training_data
@@ -14,6 +14,7 @@ __all__ = [
     "TrackLabels",
     "VideoLabels",
     "export_training_data",
+    "export_training_data_multiclass",
     "get_videos_to_prune",
     "load_training_data",
 ]

--- a/src/jabs/project/export_training.py
+++ b/src/jabs/project/export_training.py
@@ -8,7 +8,7 @@ import numpy as np
 
 import jabs.feature_extraction
 import jabs.version
-from jabs.core.constants import FINAL_TRAIN_SEED
+from jabs.core.constants import FINAL_TRAIN_SEED, MULTICLASS_NONE_BEHAVIOR
 from jabs.core.enums import ClassifierMode
 from jabs.project.project_utils import to_safe_name
 
@@ -126,6 +126,8 @@ def export_training_data_multiclass(
 
     string_type = h5py.special_dtype(vlen=str)
     behavior_names = project.settings_manager.behavior_names
+    # class_names[0] is always the background class; behavior_names[i] maps to class i+1.
+    class_names = [MULTICLASS_NONE_BEHAVIOR, *behavior_names]
 
     with h5py.File(out_file, "w") as out_h5:
         out_h5.attrs["file_version"] = jabs.feature_extraction.FEATURE_VERSION
@@ -135,11 +137,11 @@ def export_training_data_multiclass(
         out_h5.attrs["classifier_type"] = classifier_type.value
         out_h5.attrs["training_seed"] = training_seed
 
-        # Ordered list defines the class-index mapping: behavior_names[i] -> class i+1.
+        # Full ordered class list: class_names[i] is the name for class index i.
         names_ds = out_h5.create_dataset(
-            "behavior_names", shape=(len(behavior_names),), dtype=string_type
+            "class_names", shape=(len(class_names),), dtype=string_type
         )
-        for i, name in enumerate(behavior_names):
+        for i, name in enumerate(class_names):
             names_ds[i] = name
 
         write_project_settings(out_h5, project.get_project_defaults(), "settings")
@@ -150,10 +152,10 @@ def export_training_data_multiclass(
         for feature, data in features["window"].items():
             feature_group.create_dataset(f"window/{feature}", data=data)
 
-        # Per-behavior label arrays (TrackLabels.Label int8 values), row-aligned with features.
+        # Label arrays stored by class index so behavior names are never used as HDF5 paths.
         labels_group = out_h5.create_group("labels")
-        for behavior_name, label_array in features["labels_by_behavior"].items():
-            labels_group.create_dataset(behavior_name, data=label_array)
+        for i, name in enumerate(class_names):
+            labels_group.create_dataset(str(i), data=features["labels_by_behavior"][name])
 
         out_h5.create_dataset("group", data=features["groups"])
 

--- a/src/jabs/project/export_training.py
+++ b/src/jabs/project/export_training.py
@@ -126,7 +126,7 @@ def export_training_data_multiclass(
 
     string_type = h5py.special_dtype(vlen=str)
     behavior_names = project.settings_manager.behavior_names
-    # class_names[0] is always the background class; behavior_names[i] maps to class i+1.
+    # class_names[0] is always MULTICLASS_NONE_BEHAVIOR; behavior_names[i] maps to class i+1.
     class_names = [MULTICLASS_NONE_BEHAVIOR, *behavior_names]
 
     with h5py.File(out_file, "w") as out_h5:

--- a/src/jabs/project/export_training.py
+++ b/src/jabs/project/export_training.py
@@ -9,6 +9,7 @@ import numpy as np
 import jabs.feature_extraction
 import jabs.version
 from jabs.core.constants import FINAL_TRAIN_SEED
+from jabs.core.enums import ClassifierMode
 from jabs.project.project_utils import to_safe_name
 
 # these are used for type hints, but cause circular imports
@@ -87,6 +88,84 @@ def export_training_data(
 
     # return output path, so if it was generated automatically the caller
     # will know
+    return out_file
+
+
+def export_training_data_multiclass(
+    project: "Project",
+    pose_version: int,
+    classifier_type: "ClassifierType",
+    training_seed: int = FINAL_TRAIN_SEED,
+    out_file: Path | None = None,
+) -> Path:
+    """Export labeled training data from a JABS multi-class project for classifier retraining.
+
+    Collects per-frame and window features alongside per-behavior label arrays and writes
+    them to an HDF5 file. The exported file can be used to retrain a ``MultiClassClassifier``
+    outside the current environment with a stable class-index mapping.
+
+    Args:
+        project: The JABS project to export data from.
+        pose_version: Minimum required pose version for the classifier.
+        classifier_type: The classifier type for which data is exported.
+        training_seed: Random seed to ensure reproducible training splits.
+        out_file: Output file path. If None, a file is created in the project directory
+            with a timestamped name.
+
+    Returns:
+        Path: The path to the exported HDF5 file.
+
+    Raises:
+        OSError: If the output file cannot be created or written.
+    """
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    features, group_mapping = project.get_multiclass_labeled_features()
+
+    if out_file is None:
+        out_file = project.dir / f"multiclass_training_{ts}.h5"
+
+    string_type = h5py.special_dtype(vlen=str)
+    behavior_names = project.settings_manager.behavior_names
+
+    with h5py.File(out_file, "w") as out_h5:
+        out_h5.attrs["file_version"] = jabs.feature_extraction.FEATURE_VERSION
+        out_h5.attrs["app_version"] = jabs.version.version_str()
+        out_h5.attrs["min_pose_version"] = pose_version
+        out_h5.attrs["classifier_mode"] = ClassifierMode.MULTICLASS.value
+        out_h5.attrs["classifier_type"] = classifier_type.value
+        out_h5.attrs["training_seed"] = training_seed
+
+        # Ordered list defines the class-index mapping: behavior_names[i] -> class i+1.
+        names_ds = out_h5.create_dataset(
+            "behavior_names", shape=(len(behavior_names),), dtype=string_type
+        )
+        for i, name in enumerate(behavior_names):
+            names_ds[i] = name
+
+        write_project_settings(out_h5, project.get_project_defaults(), "settings")
+
+        feature_group = out_h5.create_group("features")
+        for feature, data in features["per_frame"].items():
+            feature_group.create_dataset(f"per_frame/{feature}", data=data)
+        for feature, data in features["window"].items():
+            feature_group.create_dataset(f"window/{feature}", data=data)
+
+        # Per-behavior label arrays (TrackLabels.Label int8 values), row-aligned with features.
+        labels_group = out_h5.create_group("labels")
+        for behavior_name, label_array in features["labels_by_behavior"].items():
+            labels_group.create_dataset(behavior_name, data=label_array)
+
+        out_h5.create_dataset("group", data=features["groups"])
+
+        for group in group_mapping:
+            dset = out_h5.create_dataset(f"group_mapping/{group}/identity", (1,), dtype=np.int64)
+            identity = group_mapping[group]["identity"]
+            dset[:] = identity if identity is not None else -1
+            dset = out_h5.create_dataset(
+                f"group_mapping/{group}/video_name", (1,), dtype=string_type
+            )
+            dset[:] = group_mapping[group]["video"]
+
     return out_file
 
 

--- a/src/jabs/project/read_training.py
+++ b/src/jabs/project/read_training.py
@@ -136,3 +136,74 @@ def load_training_data(training_file: Path):
             features["extended_features"] = None
 
     return features, group_mapping
+
+
+def load_multiclass_training_data(training_file: Path) -> tuple[dict[str, Any], dict]:
+    """Load multi-class training data from an exported HDF5 file.
+
+    Args:
+        training_file: Path to a multi-class training HDF5 file produced by
+            ``export_training_data_multiclass()``.
+
+    Returns:
+        Tuple of ``(features, group_mapping)`` where ``features`` contains:
+            - ``class_names``: ordered list of all class names (index 0 = background)
+            - ``behavior_names``: behavior names only (class_names[1:])
+            - ``labels_by_behavior``: dict mapping each class name to its label array
+            - ``per_frame``: DataFrame of per-frame features
+            - ``window``: DataFrame of window features
+            - ``groups``: ndarray of group IDs
+            - ``classifier_type``: ClassifierType enum
+            - ``training_seed``: int
+            - ``settings``: dict of project settings
+            - ``min_pose_version``: int
+
+        ``group_mapping`` maps group ID → ``{"identity": int | None, "video": str}``.
+
+    Raises:
+        ValueError: If the file does not contain a multi-class training export.
+    """
+    features: dict[str, Any] = {"per_frame": {}, "window": {}}
+    group_mapping: dict[int, dict[str, Any]] = {}
+
+    with h5py.File(training_file, "r") as in_h5:
+        classifier_mode = in_h5.attrs.get("classifier_mode", "")
+        if classifier_mode != "multiclass":
+            raise ValueError(
+                f"{training_file} is not a multi-class training file "
+                f"(classifier_mode={classifier_mode!r})."
+            )
+
+        features["min_pose_version"] = in_h5.attrs["min_pose_version"]
+        features["training_seed"] = in_h5.attrs["training_seed"]
+        features["classifier_type"] = ClassifierType(in_h5.attrs["classifier_type"])
+        features["settings"] = read_project_settings(in_h5["settings"])
+
+        raw = in_h5["class_names"][:]
+        class_names = [n.decode() if isinstance(n, bytes) else str(n) for n in raw]
+        features["class_names"] = class_names
+        features["behavior_names"] = class_names[1:]
+
+        labels_by_behavior: dict[str, np.ndarray] = {}
+        for i, name in enumerate(class_names):
+            labels_by_behavior[name] = in_h5[f"labels/{i}"][:]
+        features["labels_by_behavior"] = labels_by_behavior
+
+        features["groups"] = in_h5["group"][:]
+
+        for name, val in in_h5["features/per_frame"].items():
+            features["per_frame"][name] = val[:]
+        features["per_frame"] = pd.DataFrame(features["per_frame"])
+
+        for name, val in in_h5["features/window"].items():
+            features["window"][name] = val[:]
+        features["window"] = pd.DataFrame(features["window"])
+
+        for name, val in in_h5["group_mapping"].items():
+            identity_raw = int(val["identity"][0])
+            group_mapping[int(name)] = {
+                "identity": None if identity_raw == -1 else identity_raw,
+                "video": val["video_name"][0],
+            }
+
+    return features, group_mapping

--- a/src/jabs/project/read_training.py
+++ b/src/jabs/project/read_training.py
@@ -147,7 +147,7 @@ def load_multiclass_training_data(training_file: Path) -> tuple[dict[str, Any], 
 
     Returns:
         Tuple of ``(features, group_mapping)`` where ``features`` contains:
-            - ``class_names``: ordered list of all class names (index 0 = background)
+            - ``class_names``: ordered list of all class names (index 0 = ``MULTICLASS_NONE_BEHAVIOR``)
             - ``behavior_names``: behavior names only (class_names[1:])
             - ``labels_by_behavior``: dict mapping each class name to its label array
             - ``per_frame``: DataFrame of per-frame features

--- a/src/jabs/scripts/cli/cli.py
+++ b/src/jabs/scripts/cli/cli.py
@@ -87,7 +87,8 @@ cli.add_command(sample_frames_command)
     required=False,
     help=(
         "Optional path to write the exported training data file. "
-        "Default is <project_dir>/<behavior>_training_<YYYYMMDD_HHMMSS>.h5"
+        "Default is <project_dir>/<behavior>_training_<YYYYMMDD_HHMMSS>.h5 (binary) "
+        "or <project_dir>/multiclass_training_<YYYYMMDD_HHMMSS>.h5 (multi-class)."
     ),
 )
 @click.pass_context

--- a/src/jabs/scripts/cli/cli.py
+++ b/src/jabs/scripts/cli/cli.py
@@ -14,8 +14,13 @@ import click
 from rich.console import Console
 
 from jabs.classifier import Classifier
-from jabs.core.enums import ClassifierType, CrossValidationGroupingStrategy
-from jabs.project import Project, export_training_data, get_videos_to_prune
+from jabs.core.enums import ClassifierMode, ClassifierType, CrossValidationGroupingStrategy
+from jabs.project import (
+    Project,
+    export_training_data,
+    export_training_data_multiclass,
+    get_videos_to_prune,
+)
 
 from .convert_parquet import convert_parquet_command
 from .convert_to_nwb import run_conversion
@@ -62,9 +67,10 @@ cli.add_command(sample_frames_command)
 )
 @click.option(
     "--behavior",
-    required=True,
+    required=False,
+    default=None,
     type=str,
-    help="Specify the behavior to export (required).",
+    help="Behavior to export. Required for binary-mode projects; ignored for multi-class projects.",
 )
 @click.option(
     "--classifier",
@@ -86,41 +92,59 @@ cli.add_command(sample_frames_command)
 )
 @click.pass_context
 def export_training(
-    ctx: click.Context, directory: Path, behavior: str, classifier: str, outfile: Path | None
+    ctx: click.Context,
+    directory: Path,
+    behavior: str | None,
+    classifier: str,
+    outfile: Path | None,
 ):
-    """Export training data for a specified behavior and JABS project directory."""
-    #    ctx: Click context.
-    #    directory (Path): Path to the JABS project directory.
-    #    behavior (str): Behavior to export.
-    #    classifier (str): Default classifier type set in the training file,
-    #        can be overridden by the jabs-classify train command.
-    #    outfile (Path | None): Optional path to write the exported training data
-    #        file. If not provided, export_training_data will generate a unique
-    #        filename in the project directory using .
+    """Export training data for a JABS project directory.
 
-    if ctx.obj["VERBOSE"]:
-        click.echo("Exporting training data with the following parameters:")
-        click.echo(f"\tBehavior: {behavior}")
-        click.echo(f"\tClassifier type: {classifier}")
-        click.echo(f"\tJABS project directory: {directory}")
-
-    classifier = ClassifierType[classifier.upper()]
+    For binary-mode projects, --behavior is required. For multi-class projects, all
+    behaviors are exported together and --behavior is not used.
+    """
+    classifier_type = ClassifierType[classifier.upper()]
     jabs_project = Project(directory, enable_session_tracker=False)
+    classifier_mode = jabs_project.settings_manager.classifier_mode
 
-    # validate that the behavior exists in the project
-    if behavior not in jabs_project.settings["behavior"]:
-        raise click.ClickException(f"Behavior '{behavior}' not found in project.")
-
-    console = Console()
-    status_text = f"Exporting training data (behavior={behavior}, classifier={classifier.name})"
-    with console.status(status_text, spinner="dots"):
-        outfile = export_training_data(
-            jabs_project,
-            behavior,
-            jabs_project.feature_manager.min_pose_version,
-            classifier,
-            out_file=outfile,
+    if classifier_mode == ClassifierMode.MULTICLASS:
+        if behavior is not None:
+            click.echo("Note: --behavior is ignored for multi-class projects.")
+        if ctx.obj["VERBOSE"]:
+            click.echo("Exporting multi-class training data with the following parameters:")
+            click.echo(f"\tClassifier type: {classifier}")
+            click.echo(f"\tJABS project directory: {directory}")
+        console = Console()
+        status_text = f"Exporting multi-class training data (classifier={classifier_type.name})"
+        with console.status(status_text, spinner="dots"):
+            outfile = export_training_data_multiclass(
+                jabs_project,
+                jabs_project.feature_manager.min_pose_version,
+                classifier_type,
+                out_file=outfile,
+            )
+    else:
+        if behavior is None:
+            raise click.ClickException("--behavior is required for binary-mode projects.")
+        if behavior not in jabs_project.settings["behavior"]:
+            raise click.ClickException(f"Behavior '{behavior}' not found in project.")
+        if ctx.obj["VERBOSE"]:
+            click.echo("Exporting training data with the following parameters:")
+            click.echo(f"\tBehavior: {behavior}")
+            click.echo(f"\tClassifier type: {classifier}")
+            click.echo(f"\tJABS project directory: {directory}")
+        console = Console()
+        status_text = (
+            f"Exporting training data (behavior={behavior}, classifier={classifier_type.name})"
         )
+        with console.status(status_text, spinner="dots"):
+            outfile = export_training_data(
+                jabs_project,
+                behavior,
+                jabs_project.feature_manager.min_pose_version,
+                classifier_type,
+                out_file=outfile,
+            )
 
     click.echo(f"Exported training data to {outfile}")
 

--- a/src/jabs/ui/classification_thread.py
+++ b/src/jabs/ui/classification_thread.py
@@ -8,7 +8,6 @@ from PySide6.QtWidgets import QWidget
 
 from jabs.behavior.postprocessing import PostprocessingPipeline
 from jabs.classifier import Classifier, MultiClassClassifier
-from jabs.core.constants import MULTICLASS_NONE_BEHAVIOR
 from jabs.core.enums import ClassifierMode
 from jabs.feature_extraction import DEFAULT_WINDOW_SIZE, IdentityFeatures
 from jabs.project import Project
@@ -110,7 +109,7 @@ class ClassifyThread(QThread):
                     multiclass_classifier.project_settings or self._project.get_project_defaults()
                 )
                 prediction_behavior = MULTICLASS_PREDICTION_KEY
-                class_names = [MULTICLASS_NONE_BEHAVIOR, *multiclass_classifier.behavior_names]
+                class_names = multiclass_classifier.get_class_names()
                 postprocessing_pipeline = None
             else:
                 project_settings = self._project.settings_manager.get_behavior(self._behavior)

--- a/src/jabs/ui/export_training_thread.py
+++ b/src/jabs/ui/export_training_thread.py
@@ -9,8 +9,8 @@ from PySide6.QtCore import QThread, Signal
 from PySide6.QtWidgets import QWidget
 
 from jabs.core.constants import FINAL_TRAIN_SEED
-from jabs.core.enums import ClassifierType
-from jabs.project import export_training_data
+from jabs.core.enums import ClassifierMode, ClassifierType
+from jabs.project import export_training_data, export_training_data_multiclass
 
 if TYPE_CHECKING:
     from jabs.project import Project
@@ -32,9 +32,10 @@ class ExportTrainingDataThread(QThread):
     def __init__(
         self,
         project: Project,
-        behavior: str,
         pose_version: int,
         classifier_type: ClassifierType,
+        classifier_mode: ClassifierMode = ClassifierMode.BINARY,
+        behavior: str | None = None,
         training_seed: int = FINAL_TRAIN_SEED,
         parent: QWidget | None = None,
     ) -> None:
@@ -42,9 +43,11 @@ class ExportTrainingDataThread(QThread):
 
         Args:
             project: The JABS project to export training data from.
-            behavior: Name of the behavior to export.
             pose_version: Minimum required pose version for the classifier.
             classifier_type: Classifier algorithm type for the export metadata.
+            classifier_mode: Whether to export in binary or multi-class format.
+            behavior: Name of the behavior to export. Required when
+                ``classifier_mode`` is ``BINARY``; ignored for ``MULTICLASS``.
             training_seed: Random seed for reproducible training splits.
             parent: Optional parent widget.
         """
@@ -53,19 +56,28 @@ class ExportTrainingDataThread(QThread):
         self._behavior = behavior
         self._pose_version = pose_version
         self._classifier_type = classifier_type
+        self._classifier_mode = classifier_mode
         self._training_seed = training_seed
 
     def run(self) -> None:
         """Run the export in the background thread."""
         try:
             self.current_status.emit("Exporting training data...")
-            out_path = export_training_data(
-                self._project,
-                self._behavior,
-                self._pose_version,
-                self._classifier_type,
-                self._training_seed,
-            )
+            if self._classifier_mode == ClassifierMode.MULTICLASS:
+                out_path = export_training_data_multiclass(
+                    self._project,
+                    self._pose_version,
+                    self._classifier_type,
+                    self._training_seed,
+                )
+            else:
+                out_path = export_training_data(
+                    self._project,
+                    self._behavior,
+                    self._pose_version,
+                    self._classifier_type,
+                    self._training_seed,
+                )
             self.export_complete.emit(out_path)
         except Exception as e:
             self.error_callback.emit(e)

--- a/src/jabs/ui/export_training_thread.py
+++ b/src/jabs/ui/export_training_thread.py
@@ -71,6 +71,8 @@ class ExportTrainingDataThread(QThread):
                     self._training_seed,
                 )
             else:
+                if self._behavior is None:
+                    raise ValueError("behavior is required for binary training-data export")
                 out_path = export_training_data(
                     self._project,
                     self._behavior,

--- a/src/jabs/ui/main_window/menu_handlers.py
+++ b/src/jabs/ui/main_window/menu_handlers.py
@@ -166,11 +166,17 @@ class MenuHandlers:
             )
             return
 
+        classifier_mode = self.window._project.settings_manager.classifier_mode
         self._export_thread = ExportTrainingDataThread(
             project=self.window._project,
-            behavior=self.window._central_widget.behavior,
             pose_version=self.window._project.feature_manager.min_pose_version,
             classifier_type=self.window._central_widget.classifier_type,
+            classifier_mode=classifier_mode,
+            behavior=(
+                self.window._central_widget.behavior
+                if classifier_mode == ClassifierMode.BINARY
+                else None
+            ),
             training_seed=FINAL_TRAIN_SEED,
             parent=self.window,
         )

--- a/src/jabs/ui/training_thread.py
+++ b/src/jabs/ui/training_thread.py
@@ -161,7 +161,7 @@ class TrainingThread(QThread):
                     features["labels_by_behavior"],
                     behavior_names,
                 )
-                class_names = [MULTICLASS_NONE_BEHAVIOR, *behavior_names]
+                class_names = self._classifier.get_class_names()
                 class_frame_counts = {
                     name: int(np.sum(merged_labels == class_idx))
                     for class_idx, name in enumerate(class_names)

--- a/tests/classifier/test_multi_class_classifier.py
+++ b/tests/classifier/test_multi_class_classifier.py
@@ -242,7 +242,7 @@ class TestMultiClassClassifierInit:
 def test_get_class_names():
     """get_class_names returns background + behavior names in order."""
     clf = MultiClassClassifier(["walking", "rearing"])
-    assert clf.get_class_names() == ["background", "walking", "rearing"]
+    assert clf.get_class_names() == [MULTICLASS_NONE_BEHAVIOR, "walking", "rearing"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/project/test_export_training_multiclass.py
+++ b/tests/project/test_export_training_multiclass.py
@@ -1,0 +1,292 @@
+"""Tests for multi-class training data export and round-trip retraining."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from jabs.core.constants import FINAL_TRAIN_SEED, MULTICLASS_NONE_BEHAVIOR
+from jabs.core.enums import ClassifierMode, ClassifierType
+from jabs.project import export_training_data, export_training_data_multiclass
+from jabs.project.read_training import load_multiclass_training_data
+from jabs.project.track_labels import TrackLabels
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_multiclass_project(tmp_path: Path, behavior_names: list[str]) -> MagicMock:
+    """Build a minimal Project-like mock for export tests."""
+    n_rows = 6
+    per_frame = pd.DataFrame({"feat_a": np.arange(n_rows, dtype=np.float32)})
+    window = pd.DataFrame({"feat_b": np.arange(n_rows, dtype=np.float32) * 0.1})
+    groups = np.array([0, 0, 0, 1, 1, 1], dtype=np.int32)
+
+    # Three frames each: "None" labeled, Walk labeled, Run labeled
+    labels_by_behavior: dict[str, np.ndarray] = {
+        MULTICLASS_NONE_BEHAVIOR: np.array(
+            [
+                TrackLabels.Label.BEHAVIOR,
+                TrackLabels.Label.NONE,
+                TrackLabels.Label.NONE,
+                TrackLabels.Label.BEHAVIOR,
+                TrackLabels.Label.NONE,
+                TrackLabels.Label.NONE,
+            ],
+            dtype=np.int8,
+        ),
+    }
+    for i, name in enumerate(behavior_names):
+        arr = np.full(n_rows, TrackLabels.Label.NONE, dtype=np.int8)
+        arr[i + 1] = TrackLabels.Label.BEHAVIOR
+        arr[i + 4] = TrackLabels.Label.BEHAVIOR
+        labels_by_behavior[name] = arr
+
+    features = {
+        "per_frame": per_frame,
+        "window": window,
+        "labels_by_behavior": labels_by_behavior,
+        "groups": groups,
+    }
+    group_mapping = {
+        0: {"video": "vid_a.mp4", "identity": 0},
+        1: {"video": "vid_b.mp4", "identity": None},
+    }
+
+    project = MagicMock()
+    project.dir = tmp_path
+    project.get_multiclass_labeled_features.return_value = (features, group_mapping)
+    project.get_project_defaults.return_value = {"window_size": 5, "balance_labels": False}
+    project.settings_manager = SimpleNamespace(
+        classifier_mode=ClassifierMode.MULTICLASS,
+        behavior_names=behavior_names,
+    )
+    project.feature_manager = SimpleNamespace(min_pose_version=6)
+    return project
+
+
+# ---------------------------------------------------------------------------
+# Schema tests
+# ---------------------------------------------------------------------------
+
+
+def test_multiclass_export_attrs(tmp_path: Path) -> None:
+    """Exported file has the expected top-level attributes."""
+    import h5py
+
+    behavior_names = ["Walk", "Run"]
+    project = _make_multiclass_project(tmp_path, behavior_names)
+    out = export_training_data_multiclass(
+        project, pose_version=6, classifier_type=ClassifierType.RANDOM_FOREST
+    )
+
+    with h5py.File(out, "r") as f:
+        assert f.attrs["classifier_mode"] == "multiclass"
+        assert f.attrs["classifier_type"] == ClassifierType.RANDOM_FOREST.value
+        assert f.attrs["min_pose_version"] == 6
+        assert f.attrs["training_seed"] == FINAL_TRAIN_SEED
+
+
+def test_multiclass_export_class_names(tmp_path: Path) -> None:
+    """class_names dataset has background at index 0 followed by behavior names."""
+    import h5py
+
+    behavior_names = ["Walk", "Run"]
+    project = _make_multiclass_project(tmp_path, behavior_names)
+    out = export_training_data_multiclass(
+        project, pose_version=6, classifier_type=ClassifierType.RANDOM_FOREST
+    )
+
+    with h5py.File(out, "r") as f:
+        raw = f["class_names"][:]
+        class_names = [n.decode() if isinstance(n, bytes) else str(n) for n in raw]
+
+    assert class_names[0] == MULTICLASS_NONE_BEHAVIOR
+    assert class_names[1:] == behavior_names
+
+
+def test_multiclass_export_label_datasets(tmp_path: Path) -> None:
+    """labels/ group contains one dataset per class, indexed by class position."""
+    import h5py
+
+    behavior_names = ["Walk", "Run"]
+    project = _make_multiclass_project(tmp_path, behavior_names)
+    out = export_training_data_multiclass(
+        project, pose_version=6, classifier_type=ClassifierType.RANDOM_FOREST
+    )
+
+    with h5py.File(out, "r") as f:
+        n_classes = len(behavior_names) + 1
+        assert set(f["labels"].keys()) == {str(i) for i in range(n_classes)}
+        # Dataset shapes must match feature rows
+        n_rows = f["features/per_frame/feat_a"].shape[0]
+        for i in range(n_classes):
+            assert f[f"labels/{i}"].shape == (n_rows,)
+
+
+def test_multiclass_export_group_mapping(tmp_path: Path) -> None:
+    """group_mapping is written correctly; VIDEO-strategy identity stored as -1."""
+    import h5py
+
+    behavior_names = ["Walk"]
+    project = _make_multiclass_project(tmp_path, behavior_names)
+    out = export_training_data_multiclass(
+        project, pose_version=6, classifier_type=ClassifierType.RANDOM_FOREST
+    )
+
+    with h5py.File(out, "r") as f:
+        assert f["group_mapping/0/identity"][0] == 0
+        assert f["group_mapping/1/identity"][0] == -1
+
+
+def test_multiclass_export_no_behavior_names_attr(tmp_path: Path) -> None:
+    """Multiclass export does not contain the binary-only 'behavior' attr."""
+    import h5py
+
+    project = _make_multiclass_project(tmp_path, ["Walk"])
+    out = export_training_data_multiclass(
+        project, pose_version=6, classifier_type=ClassifierType.RANDOM_FOREST
+    )
+
+    with h5py.File(out, "r") as f:
+        assert "behavior" not in f.attrs
+
+
+# ---------------------------------------------------------------------------
+# Reader tests
+# ---------------------------------------------------------------------------
+
+
+def test_load_multiclass_training_data_roundtrip(tmp_path: Path) -> None:
+    """load_multiclass_training_data reconstructs class_names and labels_by_behavior."""
+    behavior_names = ["Walk", "Run"]
+    project = _make_multiclass_project(tmp_path, behavior_names)
+    out = export_training_data_multiclass(
+        project, pose_version=6, classifier_type=ClassifierType.RANDOM_FOREST
+    )
+
+    loaded, group_mapping = load_multiclass_training_data(out)
+
+    assert loaded["class_names"] == [MULTICLASS_NONE_BEHAVIOR, "Walk", "Run"]
+    assert loaded["behavior_names"] == ["Walk", "Run"]
+    assert set(loaded["labels_by_behavior"].keys()) == {MULTICLASS_NONE_BEHAVIOR, "Walk", "Run"}
+    assert loaded["classifier_type"] == ClassifierType.RANDOM_FOREST
+    assert loaded["training_seed"] == FINAL_TRAIN_SEED
+    assert isinstance(loaded["per_frame"], pd.DataFrame)
+    assert isinstance(loaded["window"], pd.DataFrame)
+    assert loaded["per_frame"].shape[0] == loaded["window"].shape[0]
+    # Identity None sentinel decoded correctly
+    assert group_mapping[1]["identity"] is None
+    assert group_mapping[0]["identity"] == 0
+
+
+def test_load_multiclass_rejects_binary_file(tmp_path: Path) -> None:
+    """load_multiclass_training_data raises ValueError on a binary training file."""
+    binary_project = MagicMock()
+    binary_project.dir = tmp_path
+    binary_project.get_labeled_features.return_value = (
+        {
+            "per_frame": pd.DataFrame({"feat_a": [1.0, 2.0]}),
+            "window": pd.DataFrame({"feat_b": [0.1, 0.2]}),
+            "labels": np.array([1, 0], dtype=np.int8),
+            "groups": np.array([0, 1], dtype=np.int32),
+        },
+        {0: {"video": "v.mp4", "identity": 0}},
+    )
+    binary_project.settings_manager = SimpleNamespace(
+        get_behavior=lambda _: {"window_size": 5, "balance_labels": False},
+    )
+    binary_project.feature_manager = SimpleNamespace(min_pose_version=6)
+
+    binary_out = export_training_data(binary_project, "Walk", 6, ClassifierType.RANDOM_FOREST)
+
+    with pytest.raises(ValueError, match="not a multi-class training file"):
+        load_multiclass_training_data(binary_out)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip retrain test
+# ---------------------------------------------------------------------------
+
+
+def test_multiclass_from_training_file_roundtrip(tmp_path: Path) -> None:
+    """MultiClassClassifier.from_training_file trains successfully from an export."""
+    from jabs.classifier.multi_class_classifier import MultiClassClassifier
+
+    behavior_names = ["Walk", "Run"]
+    project = _make_multiclass_project(tmp_path, behavior_names)
+    out = export_training_data_multiclass(
+        project, pose_version=6, classifier_type=ClassifierType.RANDOM_FOREST
+    )
+
+    clf = MultiClassClassifier.from_training_file(out)
+
+    assert clf.behavior_names == behavior_names
+    assert clf.get_class_names() == [MULTICLASS_NONE_BEHAVIOR, "Walk", "Run"]
+    assert clf.classifier_type == ClassifierType.RANDOM_FOREST
+    assert clf._classifier_file == out.name
+    assert clf._classifier_source == "training_file"
+
+
+# ---------------------------------------------------------------------------
+# CLI branching tests
+# ---------------------------------------------------------------------------
+
+
+def test_cli_binary_requires_behavior(tmp_path: Path) -> None:
+    """export-training without --behavior on a binary project raises an error."""
+    from click.testing import CliRunner
+
+    from jabs.scripts.cli.cli import cli
+
+    runner = CliRunner()
+
+    # Patch Project so no real directory is needed
+    import jabs.scripts.cli.cli as cli_module
+
+    fake_project = MagicMock()
+    fake_project.settings_manager = SimpleNamespace(
+        classifier_mode=ClassifierMode.BINARY,
+    )
+
+    original_project = cli_module.Project
+    cli_module.Project = MagicMock(return_value=fake_project)
+    try:
+        result = runner.invoke(cli, ["export-training", str(tmp_path)])
+    finally:
+        cli_module.Project = original_project
+
+    assert result.exit_code != 0
+    assert "--behavior is required" in result.output
+
+
+def test_cli_multiclass_does_not_require_behavior(tmp_path: Path) -> None:
+    """export-training without --behavior on a multiclass project succeeds."""
+    from click.testing import CliRunner
+
+    import jabs.scripts.cli.cli as cli_module
+    from jabs.scripts.cli.cli import cli
+
+    behavior_names = ["Walk", "Run"]
+    project = _make_multiclass_project(tmp_path, behavior_names)
+    project.settings_manager.classifier_mode = ClassifierMode.MULTICLASS
+    project.feature_manager.min_pose_version = 6
+
+    original_project = cli_module.Project
+    original_export = cli_module.export_training_data_multiclass
+    cli_module.Project = MagicMock(return_value=project)
+    out_path = tmp_path / "mc.h5"
+    cli_module.export_training_data_multiclass = MagicMock(return_value=out_path)
+    try:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["export-training", str(tmp_path)])
+    finally:
+        cli_module.Project = original_project
+        cli_module.export_training_data_multiclass = original_export
+
+    assert result.exit_code == 0, result.output
+    assert "Exported training data" in result.output

--- a/tests/ui/test_classification_thread.py
+++ b/tests/ui/test_classification_thread.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 try:
+    from jabs.core.constants import MULTICLASS_NONE_BEHAVIOR
     from jabs.core.enums import ClassifierMode, ProjectDistanceUnit
     from jabs.project.prediction_manager import MULTICLASS_PREDICTION_KEY
     from jabs.ui.classification_thread import ClassifyThread
@@ -61,7 +62,7 @@ class _FakeClassifier:
 
     @staticmethod
     def get_class_names() -> list[str]:
-        return ["background", "Walk", "Run"]
+        return [MULTICLASS_NONE_BEHAVIOR, "Walk", "Run"]
 
 
 class _FakePose:

--- a/tests/ui/test_training_thread.py
+++ b/tests/ui/test_training_thread.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 
 try:
+    from jabs.core.constants import MULTICLASS_NONE_BEHAVIOR
     from jabs.core.enums import (
         ClassifierMode,
         CrossValidationGroupingStrategy,
@@ -44,6 +45,9 @@ class _FakeClassifier:
         call = dict(data)
         call["random_seed"] = random_seed
         self.train_calls.append(call)
+
+    def get_class_names(self) -> list[str]:
+        return [MULTICLASS_NONE_BEHAVIOR, *self.behavior_names]
 
     @staticmethod
     def get_feature_importance(limit: int = 20) -> list[tuple[str, float]]:

--- a/tests/ui/test_training_thread.py
+++ b/tests/ui/test_training_thread.py
@@ -102,6 +102,7 @@ class _FakeProject:
         self,
         progress_callable=None,
         should_terminate_callable=None,
+        behavior_settings=None,
     ) -> tuple[dict, dict]:
         self.multiclass_calls += 1
         if should_terminate_callable is not None:


### PR DESCRIPTION
This pull request adds support for exporting and loading multi-class training data for the `MultiClassClassifier`, enabling retraining and transfer of multi-class classifiers outside the current environment. It introduces a new `export_training_data_multiclass` function, a corresponding loader, and updates the CLI to handle multi-class projects. The changes also clarify and standardize the use of the `MULTICLASS_NONE_BEHAVIOR` class throughout the documentation and code.

**Multi-class training data export and loading:**

* Added `export_training_data_multiclass` to `src/jabs/project/export_training.py` for exporting multi-class labeled training data to HDF5, including all behaviors and stable class-index mapping.
* Implemented `load_multiclass_training_data` in `src/jabs/project/read_training.py` to load multi-class training data from exported HDF5 files, returning features and group mappings.
* Updated `src/jabs/project/__init__.py` to expose the new export and load functions in the public API. [[1]](diffhunk://#diff-e161bfdf176761101c43ccf1e07da739786a15b4a930976437153805e71273c1L3-R6) [[2]](diffhunk://#diff-e161bfdf176761101c43ccf1e07da739786a15b4a930976437153805e71273c1R17-R19)

**MultiClassClassifier enhancements:**

* Added `MultiClassClassifier.from_training_file` class method to train a classifier from an exported multi-class training file.
* Updated all docstrings, comments, and class logic to consistently refer to the background class as `MULTICLASS_NONE_BEHAVIOR` rather than "background", and clarified merging/indexing rules. [[1]](diffhunk://#diff-3c8b106674e796cc6f9ef8df77d9e0c66cc7b0482b047d4fe7b6f29e9fcec130L47-R57) [[2]](diffhunk://#diff-3c8b106674e796cc6f9ef8df77d9e0c66cc7b0482b047d4fe7b6f29e9fcec130L87-R88) [[3]](diffhunk://#diff-3c8b106674e796cc6f9ef8df77d9e0c66cc7b0482b047d4fe7b6f29e9fcec130L127-R127) [[4]](diffhunk://#diff-3c8b106674e796cc6f9ef8df77d9e0c66cc7b0482b047d4fe7b6f29e9fcec130L176-R178) [[5]](diffhunk://#diff-3c8b106674e796cc6f9ef8df77d9e0c66cc7b0482b047d4fe7b6f29e9fcec130L343-R343) [[6]](diffhunk://#diff-3c8b106674e796cc6f9ef8df77d9e0c66cc7b0482b047d4fe7b6f29e9fcec130L503-R538) [[7]](diffhunk://#diff-3c8b106674e796cc6f9ef8df77d9e0c66cc7b0482b047d4fe7b6f29e9fcec130L553-R588)

**Command-line interface updates:**

* Modified the CLI export command to support multi-class projects: `--behavior` is now optional and ignored for multi-class projects, and the correct export function is called based on project mode. [[1]](diffhunk://#diff-84f7928161b01a9042340764bd1da4cdf95f8f9533a1aa2143a554240b3e82d8L17-R23) [[2]](diffhunk://#diff-84f7928161b01a9042340764bd1da4cdf95f8f9533a1aa2143a554240b3e82d8L65-R73) [[3]](diffhunk://#diff-84f7928161b01a9042340764bd1da4cdf95f8f9533a1aa2143a554240b3e82d8L84-R146)

