### PR TITLE
Fix rename_behavior desync in multi-class projects

### DIFF
--- a/src/jabs/classifier/base.py
+++ b/src/jabs/classifier/base.py
@@ -223,6 +223,20 @@ class BaseClassifier:
         feature_importance.sort(key=lambda x: x[1], reverse=True)
         return feature_importance[:limit]
 
+    def reset_persistence_identity(self) -> None:
+        """Clear the recorded file identity (path, hash, source).
+
+        ``save()`` only (re)computes ``_classifier_hash`` when
+        ``_classifier_file`` is ``None``, so an already-persisted classifier
+        keeps its previous hash even if its contents change. Call this after
+        mutating persisted state (e.g. renaming a class) so the next ``save()``
+        records a hash matching the rewritten file. ``train()`` performs the
+        same null-out after refitting.
+        """
+        self._classifier_file = None
+        self._classifier_hash = None
+        self._classifier_source = None
+
     def save(self, path: Path) -> None:
         """Serialize the classifier to disk using joblib.
 

--- a/src/jabs/classifier/multi_class_classifier.py
+++ b/src/jabs/classifier/multi_class_classifier.py
@@ -118,6 +118,32 @@ class MultiClassClassifier(BaseClassifier):
         """
         return [MULTICLASS_NONE_BEHAVIOR, *self._behavior_names]
 
+    def rename_behavior(self, old_name: str, new_name: str) -> None:
+        """Rename a behavior class in place, preserving class-index order.
+
+        The behavior keeps its existing class index, so a previously trained
+        model and any saved predictions referencing that index remain valid.
+
+        Args:
+            old_name: Current behavior name. Must be one of ``behavior_names``.
+            new_name: Replacement name. Must not already be present and must not
+                collide with the reserved ``MULTICLASS_NONE_BEHAVIOR`` name.
+
+        Raises:
+            ValueError: If ``old_name`` is not a known behavior, if ``new_name``
+                is already present, or if ``new_name`` is the reserved name.
+        """
+        if old_name not in self._behavior_names:
+            raise ValueError(f"behavior {old_name!r} is not known to this classifier")
+        if new_name == MULTICLASS_NONE_BEHAVIOR:
+            raise ValueError(
+                f"new behavior name must not be the reserved name {MULTICLASS_NONE_BEHAVIOR!r}"
+            )
+        if new_name in self._behavior_names:
+            raise ValueError(f"behavior {new_name!r} already exists")
+
+        self._behavior_names[self._behavior_names.index(old_name)] = new_name
+
     def set_project_settings(self, project) -> None:
         """Copy project defaults as classifier settings."""
         self._project_settings = dict(project.get_project_defaults())

--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -41,7 +41,7 @@ from .parallel_workers import (
     collect_multiclass_labeled_features,
     scan_video_metadata,
 )
-from .prediction_manager import PredictionManager
+from .prediction_manager import MULTICLASS_PREDICTION_KEY, PredictionManager
 from .project_paths import ProjectPaths
 from .project_utils import to_safe_name
 from .session_tracker import SessionTracker
@@ -1303,6 +1303,36 @@ class Project:
         if new_name in self._settings_manager.behavior_names:
             raise ValueError(f"Behavior {new_name} already exists in project")
 
+        # Classifier and prediction storage differs between modes, so update the
+        # mode-specific artifacts separately.
+        if self._settings_manager.classifier_mode == ClassifierMode.MULTICLASS:
+            self._rename_behavior_multiclass_artifacts(old_name, new_name)
+        else:
+            self._rename_behavior_binary_artifacts(old_name, new_name)
+
+        # rename labels inside every video's annotation file (mode-independent:
+        # labels are always keyed by behavior name on disk)
+        for video in self._video_manager.videos:
+            if (labels := self._video_manager.load_video_labels(video)) is None:
+                continue
+            labels.rename_behavior(old_name, new_name)
+            pose = self.load_pose_est(self._video_manager.video_path(video))
+            self.save_annotations(labels, pose)
+
+        # update project settings
+        self._settings_manager.rename_behavior(old_name, new_name)
+
+    def _rename_behavior_binary_artifacts(self, old_name: str, new_name: str) -> None:
+        """Rename binary-mode classifier and prediction artifacts for a behavior.
+
+        Binary mode stores one classifier pickle per behavior (keyed by safe
+        name) and one prediction group per behavior inside each video's HDF5
+        file. Both are renamed to track the behavior's new name.
+
+        Args:
+            old_name: current behavior name
+            new_name: new behavior name
+        """
         safe_old_name = to_safe_name(old_name)
         safe_new_name = to_safe_name(new_name)
 
@@ -1315,21 +1345,61 @@ class Project:
         for video in self._video_manager.videos:
             # Rename predictions dataset inside the per-video HDF5 file.
             pred_file = self._paths.prediction_dir / Path(video).with_suffix(".h5").name
-            if pred_file.exists():
-                with h5py.File(pred_file, "r+") as hf:
-                    if "predictions" in hf and safe_old_name in hf["predictions"]:
-                        grp = hf["predictions"]
-                        # If dataset already exists at the destination, remove it first
-                        if safe_new_name in grp:
-                            del grp[safe_new_name]
-                        grp.move(safe_old_name, safe_new_name)
-
-            # rename labels inside annotation file
-            if (labels := self._video_manager.load_video_labels(video)) is None:
+            if not pred_file.exists():
                 continue
-            labels.rename_behavior(old_name, new_name)
-            pose = self.load_pose_est(self._video_manager.video_path(video))
-            self.save_annotations(labels, pose)
+            with h5py.File(pred_file, "r+") as hf:
+                if "predictions" in hf and safe_old_name in hf["predictions"]:
+                    grp = hf["predictions"]
+                    # If dataset already exists at the destination, remove it first
+                    if safe_new_name in grp:
+                        del grp[safe_new_name]
+                    grp.move(safe_old_name, safe_new_name)
 
-        # update project settings
-        self._settings_manager.rename_behavior(old_name, new_name)
+    def _rename_behavior_multiclass_artifacts(self, old_name: str, new_name: str) -> None:
+        """Rename multi-class classifier and prediction artifacts for a behavior.
+
+        Multi-class mode stores a single classifier pickle and a single
+        prediction group shared across all behaviors; the behavior name is
+        recorded inside each (``MultiClassClassifier._behavior_names`` and the
+        per-video ``class_names`` dataset). These are updated in place so they
+        do not desync from the project settings after a rename.
+
+        Args:
+            old_name: current behavior name
+            new_name: new behavior name
+        """
+        # Imported here rather than at module scope because jabs.classifier
+        # imports jabs.project, so a top-level import would be circular.
+        from jabs.classifier import MultiClassClassifier
+
+        # update behavior name inside the saved multi-class classifier
+        classifier_path = self._paths.classifier_dir / MULTICLASS_CLASSIFIER_FILENAME
+        if classifier_path.exists():
+            classifier = MultiClassClassifier.from_pickle(classifier_path)
+            if old_name in classifier.behavior_names:
+                classifier.rename_behavior(old_name, new_name)
+                classifier.save(classifier_path)
+
+        # update the class_names dataset inside each video's prediction group
+        safe_multiclass_name = to_safe_name(MULTICLASS_PREDICTION_KEY)
+        for video in self._video_manager.videos:
+            pred_file = self._paths.prediction_dir / Path(video).with_suffix(".h5").name
+            if not pred_file.exists():
+                continue
+            with h5py.File(pred_file, "r+") as hf:
+                group = hf.get(f"predictions/{safe_multiclass_name}")
+                if group is None or "class_names" not in group:
+                    continue
+                names = [
+                    v.decode("utf-8") if isinstance(v, bytes) else str(v)
+                    for v in group["class_names"][()]
+                ]
+                if old_name not in names:
+                    continue
+                names[names.index(old_name)] = new_name
+                del group["class_names"]
+                group.create_dataset(
+                    "class_names",
+                    data=np.array(names, dtype=object),
+                    dtype=h5py.string_dtype(encoding="utf-8"),
+                )

--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -1386,6 +1386,8 @@ class Project:
 
         # update behavior name inside the saved multi-class classifier
         classifier_path = self._paths.classifier_dir / MULTICLASS_CLASSIFIER_FILENAME
+        new_classifier_file: str | None = None
+        new_classifier_hash: str | None = None
         if classifier_path.exists():
             classifier = MultiClassClassifier.from_pickle(classifier_path)
             if old_name in classifier.behavior_names:
@@ -1394,6 +1396,10 @@ class Project:
                 # and let save() record a hash matching the rewritten file.
                 classifier.reset_persistence_identity()
                 classifier.save(classifier_path)
+                # Capture the rewritten pickle's identity so per-video prediction
+                # metadata can be repointed at the renamed classifier file.
+                new_classifier_file = classifier.classifier_file
+                new_classifier_hash = classifier.classifier_hash
 
         # update the class_names dataset inside each video's prediction group
         safe_multiclass_name = to_safe_name(MULTICLASS_PREDICTION_KEY)
@@ -1418,3 +1424,11 @@ class Project:
                     data=np.array(names, dtype=object),
                     dtype=h5py.string_dtype(encoding="utf-8"),
                 )
+                # The rename re-saved the classifier with a new content hash, so
+                # repoint this group's classifier metadata at the rewritten file;
+                # the predictions themselves remain valid (only a class name
+                # changed). Skipped when no classifier pickle was re-saved.
+                if new_classifier_file is not None:
+                    group.attrs["classifier_file"] = new_classifier_file
+                if new_classifier_hash is not None:
+                    group.attrs["classifier_hash"] = new_classifier_hash

--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -1303,6 +1303,18 @@ class Project:
         if new_name in self._settings_manager.behavior_names:
             raise ValueError(f"Behavior {new_name} already exists in project")
 
+        # In multi-class mode "None" is a reserved background class that must not
+        # appear in the project's behavior list. Reject the rename here so it is
+        # caught even when no multi-class classifier has been trained/saved yet.
+        if (
+            self._settings_manager.classifier_mode == ClassifierMode.MULTICLASS
+            and new_name == MULTICLASS_NONE_BEHAVIOR
+        ):
+            raise ValueError(
+                f"Cannot rename a behavior to the reserved multi-class name "
+                f"{MULTICLASS_NONE_BEHAVIOR!r}"
+            )
+
         # Classifier and prediction storage differs between modes, so update the
         # mode-specific artifacts separately.
         if self._settings_manager.classifier_mode == ClassifierMode.MULTICLASS:
@@ -1378,6 +1390,9 @@ class Project:
             classifier = MultiClassClassifier.from_pickle(classifier_path)
             if old_name in classifier.behavior_names:
                 classifier.rename_behavior(old_name, new_name)
+                # The pickle's contents changed, so drop the stale file identity
+                # and let save() record a hash matching the rewritten file.
+                classifier.reset_persistence_identity()
                 classifier.save(classifier_path)
 
         # update the class_names dataset inside each video's prediction group

--- a/tests/classifier/test_multi_class_classifier.py
+++ b/tests/classifier/test_multi_class_classifier.py
@@ -245,6 +245,45 @@ def test_get_class_names():
 
 
 # ---------------------------------------------------------------------------
+# rename_behavior
+# ---------------------------------------------------------------------------
+
+
+class TestRenameBehavior:
+    """Renaming a behavior preserves class-index order and validates inputs."""
+
+    def test_rename_preserves_class_index(self):
+        """Renaming keeps the behavior's position (and therefore class index)."""
+        clf = MultiClassClassifier(["walking", "rearing", "grooming"])
+        clf.rename_behavior("rearing", "standing")
+        assert clf.behavior_names == ["walking", "standing", "grooming"]
+        assert clf.get_class_names() == [
+            MULTICLASS_NONE_BEHAVIOR,
+            "walking",
+            "standing",
+            "grooming",
+        ]
+
+    def test_rename_unknown_behavior_raises(self):
+        """Renaming a behavior not in the classifier raises ValueError."""
+        clf = MultiClassClassifier(["walking", "rearing"])
+        with pytest.raises(ValueError, match="not known"):
+            clf.rename_behavior("missing", "standing")
+
+    def test_rename_to_existing_behavior_raises(self):
+        """Renaming to a name already present raises ValueError."""
+        clf = MultiClassClassifier(["walking", "rearing"])
+        with pytest.raises(ValueError, match="already exists"):
+            clf.rename_behavior("walking", "rearing")
+
+    def test_rename_to_reserved_name_raises(self):
+        """Renaming to the reserved None name raises ValueError."""
+        clf = MultiClassClassifier(["walking", "rearing"])
+        with pytest.raises(ValueError, match="reserved"):
+            clf.rename_behavior("walking", MULTICLASS_NONE_BEHAVIOR)
+
+
+# ---------------------------------------------------------------------------
 # Classifier compatibility surface
 # ---------------------------------------------------------------------------
 

--- a/tests/classifier/test_multi_class_classifier.py
+++ b/tests/classifier/test_multi_class_classifier.py
@@ -549,6 +549,22 @@ class TestSaveLoad:
         with pytest.raises(ValueError, match="not an instance of MultiClassClassifier"):
             clf.load(path)
 
+    def test_reset_persistence_identity_refreshes_hash_on_resave(self, trained_clf, tmp_path):
+        """After mutating contents, reset + save records a hash matching the new file."""
+        from jabs.core.utils import hash_file
+
+        path = tmp_path / "multi.pkl"
+        trained_clf.save(path)
+        original_hash = trained_clf.classifier_hash
+
+        # mutate persisted content, then reset identity before re-saving
+        trained_clf.rename_behavior(BEHAVIOR_NAMES[0], "renamed")
+        trained_clf.reset_persistence_identity()
+        trained_clf.save(path)
+
+        assert trained_clf.classifier_hash != original_hash
+        assert trained_clf.classifier_hash == hash_file(path)
+
 
 # ---------------------------------------------------------------------------
 # leave_one_group_out / get_leave_one_group_out_max

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -548,10 +548,13 @@ def test_rename_behavior_multiclass_updates_classifier_and_predictions(tmp_path:
     MultiClassClassifier(["Walk", "Run"]).save(classifier_path)
 
     # write a prediction file holding the shared multi-class class_names dataset
+    # plus stale classifier metadata referencing the pre-rename pickle
     safe_multiclass = to_safe_name(MULTICLASS_PREDICTION_KEY)
     pred_file = project.project_paths.prediction_dir / "video1.h5"
     with h5py.File(pred_file, "w") as hf:
         group = hf.create_group(f"predictions/{safe_multiclass}")
+        group.attrs["classifier_file"] = "_multiclass.pickle"
+        group.attrs["classifier_hash"] = "stale-pre-rename-hash"
         group.create_dataset(
             "class_names",
             data=np.array([MULTICLASS_NONE_BEHAVIOR, "Walk", "Run"], dtype=object),
@@ -567,9 +570,13 @@ def test_rename_behavior_multiclass_updates_classifier_and_predictions(tmp_path:
     # the rewritten pickle's recorded hash matches its new contents (not stale)
     assert reloaded.classifier_hash == hash_file(classifier_path)
 
-    # prediction class_names dataset updated, None class untouched
+    # prediction class_names dataset updated, None class untouched, and the
+    # group's classifier metadata repointed at the rewritten pickle
     with h5py.File(pred_file, "r") as hf:
-        names = [v.decode("utf-8") for v in hf[f"predictions/{safe_multiclass}/class_names"][()]]
+        group = hf[f"predictions/{safe_multiclass}"]
+        names = [v.decode("utf-8") for v in group["class_names"][()]]
+        assert group.attrs["classifier_hash"] == reloaded.classifier_hash
+        assert group.attrs["classifier_file"] == reloaded.classifier_file
     assert names == [MULTICLASS_NONE_BEHAVIOR, "Standing", "Run"]
 
     # project settings reflect the rename

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -4,16 +4,19 @@ import shutil
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import h5py
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import pytest
 
+from jabs.classifier import MultiClassClassifier
 from jabs.classifier.protocols import ClassifierProtocol
 from jabs.core.constants import CLASSIFIER_MODE_KEY, MULTICLASS_NONE_BEHAVIOR
 from jabs.core.enums import ClassifierMode
 from jabs.core.utils import hide_stderr
 from jabs.project import Project, VideoLabels
+from jabs.project.prediction_manager import MULTICLASS_PREDICTION_KEY
 from jabs.project.project_utils import to_safe_name
 from jabs.project.track_labels import TrackLabels
 
@@ -525,6 +528,50 @@ def test_overlapping_labels_multiple_videos_sorted(tmp_path: Path) -> None:
         },
     )
     assert project.get_overlapping_behavior_label_videos() == ["mmm.avi", "zzz.avi"]
+
+
+def test_rename_behavior_multiclass_updates_classifier_and_predictions(tmp_path: Path) -> None:
+    """In multi-class mode, rename updates the shared classifier and prediction class_names.
+
+    The single ``_multiclass.pickle`` and the per-video ``class_names`` dataset
+    are not behavior-keyed, so they must be updated in place rather than moved.
+    """
+    project = _make_project_with_mock_vm(tmp_path, {"video1.avi": None})
+    project.settings_manager.save_project_file(
+        {"settings": {CLASSIFIER_MODE_KEY: ClassifierMode.MULTICLASS.value}}
+    )
+    project.settings_manager.save_behavior("Walk", {})
+    project.settings_manager.save_behavior("Run", {})
+
+    # save a real multi-class classifier under the reserved filename
+    classifier_path = project.classifier_dir / "_multiclass.pickle"
+    MultiClassClassifier(["Walk", "Run"]).save(classifier_path)
+
+    # write a prediction file holding the shared multi-class class_names dataset
+    safe_multiclass = to_safe_name(MULTICLASS_PREDICTION_KEY)
+    pred_file = project.project_paths.prediction_dir / "video1.h5"
+    with h5py.File(pred_file, "w") as hf:
+        group = hf.create_group(f"predictions/{safe_multiclass}")
+        group.create_dataset(
+            "class_names",
+            data=np.array([MULTICLASS_NONE_BEHAVIOR, "Walk", "Run"], dtype=object),
+            dtype=h5py.string_dtype(encoding="utf-8"),
+        )
+
+    project.rename_behavior("Walk", "Standing")
+
+    # classifier behavior names updated in place (class index order preserved)
+    reloaded = MultiClassClassifier.from_pickle(classifier_path)
+    assert reloaded.behavior_names == ["Standing", "Run"]
+
+    # prediction class_names dataset updated, None class untouched
+    with h5py.File(pred_file, "r") as hf:
+        names = [v.decode("utf-8") for v in hf[f"predictions/{safe_multiclass}/class_names"][()]]
+    assert names == [MULTICLASS_NONE_BEHAVIOR, "Standing", "Run"]
+
+    # project settings reflect the rename
+    assert "Standing" in project.settings_manager.behavior_names
+    assert "Walk" not in project.settings_manager.behavior_names
 
 
 def test_get_multiclass_labeled_features_aligns_labels_and_features(

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -14,7 +14,7 @@ from jabs.classifier import MultiClassClassifier
 from jabs.classifier.protocols import ClassifierProtocol
 from jabs.core.constants import CLASSIFIER_MODE_KEY, MULTICLASS_NONE_BEHAVIOR
 from jabs.core.enums import ClassifierMode
-from jabs.core.utils import hide_stderr
+from jabs.core.utils import hash_file, hide_stderr
 from jabs.project import Project, VideoLabels
 from jabs.project.prediction_manager import MULTICLASS_PREDICTION_KEY
 from jabs.project.project_utils import to_safe_name
@@ -564,6 +564,9 @@ def test_rename_behavior_multiclass_updates_classifier_and_predictions(tmp_path:
     reloaded = MultiClassClassifier.from_pickle(classifier_path)
     assert reloaded.behavior_names == ["Standing", "Run"]
 
+    # the rewritten pickle's recorded hash matches its new contents (not stale)
+    assert reloaded.classifier_hash == hash_file(classifier_path)
+
     # prediction class_names dataset updated, None class untouched
     with h5py.File(pred_file, "r") as hf:
         names = [v.decode("utf-8") for v in hf[f"predictions/{safe_multiclass}/class_names"][()]]
@@ -572,6 +575,28 @@ def test_rename_behavior_multiclass_updates_classifier_and_predictions(tmp_path:
     # project settings reflect the rename
     assert "Standing" in project.settings_manager.behavior_names
     assert "Walk" not in project.settings_manager.behavior_names
+
+
+def test_rename_behavior_multiclass_rejects_reserved_none_name(tmp_path: Path) -> None:
+    """In multi-class mode, renaming a behavior to the reserved "None" name is rejected.
+
+    The guard lives at the project level so it fires even when no multi-class
+    classifier has been trained/saved yet (the in-classifier validation would
+    otherwise be skipped).
+    """
+    project = _make_project_with_mock_vm(tmp_path, {"video1.avi": None})
+    project.settings_manager.save_project_file(
+        {"settings": {CLASSIFIER_MODE_KEY: ClassifierMode.MULTICLASS.value}}
+    )
+    project.settings_manager.save_behavior("Walk", {})
+
+    # No _multiclass.pickle exists, so the only protection is the project guard.
+    with pytest.raises(ValueError, match="reserved"):
+        project.rename_behavior("Walk", MULTICLASS_NONE_BEHAVIOR)
+
+    # behavior list is unchanged and never gained the reserved name
+    assert "Walk" in project.settings_manager.behavior_names
+    assert MULTICLASS_NONE_BEHAVIOR not in project.settings_manager.behavior_names
 
 
 def test_get_multiclass_labeled_features_aligns_labels_and_features(


### PR DESCRIPTION
This pull request adds robust support for renaming behaviors in both multi-class and binary classifier modes, ensuring that all relevant artifacts (classifiers, prediction files, and project settings) are updated consistently. The update introduces a new `rename_behavior` method for the multi-class classifier, refactors the project-level renaming logic to handle both modes correctly, and adds comprehensive tests for these changes.

**Multi-class behavior renaming support:**

* Added a `rename_behavior` method to `MultiClassClassifier` that renames a behavior in place while preserving its class index and validating inputs. This ensures previously trained models and saved predictions remain valid.
* Updated `Project.rename_behavior` to handle multi-class and binary modes separately, with dedicated helper methods for updating classifiers and per-video prediction files in each mode. In multi-class mode, the classifier pickle and the `class_names` dataset in each prediction file are updated in place. [[1]](diffhunk://#diff-3f0889619eec01a6d80eb14b367f39989b008102a20334986d81f2d408882b62R1306-R1335) [[2]](diffhunk://#diff-3f0889619eec01a6d80eb14b367f39989b008102a20334986d81f2d408882b62L1318-R1349)

**Testing and validation:**

* Added a test class for `MultiClassClassifier.rename_behavior` covering successful renaming, error cases for unknown behaviors, duplicate names, and reserved names.
* Added an integration test to ensure that, in multi-class mode, renaming a behavior updates the classifier, the per-video `class_names` dataset, and the project settings as expected.

**Imports and code hygiene:**

* Updated imports in `project.py` and test files to ensure access to new constants and classes required for the new functionality and tests. [[1]](diffhunk://#diff-3f0889619eec01a6d80eb14b367f39989b008102a20334986d81f2d408882b62L44-R44) [[2]](diffhunk://#diff-b974140cf52b9dfded02bc399d62a4e3e6e980cbbaaa5da387d3c60ddf8ab293R7-R19)

These changes make behavior renaming safer and more consistent across the codebase, especially in multi-class scenarios.