### PR TITLE
Fix/multiclass prediction type safety

### DIFF
--- a/src/jabs/classifier/classifier.py
+++ b/src/jabs/classifier/classifier.py
@@ -171,19 +171,23 @@ class Classifier(BaseClassifier):
         """Augment features with left/right reflected duplicates."""
         return classifier_utils.augment_symmetric(features, labels, random_str)
 
-    def set_project_settings(self, project: Project) -> None:
+    def set_project_settings(self, project: Project, behavior: str | None = None) -> None:
         """Assign project settings to the classifier.
-
-        If no behavior is currently set, uses project defaults; otherwise looks
-        up the behavior-scoped settings from the project's settings manager.
 
         Args:
             project: Project to copy classifier-relevant settings from.
+            behavior: Behavior to scope settings to. Defaults to this
+                classifier's current ``behavior_name`` when not given. When no
+                behavior can be resolved, project-level defaults are used
+                instead of behavior-scoped settings. Passing ``behavior``
+                explicitly avoids the historical requirement to set
+                ``behavior_name`` before calling this method.
         """
-        if self._behavior is None:
+        effective_behavior = behavior if behavior is not None else self._behavior
+        if effective_behavior is None:
             self._project_settings = project.get_project_defaults()
         else:
-            self._project_settings = project.settings_manager.get_behavior(self._behavior)
+            self._project_settings = project.settings_manager.get_behavior(effective_behavior)
 
     def train(self, data: dict, random_seed: int | None = None) -> None:
         """Train the classifier.

--- a/src/jabs/classifier/cross_validation.py
+++ b/src/jabs/classifier/cross_validation.py
@@ -87,8 +87,8 @@ def _train_binary_fold(
     data: dict,
 ) -> None:
     """Train a binary classifier on the training portion of one CV fold."""
-    classifier.set_project_settings(project)
     classifier.behavior_name = behavior
+    classifier.set_project_settings(project, behavior)
     classifier.train(data)
 
 

--- a/src/jabs/classifier/multi_class_classifier.py
+++ b/src/jabs/classifier/multi_class_classifier.py
@@ -118,8 +118,16 @@ class MultiClassClassifier(BaseClassifier):
         """
         return [MULTICLASS_NONE_BEHAVIOR, *self._behavior_names]
 
-    def set_project_settings(self, project) -> None:
-        """Copy project defaults as classifier settings."""
+    def set_project_settings(self, project, behavior: str | None = None) -> None:
+        """Copy project defaults as classifier settings.
+
+        Args:
+            project: Project to copy default settings from.
+            behavior: Unused; accepted only for signature parity with
+                ``Classifier.set_project_settings``. Multi-class mode trains a
+                single shared classifier with no behavior to scope to, so
+                project-level defaults are always used.
+        """
         self._project_settings = dict(project.get_project_defaults())
 
     def train(self, data: dict, random_seed: int | None = None) -> None:

--- a/src/jabs/project/prediction_manager.py
+++ b/src/jabs/project/prediction_manager.py
@@ -107,6 +107,7 @@ class PredictionManager:
         predictions, probabilities, postprocessed_predictions, _ = self._load_prediction_record(
             video,
             behavior,
+            expect_multiclass=False,
         )
 
         return predictions, probabilities, postprocessed_predictions
@@ -128,14 +129,36 @@ class PredictionManager:
             names. Missing predictions return empty dicts and ``None`` for
             class names.
         """
-        return self._load_prediction_record(video, MULTICLASS_PREDICTION_KEY)
+        return self._load_prediction_record(
+            video, MULTICLASS_PREDICTION_KEY, expect_multiclass=True
+        )
 
     def _load_prediction_record(
-        self, video: str, behavior: str
+        self, video: str, behavior: str, *, expect_multiclass: bool
     ) -> tuple[
         dict[int, np.ndarray], dict[int, np.ndarray], dict[int, np.ndarray], list[str] | None
     ]:
-        """Load one prediction record from a video's prediction file."""
+        """Load one prediction record from a video's prediction file.
+
+        Args:
+            video: name of the video to load predictions for.
+            behavior: behavior key (or ``MULTICLASS_PREDICTION_KEY``) to load.
+            expect_multiclass: whether the caller expects a multi-class record.
+                Multi-class records carry a ``class_names`` list and 3D
+                probabilities; binary records do not. A mismatch (e.g. a binary
+                caller reading a multi-class file) yields probabilities with the
+                wrong dimensionality, so it is rejected here rather than returned
+                silently.
+
+        Returns:
+            Tuple of (predictions, probabilities, postprocessed_predictions,
+            class_names) keyed by identity. Missing predictions return empty
+            dicts and ``None`` for class names.
+
+        Raises:
+            ValueError: If the stored record's mode does not match
+                ``expect_multiclass``.
+        """
         predictions = {}
         probabilities = {}
         postprocessed_predictions = {}
@@ -159,6 +182,19 @@ class PredictionManager:
             if pred.predicted_class.shape[0] != nident or pred.probabilities.shape[0] != nident:
                 print(f"unable to open saved inferences for {video}", file=sys.stderr)
                 return {}, {}, {}, None
+
+            # Guard against reading a record in the wrong mode: multi-class
+            # records carry class_names (and 3D probabilities), binary records
+            # do not. Reading across modes would silently return mis-shaped data.
+            record_is_multiclass = pred.class_names is not None
+            if record_is_multiclass != expect_multiclass:
+                expected = "multi-class" if expect_multiclass else "binary"
+                found = "multi-class" if record_is_multiclass else "binary"
+                raise ValueError(
+                    f"Expected {expected} predictions for {behavior!r} in {video!r}, "
+                    f"but the stored record is {found}."
+                )
+
             class_names = pred.class_names
 
             for i in range(nident):

--- a/tests/classifier/test_classifier.py
+++ b/tests/classifier/test_classifier.py
@@ -559,6 +559,24 @@ class TestClassifierSettings:
         assert clf.project_settings is not None
         mock_project.get_project_defaults.assert_called_once()
 
+    def test_set_project_settings_explicit_behavior_overrides_attribute(self, mock_project):
+        """An explicit behavior argument scopes settings without relying on behavior_name."""
+        clf = Classifier()
+        # behavior_name intentionally left unset to prove the argument is used
+        clf.set_project_settings(mock_project, "Rearing")
+
+        mock_project.settings_manager.get_behavior.assert_called_with("Rearing")
+        mock_project.get_project_defaults.assert_not_called()
+
+    def test_set_project_settings_explicit_behavior_preferred_over_attribute(self, mock_project):
+        """The explicit behavior argument takes precedence over behavior_name."""
+        clf = Classifier()
+        clf.behavior_name = "Grooming"
+
+        clf.set_project_settings(mock_project, "Walking")
+
+        mock_project.settings_manager.get_behavior.assert_called_with("Walking")
+
     def test_set_dict_settings(self):
         """Test setting project settings via dictionary."""
         clf = Classifier()

--- a/tests/classifier/test_cross_validation.py
+++ b/tests/classifier/test_cross_validation.py
@@ -50,7 +50,7 @@ class _MultiClassCVClassifier:
             "feature_names": ["f"],
         }
 
-    def set_project_settings(self, _project) -> None:
+    def set_project_settings(self, _project, _behavior=None) -> None:
         self.set_project_settings_calls += 1
 
     def train(self, data: dict) -> None:

--- a/tests/project/test_prediction_manager.py
+++ b/tests/project/test_prediction_manager.py
@@ -228,6 +228,60 @@ def test_load_multiclass_predictions_invalid_shape_returns_empty(
     assert class_names is None
 
 
+def test_load_predictions_rejects_multiclass_record(
+    prediction_manager,
+    mock_project,
+    mock_pose,
+    mock_classifier,
+) -> None:
+    """A binary load of a record carrying class_names raises instead of returning bad shapes."""
+    prediction_file = mock_project.project_paths.prediction_dir / "test_video.h5"
+    behavior = "Walking"
+    predictions = np.array([[1, 0, -1], [2, 1, -1]], dtype=np.int8)
+    probabilities = np.zeros((2, 3, 3), dtype=np.float32)
+
+    # Write a multi-class-shaped record (class_names + 3-D probabilities) under
+    # a plain behavior key to simulate a cross-mode read.
+    PredictionManager.write_predictions(
+        behavior,
+        prediction_file,
+        predictions,
+        probabilities,
+        mock_pose,
+        mock_classifier,
+        class_names=["None", "Walking", "Rearing"],
+    )
+
+    with pytest.raises(ValueError, match="binary"):
+        prediction_manager.load_predictions("test_video.avi", behavior)
+
+
+def test_load_multiclass_predictions_rejects_binary_record(
+    prediction_manager,
+    mock_project,
+    mock_pose,
+    mock_classifier,
+) -> None:
+    """A multi-class load of a binary record (no class_names) raises instead of mis-shaping."""
+    prediction_file = mock_project.project_paths.prediction_dir / "test_video.h5"
+    predictions = np.array([[1, 0, -1], [0, 1, -1]], dtype=np.int8)
+    probabilities = np.array([[0.9, 0.8, -1], [0.7, 0.6, -1]], dtype=np.float32)
+
+    # Write a binary-shaped record (no class_names, 2-D probabilities) under the
+    # reserved multi-class key.
+    PredictionManager.write_predictions(
+        MULTICLASS_PREDICTION_KEY,
+        prediction_file,
+        predictions,
+        probabilities,
+        mock_pose,
+        mock_classifier,
+    )
+
+    with pytest.raises(ValueError, match="multi-class"):
+        prediction_manager.load_multiclass_predictions("test_video.avi")
+
+
 def test_load_predictions_missing_behavior(prediction_manager, mock_project):
     """Test loading predictions when behavior is missing."""
     video = "test_video.avi"


### PR DESCRIPTION
This pull request introduces improvements to how classifier settings are scoped by behavior and adds robust validation to prediction loading to prevent mismatches between binary and multi-class prediction records. It also updates the relevant tests to ensure correct behavior in these scenarios.

**Classifier settings scoping improvements:**

* The `Classifier.set_project_settings` method now accepts an optional `behavior` argument, allowing explicit scoping of settings without relying on the classifier's `behavior_name` attribute. This makes the method more flexible and avoids previous ordering requirements. (`src/jabs/classifier/classifier.py` [[1]](diffhunk://#diff-fabaf95a3c7b5f89721a7e553771ee428ccec1240e497909dc726922180d3400L174-R190) `src/jabs/classifier/cross_validation.py` [[2]](diffhunk://#diff-9cd5a05b75fa55731792a424737abcaa7cd162c95623cb46fd28530061295136L90-R91)
* The `MultiClassClassifier.set_project_settings` method signature is updated for consistency, accepting a (unused) `behavior` argument to match the base class, simplifying interface usage. (`src/jabs/classifier/multi_class_classifier.py` [src/jabs/classifier/multi_class_classifier.pyL121-R130](diffhunk://#diff-3c8b106674e796cc6f9ef8df77d9e0c66cc7b0482b047d4fe7b6f29e9fcec130L121-R130))
* Corresponding test cases are added to verify that explicitly provided `behavior` arguments are preferred over the attribute and that the correct project settings are loaded. (`tests/classifier/test_classifier.py` [[1]](diffhunk://#diff-860a3c715b438ac63add782876b19ba16895a5833c551855290bec7372567095R562-R579) `tests/classifier/test_cross_validation.py` [[2]](diffhunk://#diff-5e1ed2f759f5cab7f5e4a6d0b913c466363fdc31997b3a881a006a47543ecb68L53-R53)

**Prediction loading validation:**

* The prediction manager now validates that the mode (binary vs multi-class) of loaded prediction records matches the caller's expectations. If a mismatch is detected, a `ValueError` is raised instead of silently returning mis-shaped data, preventing subtle bugs. (`src/jabs/project/prediction_manager.py` [[1]](diffhunk://#diff-0f85e6b6688a5ba09d483f8899b387ed42ff556f42f03c9e96195f84b710a0a2R110) [[2]](diffhunk://#diff-0f85e6b6688a5ba09d483f8899b387ed42ff556f42f03c9e96195f84b710a0a2L131-R161) [[3]](diffhunk://#diff-0f85e6b6688a5ba09d483f8899b387ed42ff556f42f03c9e96195f84b710a0a2R185-R197)
* New tests ensure that attempts to load a multi-class record as binary (or vice versa) are correctly rejected with errors, rather than returning incorrect data. (`tests/project/test_prediction_manager.py` [tests/project/test_prediction_manager.pyR231-R284](diffhunk://#diff-0aefe70afa578bfc763610b98817feecd9d27b6c0bdc7db3da3fd602ad310b3bR231-R284))