### PR TITLE
Label multi-class classifier mode as a preview feature

### DIFF
--- a/src/jabs/ui/settings_dialog/classifier_mode_settings_group.py
+++ b/src/jabs/ui/settings_dialog/classifier_mode_settings_group.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 _CLASSIFIER_MODE_LABELS: dict[ClassifierMode, str] = {
     ClassifierMode.BINARY: "Binary",
-    ClassifierMode.MULTICLASS: "Multi-class",
+    ClassifierMode.MULTICLASS: "Multi-class (Preview)",
 }
 
 
@@ -50,16 +50,21 @@ class ClassifierModeSettingsGroup(SettingsGroup):
             or a single multi-class classifier across all behaviors simultaneously.</p>
 
             <ul>
-              <li><b>Binary (default):</b> Trains one independent binary classifier for 
+              <li><b>Binary (default):</b> Trains one independent binary classifier for
               the currently active behavior. Each classifier predicts whether a given
               frame contains that behavior or not. This is the standard JABS mode and
               works well for non-exclusive behaviors.</li>
 
-              <li><b>Multi-class:</b> Trains a single classifier across all annotated
-              behaviors at once. The classifier assigns each frame to exactly one behavior
-              class (or background). Multi-class mode is appropriate when behaviors are
-              mutually exclusive.</li>
+              <li><b>Multi-class (Preview):</b> Trains a single classifier across all
+              annotated behaviors at once. The classifier assigns each frame to exactly
+              one behavior class (or background). Multi-class mode is appropriate when
+              behaviors are mutually exclusive.</li>
             </ul>
+
+            <p><b>Preview feature:</b> Multi-class mode is under active development and is
+            provided as a preview. Some capabilities are not yet available (for example,
+            prediction post-processing is not applied to multi-class predictions), and its
+            behavior, stored data, and settings may change in upcoming JABS releases.</p>
 
             <p><b>Note:</b> In multi-class mode, behaviors must be mutually exclusive.
             Frames labeled with more than one behavior simultaneously will cause a conflict and must be resolved before training.</p>

--- a/tests/ui/test_settings_dialog.py
+++ b/tests/ui/test_settings_dialog.py
@@ -3,9 +3,15 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from jabs.core.constants import CLASSIFIER_MODE_KEY
+from jabs.core.enums import ClassifierMode
+
 try:
     from PySide6.QtWidgets import QApplication
 
+    from jabs.ui.settings_dialog.classifier_mode_settings_group import (
+        ClassifierModeSettingsGroup,
+    )
     from jabs.ui.settings_dialog.settings_dialog import _OverlapCheckThread
 
     SKIP_UI_TESTS = False
@@ -64,3 +70,14 @@ def test_overlap_check_thread_emits_error_on_exception() -> None:
 
     assert emitted_results == []
     assert emitted_errors == [expected_error]
+
+
+def test_classifier_mode_group_roundtrips_enum_not_label() -> None:
+    """Set/get bind to the ClassifierMode value, independent of the display label."""
+    group = ClassifierModeSettingsGroup()
+
+    group.set_values({CLASSIFIER_MODE_KEY: ClassifierMode.MULTICLASS.value})
+    assert group.get_values() == {CLASSIFIER_MODE_KEY: ClassifierMode.MULTICLASS}
+
+    group.set_values({CLASSIFIER_MODE_KEY: ClassifierMode.BINARY.value})
+    assert group.get_values() == {CLASSIFIER_MODE_KEY: ClassifierMode.BINARY}


### PR DESCRIPTION
## Summary

Marks multi-class classifier mode as a **preview/beta** feature in the UI, the one hard blocker for merging multi-class into `main` as a preview while remaining work continues in follow-up releases.

## Changes

- `classifier_mode_settings_group.py`:
  - Combo option relabeled `"Multi-class"` → `"Multi-class (Preview)"`.
  - Help text gains a **Preview feature** paragraph noting the mode is under active development, that some capabilities are not yet available (prediction post-processing is not applied to multi-class predictions), and that its behavior, stored data, and settings may change in upcoming releases.
- The combo stores the `ClassifierMode` enum as item *data* (the string is display-only), so the relabel does not affect persistence — `get_values`/`set_values` still bind to the enum.

## Tests

- Added `test_classifier_mode_group_roundtrips_enum_not_label`, confirming set/get round-trip on the `ClassifierMode` value independent of the display label (guards against the relabel breaking data binding).

3 settings-dialog tests pass; ruff clean.

## Notes

Default mode remains `BINARY`; binary projects are unaffected. This is part of the multi-class beta-readiness work — the section 10 latent-bug fixes (PRs #385, #386, and `fix/multiclass-save-predictions-shape`) should also land on `feature/multiclass` before it is merged to `main`.
