### PR TITLE
add jabs-cli compute-features, deprecate jabs-features

### DIFF
--- a/src/jabs/feature_extraction/features.py
+++ b/src/jabs/feature_extraction/features.py
@@ -691,6 +691,9 @@ class IdentityFeatures:
             ...
         }
         """
+        if self._per_frame is None:
+            self._per_frame = self._unflatten_per_frame(self._per_frame_flat)
+
         window_features = {}
 
         for key in self._feature_modules:

--- a/src/jabs/feature_extraction/features.py
+++ b/src/jabs/feature_extraction/features.py
@@ -104,7 +104,7 @@ class IdentityFeatures:
 
     def __init__(
         self,
-        source_file: str,
+        source_file: str | Path,
         identity: int,
         directory: str | Path | None,
         pose_est: PoseEstimation,

--- a/src/jabs/scripts/cli/cli.py
+++ b/src/jabs/scripts/cli/cli.py
@@ -17,6 +17,7 @@ from jabs.classifier import Classifier
 from jabs.core.enums import ClassifierType, CrossValidationGroupingStrategy
 from jabs.project import Project, export_training_data, get_videos_to_prune
 
+from .compute_features import compute_features_command
 from .convert_parquet import convert_parquet_command
 from .convert_to_nwb import run_conversion
 from .cross_validation import run_cross_validation
@@ -44,6 +45,7 @@ def cli(ctx: click.Context, verbose):
 
 
 cli.add_command(apply_postprocessing_command)
+cli.add_command(compute_features_command)
 cli.add_command(convert_parquet_command)
 cli.add_command(update_pose_command)
 cli.add_command(sample_pose_intervals_command)

--- a/src/jabs/scripts/cli/compute_features.py
+++ b/src/jabs/scripts/cli/compute_features.py
@@ -1,0 +1,130 @@
+"""Compute and cache JABS features for a pose file."""
+
+import logging
+from pathlib import Path
+
+import click
+
+from jabs.core.enums import CacheFormat, ProjectDistanceUnit
+from jabs.feature_extraction.features import IdentityFeatures
+from jabs.pose_estimation import get_pose_file_major_version, open_pose_file
+from jabs.project import Project
+
+logger = logging.getLogger(__name__)
+
+
+@click.command(name="compute-features")
+@click.option(
+    "--pose-file",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Pose file to compute features for.",
+)
+@click.option(
+    "--feature-dir",
+    required=True,
+    type=click.Path(file_okay=False, path_type=Path),
+    help="Directory to write output features.",
+)
+@click.option(
+    "--use-pixel-distances",
+    "use_pixel_distances",
+    is_flag=True,
+    help="Force pixel distance units (overrides the cm default when the pose file supports it).",
+)
+@click.option(
+    "-w",
+    "--window-size",
+    "window_sizes",
+    type=int,
+    multiple=True,
+    help=(
+        "Window size for features. Repeat to compute multiple window sizes "
+        "(e.g. -w 5 -w 10). Omit to skip window feature computation."
+    ),
+)
+@click.option(
+    "--fps",
+    type=int,
+    default=30,
+    show_default=True,
+    help="Frames per second to use for feature calculation.",
+)
+@click.option(
+    "--use-pose-hash",
+    is_flag=True,
+    default=False,
+    help=(
+        "Include the pose file hash as a subdirectory level in the feature cache path "
+        "(e.g. <feature-dir>/<video>/<pose-hash>/<identity>); "
+        "prevents collisions when a shared cache dir is used across multiple pipelines."
+    ),
+)
+@click.option(
+    "--cache-format",
+    type=click.Choice([f.value for f in CacheFormat], case_sensitive=False),
+    default=CacheFormat.PARQUET.value,
+    show_default=True,
+    help="Storage format for the feature cache.",
+)
+def compute_features_command(
+    pose_file: Path,
+    feature_dir: Path,
+    use_pixel_distances: bool,
+    window_sizes: tuple[int, ...],
+    fps: int,
+    use_pose_hash: bool,
+    cache_format: str,
+) -> None:
+    """Compute and cache JABS features for a pose file.
+
+    The pose file version is inferred from the filename (e.g. *_pose_est_v6.h5).
+    Distance units default to cm when the pose file provides a pixel-to-cm
+    scale, otherwise pixel; use --use-pixel-distances to force pixel units.
+    """
+    try:
+        pose_version = get_pose_file_major_version(pose_file)
+    except (AttributeError, ValueError) as e:
+        raise click.ClickException(
+            f"Unable to determine pose version from filename '{pose_file.name}'; "
+            "expected a name like '*_pose_est_v<N>.h5'."
+        ) from e
+
+    pose_est = open_pose_file(pose_file)
+
+    if use_pixel_distances or pose_est.cm_per_pixel is None:
+        distance_unit = ProjectDistanceUnit.PIXEL
+    else:
+        distance_unit = ProjectDistanceUnit.CM
+
+    settings = Project.settings_by_pose_version(pose_version, distance_unit)
+
+    sorted_window_sizes = sorted(set(window_sizes))
+    cache_window = bool(sorted_window_sizes)
+
+    cache_format_enum = CacheFormat(cache_format.lower())
+
+    logger.info(
+        "computing features for %s (pose v%s, %s, cache=%s)",
+        pose_file,
+        pose_version,
+        distance_unit.name,
+        cache_format_enum.value,
+    )
+
+    for curr_id in pose_est.identities:
+        # Note: Features are still cached with the highest pose version.
+        # It isn't until get_features is called that filtering occurs.
+        features = IdentityFeatures(
+            pose_file,
+            curr_id,
+            feature_dir,
+            pose_est,
+            fps=fps,
+            op_settings=settings,
+            cache_window=cache_window,
+            cache_format=cache_format_enum,
+            include_pose_hash=use_pose_hash,
+        )
+        for ws in sorted_window_sizes:
+            _ = features.get_window_features(ws, settings["social"], force=True)

--- a/src/jabs/scripts/cli/compute_features.py
+++ b/src/jabs/scripts/cli/compute_features.py
@@ -4,6 +4,7 @@ import logging
 from pathlib import Path
 
 import click
+from rich.console import Console
 
 from jabs.core.enums import CacheFormat, ProjectDistanceUnit
 from jabs.feature_extraction.features import IdentityFeatures
@@ -67,6 +68,12 @@ logger = logging.getLogger(__name__)
     show_default=True,
     help="Storage format for the feature cache.",
 )
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Recompute features and overwrite the cache even when a valid cache exists.",
+)
 def compute_features_command(
     pose_file: Path,
     feature_dir: Path,
@@ -75,6 +82,7 @@ def compute_features_command(
     fps: int,
     use_pose_hash: bool,
     cache_format: str,
+    force: bool,
 ) -> None:
     """Compute and cache JABS features for a pose file.
 
@@ -90,7 +98,9 @@ def compute_features_command(
             "expected a name like '*_pose_est_v<N>.h5'."
         ) from e
 
-    pose_est = open_pose_file(pose_file)
+    console = Console()
+    with console.status(f"Opening pose file {pose_file.name}...", spinner="dots"):
+        pose_est = open_pose_file(pose_file)
 
     if use_pixel_distances or pose_est.cm_per_pixel is None:
         distance_unit = ProjectDistanceUnit.PIXEL
@@ -112,19 +122,30 @@ def compute_features_command(
         cache_format_enum.value,
     )
 
-    for curr_id in pose_est.identities:
-        # Note: Features are still cached with the highest pose version.
-        # It isn't until get_features is called that filtering occurs.
-        features = IdentityFeatures(
-            pose_file,
-            curr_id,
-            feature_dir,
-            pose_est,
-            fps=fps,
-            op_settings=settings,
-            cache_window=cache_window,
-            cache_format=cache_format_enum,
-            include_pose_hash=use_pose_hash,
-        )
-        for ws in sorted_window_sizes:
-            _ = features.get_window_features(ws, force=True)
+    identities = list(pose_est.identities)
+    with console.status("Computing features...", spinner="dots") as status:
+        for curr_id in identities:
+            status.update(
+                f"Computing per-frame features for identity {curr_id} "
+                f"({identities.index(curr_id) + 1}/{len(identities)})..."
+            )
+            # Note: Features are still cached with the highest pose version.
+            # It isn't until get_features is called that filtering occurs.
+            features = IdentityFeatures(
+                pose_file,
+                curr_id,
+                feature_dir,
+                pose_est,
+                force=force,
+                fps=fps,
+                op_settings=settings,
+                cache_window=cache_window,
+                cache_format=cache_format_enum,
+                include_pose_hash=use_pose_hash,
+            )
+            for ws in sorted_window_sizes:
+                status.update(
+                    f"Computing window features (size={ws}) for identity {curr_id} "
+                    f"({identities.index(curr_id) + 1}/{len(identities)})..."
+                )
+                _ = features.get_window_features(ws, force=force)

--- a/src/jabs/scripts/cli/compute_features.py
+++ b/src/jabs/scripts/cli/compute_features.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
     "-w",
     "--window-size",
     "window_sizes",
-    type=int,
+    type=click.IntRange(min=1),
     multiple=True,
     help=(
         "Window size for features. Repeat to compute multiple window sizes "
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 )
 @click.option(
     "--fps",
-    type=int,
+    type=click.IntRange(min=1),
     default=30,
     show_default=True,
     help="Frames per second to use for feature calculation.",
@@ -127,4 +127,4 @@ def compute_features_command(
             include_pose_hash=use_pose_hash,
         )
         for ws in sorted_window_sizes:
-            _ = features.get_window_features(ws, settings["social"], force=True)
+            _ = features.get_window_features(ws, force=True)

--- a/src/jabs/scripts/generate_features.py
+++ b/src/jabs/scripts/generate_features.py
@@ -59,7 +59,12 @@ def generate_feature_cache(args):
 
 def main():
     """jabs-features"""
-    parser = argparse.ArgumentParser(prog=f"{script_name()} features")
+    script = Path(sys.argv[0]).name
+    print(
+        f"{script} is deprecated, use `jabs-cli compute-features` instead.",
+        file=sys.stderr,
+    )
+    parser = argparse.ArgumentParser()
     parser.add_argument(
         "--pose-file",
         required=True,
@@ -108,11 +113,6 @@ def main():
     args = parser.parse_args()
 
     generate_feature_cache(args)
-
-
-def script_name() -> str:
-    """return the script name"""
-    return Path(sys.argv[0]).name
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_compute_features.py
+++ b/tests/scripts/test_compute_features.py
@@ -1,0 +1,258 @@
+"""Tests for the compute-features CLI subcommand."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from jabs.core.enums import CacheFormat, ProjectDistanceUnit
+from jabs.scripts.cli.cli import cli
+
+MODULE = "jabs.scripts.cli.compute_features"
+
+
+def _make_pose_file(tmp_path: Path, name: str = "session_pose_est_v6.h5") -> Path:
+    pose_file = tmp_path / name
+    pose_file.touch()
+    return pose_file
+
+
+def _fake_pose(cm_per_pixel: float | None = None, identities: tuple[int, ...] = (0,)) -> MagicMock:
+    pose = MagicMock()
+    pose.cm_per_pixel = cm_per_pixel
+    pose.identities = identities
+    return pose
+
+
+def test_invalid_filename_rejected(tmp_path: Path) -> None:
+    """Filename without a recognizable _v<N>.h5 produces a clear error."""
+    bad_pose = tmp_path / "poses.h5"
+    bad_pose.touch()
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["compute-features", "--pose-file", str(bad_pose), "--feature-dir", str(tmp_path)],
+    )
+    assert result.exit_code != 0
+    assert "pose version" in result.output
+
+
+def test_window_size_rejects_zero(tmp_path: Path) -> None:
+    """--window-size 0 fails argument validation."""
+    pose_file = _make_pose_file(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "compute-features",
+            "--pose-file",
+            str(pose_file),
+            "--feature-dir",
+            str(tmp_path),
+            "--window-size",
+            "0",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "x>=1" in result.output or "Invalid value" in result.output
+
+
+def test_window_size_rejects_negative(tmp_path: Path) -> None:
+    """--window-size -1 fails argument validation."""
+    pose_file = _make_pose_file(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "compute-features",
+            "--pose-file",
+            str(pose_file),
+            "--feature-dir",
+            str(tmp_path),
+            "-w",
+            "-1",
+        ],
+    )
+    assert result.exit_code != 0
+
+
+def test_fps_rejects_zero(tmp_path: Path) -> None:
+    """--fps 0 fails argument validation."""
+    pose_file = _make_pose_file(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "compute-features",
+            "--pose-file",
+            str(pose_file),
+            "--feature-dir",
+            str(tmp_path),
+            "--fps",
+            "0",
+        ],
+    )
+    assert result.exit_code != 0
+
+
+def test_default_cm_when_pose_has_scale(tmp_path: Path) -> None:
+    """When pose file provides cm_per_pixel, distance unit defaults to CM."""
+    pose_file = _make_pose_file(tmp_path)
+    pose = _fake_pose(cm_per_pixel=0.05)
+    with (
+        patch(f"{MODULE}.open_pose_file", return_value=pose),
+        patch(f"{MODULE}.Project.settings_by_pose_version") as mock_settings,
+        patch(f"{MODULE}.IdentityFeatures") as mock_features_cls,
+    ):
+        mock_settings.return_value = {"social": False}
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "compute-features",
+                "--pose-file",
+                str(pose_file),
+                "--feature-dir",
+                str(tmp_path),
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    mock_settings.assert_called_once_with(6, ProjectDistanceUnit.CM)
+    mock_features_cls.assert_called_once()
+
+
+def test_default_pixel_when_pose_lacks_scale(tmp_path: Path) -> None:
+    """When pose file lacks cm_per_pixel, distance unit defaults to PIXEL."""
+    pose_file = _make_pose_file(tmp_path)
+    pose = _fake_pose(cm_per_pixel=None)
+    with (
+        patch(f"{MODULE}.open_pose_file", return_value=pose),
+        patch(f"{MODULE}.Project.settings_by_pose_version") as mock_settings,
+        patch(f"{MODULE}.IdentityFeatures"),
+    ):
+        mock_settings.return_value = {"social": False}
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "compute-features",
+                "--pose-file",
+                str(pose_file),
+                "--feature-dir",
+                str(tmp_path),
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    mock_settings.assert_called_once_with(6, ProjectDistanceUnit.PIXEL)
+
+
+def test_use_pixel_distances_overrides_cm_default(tmp_path: Path) -> None:
+    """--use-pixel-distances forces PIXEL even when the pose file has scale."""
+    pose_file = _make_pose_file(tmp_path)
+    pose = _fake_pose(cm_per_pixel=0.05)
+    with (
+        patch(f"{MODULE}.open_pose_file", return_value=pose),
+        patch(f"{MODULE}.Project.settings_by_pose_version") as mock_settings,
+        patch(f"{MODULE}.IdentityFeatures"),
+    ):
+        mock_settings.return_value = {"social": False}
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "compute-features",
+                "--pose-file",
+                str(pose_file),
+                "--feature-dir",
+                str(tmp_path),
+                "--use-pixel-distances",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    mock_settings.assert_called_once_with(6, ProjectDistanceUnit.PIXEL)
+
+
+def test_identity_features_invoked_with_expected_args(tmp_path: Path) -> None:
+    """IdentityFeatures is constructed once per identity with the right kwargs."""
+    pose_file = _make_pose_file(tmp_path, "rec_pose_est_v8.h5")
+    feature_dir = tmp_path / "feats"
+    pose = _fake_pose(cm_per_pixel=0.04, identities=(0, 1))
+    settings = {"social": True}
+
+    fake_features = MagicMock()
+    with (
+        patch(f"{MODULE}.open_pose_file", return_value=pose),
+        patch(f"{MODULE}.Project.settings_by_pose_version", return_value=settings),
+        patch(f"{MODULE}.IdentityFeatures", return_value=fake_features) as mock_features_cls,
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "compute-features",
+                "--pose-file",
+                str(pose_file),
+                "--feature-dir",
+                str(feature_dir),
+                "--fps",
+                "60",
+                "--cache-format",
+                "hdf5",
+                "--use-pose-hash",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert mock_features_cls.call_count == 2
+    for call, expected_id in zip(mock_features_cls.call_args_list, (0, 1), strict=True):
+        args, kwargs = call
+        assert args == (pose_file, expected_id, feature_dir, pose)
+        assert kwargs == {
+            "fps": 60,
+            "op_settings": settings,
+            "cache_window": False,
+            "cache_format": CacheFormat.HDF5,
+            "include_pose_hash": True,
+        }
+    fake_features.get_window_features.assert_not_called()
+
+
+def test_window_sizes_iterated_dedup_sorted(tmp_path: Path) -> None:
+    """Repeated -w values are deduplicated, sorted, and each triggers a window feature call."""
+    pose_file = _make_pose_file(tmp_path)
+    pose = _fake_pose(cm_per_pixel=0.05, identities=(0,))
+
+    fake_features = MagicMock()
+    with (
+        patch(f"{MODULE}.open_pose_file", return_value=pose),
+        patch(f"{MODULE}.Project.settings_by_pose_version", return_value={"social": False}),
+        patch(f"{MODULE}.IdentityFeatures", return_value=fake_features) as mock_features_cls,
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "compute-features",
+                "--pose-file",
+                str(pose_file),
+                "--feature-dir",
+                str(tmp_path),
+                "-w",
+                "10",
+                "-w",
+                "5",
+                "-w",
+                "10",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    _, kwargs = mock_features_cls.call_args
+    assert kwargs["cache_window"] is True
+    assert fake_features.get_window_features.call_count == 2
+    called_sizes = [call.args[0] for call in fake_features.get_window_features.call_args_list]
+    assert called_sizes == [5, 10]
+    for call in fake_features.get_window_features.call_args_list:
+        assert call.kwargs == {"force": True}

--- a/tests/scripts/test_compute_features.py
+++ b/tests/scripts/test_compute_features.py
@@ -210,6 +210,7 @@ def test_identity_features_invoked_with_expected_args(tmp_path: Path) -> None:
         args, kwargs = call
         assert args == (pose_file, expected_id, feature_dir, pose)
         assert kwargs == {
+            "force": False,
             "fps": 60,
             "op_settings": settings,
             "cache_window": False,
@@ -255,4 +256,36 @@ def test_window_sizes_iterated_dedup_sorted(tmp_path: Path) -> None:
     called_sizes = [call.args[0] for call in fake_features.get_window_features.call_args_list]
     assert called_sizes == [5, 10]
     for call in fake_features.get_window_features.call_args_list:
-        assert call.kwargs == {"force": True}
+        assert call.kwargs == {"force": False}
+
+
+def test_force_flag_forwarded(tmp_path: Path) -> None:
+    """--force is forwarded to IdentityFeatures and get_window_features."""
+    pose_file = _make_pose_file(tmp_path)
+    pose = _fake_pose(cm_per_pixel=0.05, identities=(0,))
+
+    fake_features = MagicMock()
+    with (
+        patch(f"{MODULE}.open_pose_file", return_value=pose),
+        patch(f"{MODULE}.Project.settings_by_pose_version", return_value={"social": False}),
+        patch(f"{MODULE}.IdentityFeatures", return_value=fake_features) as mock_features_cls,
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "compute-features",
+                "--pose-file",
+                str(pose_file),
+                "--feature-dir",
+                str(tmp_path),
+                "-w",
+                "5",
+                "--force",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    _, kwargs = mock_features_cls.call_args
+    assert kwargs["force"] is True
+    fake_features.get_window_features.assert_called_once_with(5, force=True)


### PR DESCRIPTION
This pull request introduces a new CLI command for computing and caching JABS features, modernizes argument types, and begins deprecating the old feature generation script. The most important changes are summarized below:

**New CLI Command for Feature Computation:**

* Added a new `compute-features` command to the CLI, implemented in `compute_features.py`, which provides a robust and user-friendly interface for computing and caching features from pose files. This includes options for window sizes, distance units, cache format, and pose hash handling.
* Registered the new `compute-features` command in the main CLI by importing and adding it to the command group in `cli.py`. [[1]](diffhunk://#diff-84f7928161b01a9042340764bd1da4cdf95f8f9533a1aa2143a554240b3e82d8R20) [[2]](diffhunk://#diff-84f7928161b01a9042340764bd1da4cdf95f8f9533a1aa2143a554240b3e82d8R48)

**Type and Interface Improvements:**

* Updated the `IdentityFeatures` class constructor to accept `source_file` as either a `str` or a `Path`

**Deprecation of Old Feature Generation Script:**

* Modified `generate_features.py` to print a deprecation warning directing users to use the new `jabs-cli compute-features` command, and simplified its argument parsing.