### PR TITLE
Tint Label Behavior button with selected behavior color (multi-class, T14)

### DIFF
--- a/src/jabs/ui/behavior_timeline/behavior_timeline_widget.py
+++ b/src/jabs/ui/behavior_timeline/behavior_timeline_widget.py
@@ -277,6 +277,11 @@ class BehaviorTimelineWidget(QWidget):
         """Return the multiclass color LUT, or None when in binary mode."""
         return self._multiclass_color_lut
 
+    @property
+    def behavior_color_map(self) -> dict[str, QColor]:
+        """Return a copy of the behavior→color map (empty in binary mode)."""
+        return dict(self._behavior_color_map)
+
     def set_classifier_mode(self, mode: ClassifierMode, behavior_names: list[str]) -> None:
         """Set the classifier mode and rebuild the layout for multi-class or binary display.
 

--- a/src/jabs/ui/colors.py
+++ b/src/jabs/ui/colors.py
@@ -23,6 +23,27 @@ ACTIVE_ID_COLOR = QColor(255, 0, 0, 255)
 
 SEARCH_HIT_COLOR = QColor(0, 255, 0, 255)
 
+# Luminance threshold (0-255) above which a fill color is treated as "light",
+# meaning dark text reads better on it than light text.
+LIGHT_COLOR_LUMINANCE_THRESHOLD = 160
+
+
+def is_color_light(color: QColor) -> bool:
+    """Return True if a color is perceptually light.
+
+    Light fills read better with dark (black) text; dark fills with light
+    (white) text. Uses the ITU-R BT.709 luminance formula.
+
+    Args:
+        color: The color to evaluate.
+
+    Returns:
+        True if the color's luminance exceeds
+        ``LIGHT_COLOR_LUMINANCE_THRESHOLD``.
+    """
+    luminance = 0.2126 * color.red() + 0.7152 * color.green() + 0.0722 * color.blue()
+    return luminance > LIGHT_COLOR_LUMINANCE_THRESHOLD
+
 
 # Generate distinct colors for keypoints
 # Use a fixed seed for reproducible colors

--- a/src/jabs/ui/main_control_widget/main_control_widget.py
+++ b/src/jabs/ui/main_control_widget/main_control_widget.py
@@ -13,7 +13,7 @@ Todo:
 import sys
 
 from PySide6 import QtCore, QtWidgets
-from PySide6.QtGui import QIcon, QPainter, QPixmap
+from PySide6.QtGui import QColor, QIcon, QPainter, QPixmap
 
 from jabs.classifier import Classifier
 from jabs.core.enums import ClassifierMode, ClassifierType
@@ -25,6 +25,7 @@ from ..colors import (
     NOT_BEHAVIOR_BUTTON_DISABLED_COLOR,
     NOT_BEHAVIOR_COLOR,
     NOT_BEHAVIOR_COLOR_BRIGHT,
+    is_color_light,
 )
 from ..dialogs.message_dialog import MessageDialog
 from ..ear_tag_icons import EarTagIconManager
@@ -193,25 +194,9 @@ class MainControlWidget(QtWidgets.QWidget):
         self._label_behavior_button = QtWidgets.QPushButton()
         self._label_behavior_button.setToolTip("[z]")
         self._label_behavior_button.clicked.connect(self.label_behavior_clicked)
-        self._label_behavior_button.setStyleSheet(
-            f"""
-                QPushButton {{
-                    background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
-                                       stop: 0 rgba{BEHAVIOR_BUTTON_COLOR_BRIGHT.getRgb()},
-                                       stop: 1.0 rgba{BEHAVIOR_COLOR.getRgb()});
-                    border-radius: 4px;
-                    padding: 2px;
-                    color: white;
-                }}
-                QPushButton:pressed {{
-                    background-color: rgba{BEHAVIOR_BUTTON_COLOR_BRIGHT.getRgb()};
-                }}
-                QPushButton:disabled {{
-                    background-color: rgba{BEHAVIOR_BUTTON_DISABLED_COLOR.getRgb()};
-                    color: grey;
-                }}
-            """
-        )
+        # default (binary-mode) orange tint; multi-class mode overrides this with
+        # the selected behavior's color via set_behavior_button_color()
+        self.set_behavior_button_color(None)
 
         self._label_not_behavior_button = QtWidgets.QPushButton()
         self._label_not_behavior_button.setToolTip("[c]")
@@ -407,6 +392,56 @@ class MainControlWidget(QtWidgets.QWidget):
         except KeyError:
             # unable to use the classifier
             pass
+
+    @staticmethod
+    def _behavior_button_stylesheet(
+        base: QColor, bright: QColor, disabled: QColor, text_color: str
+    ) -> str:
+        """Build the Label Behavior button stylesheet for the given colors."""
+        return f"""
+                QPushButton {{
+                    background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
+                                       stop: 0 rgba{bright.getRgb()},
+                                       stop: 1.0 rgba{base.getRgb()});
+                    border-radius: 4px;
+                    padding: 2px;
+                    color: {text_color};
+                }}
+                QPushButton:pressed {{
+                    background-color: rgba{bright.getRgb()};
+                }}
+                QPushButton:disabled {{
+                    background-color: rgba{disabled.getRgb()};
+                    color: grey;
+                }}
+            """
+
+    def set_behavior_button_color(self, color: QColor | None) -> None:
+        """Tint the "Label {behavior}" button.
+
+        Args:
+            color: Behavior color to tint the button with (multi-class mode).
+                Pass ``None`` to restore the default binary-mode orange.
+        """
+        if color is None:
+            self._label_behavior_button.setStyleSheet(
+                self._behavior_button_stylesheet(
+                    BEHAVIOR_COLOR,
+                    BEHAVIOR_BUTTON_COLOR_BRIGHT,
+                    BEHAVIOR_BUTTON_DISABLED_COLOR,
+                    "white",
+                )
+            )
+            return
+
+        # Derive gradient/disabled variants from the behavior color, and pick a
+        # readable text color based on the base color's perceived luminance.
+        text_color = "black" if is_color_light(color) else "white"
+        self._label_behavior_button.setStyleSheet(
+            self._behavior_button_stylesheet(
+                color, color.lighter(125), color.darker(120), text_color
+            )
+        )
 
     def set_label_summary_class_labels(self, positive_label: str, negative_label: str) -> None:
         """retitle the label summary's positive/negative row headers"""

--- a/src/jabs/ui/main_control_widget/main_control_widget.py
+++ b/src/jabs/ui/main_control_widget/main_control_widget.py
@@ -395,7 +395,11 @@ class MainControlWidget(QtWidgets.QWidget):
 
     @staticmethod
     def _behavior_button_stylesheet(
-        base: QColor, bright: QColor, disabled: QColor, text_color: str
+        base: QColor,
+        bright: QColor,
+        disabled: QColor,
+        text_color: str,
+        disabled_text_color: str,
     ) -> str:
         """Build the Label Behavior button stylesheet for the given colors."""
         return f"""
@@ -412,7 +416,7 @@ class MainControlWidget(QtWidgets.QWidget):
                 }}
                 QPushButton:disabled {{
                     background-color: rgba{disabled.getRgb()};
-                    color: grey;
+                    color: {disabled_text_color};
                 }}
             """
 
@@ -430,16 +434,21 @@ class MainControlWidget(QtWidgets.QWidget):
                     BEHAVIOR_BUTTON_COLOR_BRIGHT,
                     BEHAVIOR_BUTTON_DISABLED_COLOR,
                     "white",
+                    "grey",
                 )
             )
             return
 
-        # Derive gradient/disabled variants from the behavior color, and pick a
-        # readable text color based on the base color's perceived luminance.
+        # Derive gradient/disabled variants from the behavior color, and pick
+        # readable text colors for both the enabled and disabled backgrounds
+        # based on their perceived luminance (a fixed grey can be unreadable on
+        # a dark derived disabled color).
+        disabled = color.darker(120)
         text_color = "black" if is_color_light(color) else "white"
+        disabled_text_color = "#555555" if is_color_light(disabled) else "#cccccc"
         self._label_behavior_button.setStyleSheet(
             self._behavior_button_stylesheet(
-                color, color.lighter(125), color.darker(120), text_color
+                color, color.lighter(125), disabled, text_color, disabled_text_color
             )
         )
 

--- a/src/jabs/ui/main_window/central_widget.py
+++ b/src/jabs/ui/main_window/central_widget.py
@@ -426,6 +426,7 @@ class CentralWidget(QtWidgets.QWidget):
             )
             self._suppress_label_track_update = False
             self._set_label_track()
+            self._update_label_button_color()
             self._update_select_button_state()
             self._update_timeline_search_results()
             self._update_label_counts()
@@ -628,9 +629,26 @@ class CentralWidget(QtWidgets.QWidget):
 
         # display labels and predictions for new behavior
         self._set_label_track()
+        self._update_label_button_color()
         self.set_train_button_enabled_state()
 
         self._project.settings_manager.save_project_file({"selected_behavior": self.behavior})
+
+    def _update_label_button_color(self) -> None:
+        """Tint the Label Behavior button to match the selected behavior.
+
+        In multi-class mode the button is tinted with the selected behavior's
+        color from the timeline color map; in binary mode it keeps the default
+        orange.
+        """
+        if (
+            self._project is not None
+            and self._project.settings_manager.classifier_mode == ClassifierMode.MULTICLASS
+        ):
+            color = self._jabs_timeline.behavior_color_map.get(self.behavior)
+            self._controls.set_behavior_button_color(color)
+        else:
+            self._controls.set_behavior_button_color(None)
 
     def _start_selection(self, pressed: bool) -> None:
         """Handle a click on "select" button.
@@ -1351,6 +1369,7 @@ class CentralWidget(QtWidgets.QWidget):
             self._controls.behaviors,
         )
         self._set_label_track()
+        self._update_label_button_color()
 
     def set_train_button_enabled_state(self) -> None:
         """set the enabled property of the train button

--- a/src/jabs/ui/player_widget/overlays/annotation_overlay.py
+++ b/src/jabs/ui/player_widget/overlays/annotation_overlay.py
@@ -3,6 +3,8 @@ from typing import TYPE_CHECKING
 
 from PySide6 import QtCore, QtGui
 
+from jabs.ui.colors import is_color_light
+
 from ...dialogs import AnnotationInfoDialog
 from .overlay import Overlay
 
@@ -159,7 +161,7 @@ class AnnotationOverlay(Overlay):
                         fill_color = QtGui.QColor(220, 220, 220)
                     text_color = (
                         QtGui.QColor(0, 0, 0)
-                        if self._is_color_light(fill_color)
+                        if is_color_light(fill_color)
                         else QtGui.QColor(255, 255, 255)
                     )
                     painter.setBrush(fill_color)
@@ -200,7 +202,7 @@ class AnnotationOverlay(Overlay):
             fill_color.setAlpha(220)
             text_color = (
                 QtGui.QColor(0, 0, 0)
-                if self._is_color_light(fill_color)
+                if is_color_light(fill_color)
                 else QtGui.QColor(255, 255, 255)
             )
             painter.setBrush(fill_color)

--- a/src/jabs/ui/player_widget/overlays/floating_id_overlay.py
+++ b/src/jabs/ui/player_widget/overlays/floating_id_overlay.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from PySide6 import QtCore, QtGui
 
-from jabs.ui.colors import ACTIVE_ID_COLOR, INACTIVE_ID_COLOR
+from jabs.ui.colors import ACTIVE_ID_COLOR, INACTIVE_ID_COLOR, is_color_light
 from jabs.ui.ear_tag_icons import EarTagIconManager
 
 from .overlay import Overlay
@@ -243,7 +243,7 @@ class FloatingIdOverlay(Overlay):
             self._rects_with_data.append((q_rect, identity_rect))
             text_color = (
                 QtGui.QColor(0, 0, 0)
-                if self._is_color_light(identity_rect.color)
+                if is_color_light(identity_rect.color)
                 else QtGui.QColor(255, 255, 255)
             )
             painter.setBrush(identity_rect.color)

--- a/src/jabs/ui/player_widget/overlays/overlay.py
+++ b/src/jabs/ui/player_widget/overlays/overlay.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
 class Overlay(QObject):
     """Base class for interactive overlays in the frame widget."""
 
-    _LIGHT_COLOR_THRESHOLD = 160  # Luminance threshold to determine if a color is "light"
     _MAX_PRIORITY = 1000  # Maximum priority for painting order
 
     def __init__(self, parent: "FrameWithOverlaysWidget"):
@@ -82,9 +81,3 @@ class Overlay(QObject):
             return None
 
         return convex_hull.centroid
-
-    def _is_color_light(self, color: QtGui.QColor) -> bool:
-        """Determines if a color is considered light based on its luminance."""
-        # Calculate luminance using the ITU-R BT.709 formula
-        luminance = 0.2126 * color.red() + 0.7152 * color.green() + 0.0722 * color.blue()
-        return luminance > self._LIGHT_COLOR_THRESHOLD

--- a/tests/ui/test_colors.py
+++ b/tests/ui/test_colors.py
@@ -4,12 +4,15 @@ import numpy as np
 import pytest
 
 try:
+    from PySide6.QtGui import QColor
+
     from jabs.core.constants import MULTICLASS_NONE_BEHAVIOR
     from jabs.ui.colors import (
         BACKGROUND_COLOR,
         BEHAVIOR_COLOR,
         NOT_BEHAVIOR_COLOR,
         build_multiclass_color_lut,
+        is_color_light,
         make_behavior_color_map,
     )
 
@@ -137,3 +140,19 @@ def test_build_multiclass_color_lut_missing_key_raises():
     """Name in behavior_names absent from color_map raises ValueError."""
     with pytest.raises(ValueError, match="missing from color_map"):
         build_multiclass_color_lut(["walk"], {})
+
+
+def test_is_color_light_dark_color():
+    """A dark color is not considered light."""
+    assert is_color_light(QColor(20, 20, 20)) is False
+
+
+def test_is_color_light_light_color():
+    """A near-white color is considered light."""
+    assert is_color_light(QColor(240, 240, 240)) is True
+
+
+def test_is_color_light_uses_green_weighting():
+    """Saturated green reads as light while saturated blue does not (BT.709)."""
+    assert is_color_light(QColor(0, 255, 0)) is True
+    assert is_color_light(QColor(0, 0, 255)) is False

--- a/tests/ui/test_main_control_widget.py
+++ b/tests/ui/test_main_control_widget.py
@@ -1,0 +1,69 @@
+import pytest
+
+try:
+    from PySide6.QtGui import QColor
+    from PySide6.QtWidgets import QApplication
+
+    from jabs.ui.colors import BEHAVIOR_COLOR
+    from jabs.ui.main_control_widget.main_control_widget import MainControlWidget
+
+    SKIP_UI_TESTS = False
+    SKIP_REASON = None
+except ImportError as e:
+    SKIP_UI_TESTS = True
+    SKIP_REASON = f"Qt/UI dependencies not available: {e}"
+
+pytestmark = pytest.mark.skipif(
+    SKIP_UI_TESTS,
+    reason=SKIP_REASON if SKIP_UI_TESTS else "",
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def qapp():
+    """Ensure a QApplication exists for widget tests."""
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    yield app
+
+
+def test_default_label_button_color_is_orange() -> None:
+    """A freshly built control widget uses the default orange behavior tint."""
+    widget = MainControlWidget()
+
+    style = widget._label_behavior_button.styleSheet()
+    assert f"rgba{BEHAVIOR_COLOR.getRgb()}" in style
+    assert "color: white" in style
+
+
+def test_set_behavior_button_color_none_restores_default() -> None:
+    """Passing None restores the default orange (binary-mode) tint."""
+    widget = MainControlWidget()
+
+    widget.set_behavior_button_color(QColor(10, 20, 30))
+    widget.set_behavior_button_color(None)
+
+    style = widget._label_behavior_button.styleSheet()
+    assert f"rgba{BEHAVIOR_COLOR.getRgb()}" in style
+
+
+def test_set_behavior_button_color_applies_behavior_color() -> None:
+    """A behavior color tints the button gradient with that color."""
+    widget = MainControlWidget()
+
+    widget.set_behavior_button_color(QColor(10, 20, 30))
+
+    style = widget._label_behavior_button.styleSheet()
+    assert "rgba(10, 20, 30, 255)" in style
+
+
+def test_set_behavior_button_color_picks_readable_text() -> None:
+    """Text color adapts to the base color's luminance for readability."""
+    widget = MainControlWidget()
+
+    widget.set_behavior_button_color(QColor(20, 20, 20))  # dark -> white text
+    assert "color: white" in widget._label_behavior_button.styleSheet()
+
+    widget.set_behavior_button_color(QColor(240, 240, 240))  # light -> black text
+    assert "color: black" in widget._label_behavior_button.styleSheet()

--- a/tests/ui/test_main_control_widget.py
+++ b/tests/ui/test_main_control_widget.py
@@ -67,3 +67,24 @@ def test_set_behavior_button_color_picks_readable_text() -> None:
 
     widget.set_behavior_button_color(QColor(240, 240, 240))  # light -> black text
     assert "color: black" in widget._label_behavior_button.styleSheet()
+
+
+def test_set_behavior_button_color_disabled_text_contrasts() -> None:
+    """Disabled text color contrasts with the derived disabled background."""
+    widget = MainControlWidget()
+
+    # dark behavior color -> dark disabled background -> light disabled text
+    widget.set_behavior_button_color(QColor(20, 20, 20))
+    assert "color: #cccccc" in widget._label_behavior_button.styleSheet()
+
+    # light behavior color -> light disabled background -> dark disabled text
+    widget.set_behavior_button_color(QColor(240, 240, 240))
+    assert "color: #555555" in widget._label_behavior_button.styleSheet()
+
+
+def test_default_disabled_text_is_grey() -> None:
+    """Binary-mode default keeps grey disabled text (unchanged)."""
+    widget = MainControlWidget()
+
+    widget.set_behavior_button_color(None)
+    assert "color: grey" in widget._label_behavior_button.styleSheet()


### PR DESCRIPTION
In binary classifier mode, the "Label {behavior}" button color matches the color used on the timeline for the behavior label (orange). In multi-class mode, each behavior has a different color. 

This pull request enhances the JABS UI to improve the user experience in multi-class mode: the "Label {behavior}" button is tinted with the currently selected behavior's color in multi-class mode, giving a continuous visual cue about which class you're labeling. Binary mode is unchanged (orange).

## Changes
- **`MainControlWidget.set_behavior_button_color(color | None)`** — retints the Label Behavior button. `None` restores the default binary-mode orange; a `QColor` derives the gradient (lighter) and disabled (darker) variants and picks a readable text color. The button stylesheet was extracted into a `_behavior_button_stylesheet(...)` helper.
- **`BehaviorTimelineWidget.behavior_color_map`** — new read-only property exposing the behavior→color map.
- **`central_widget`** — `_update_label_button_color()` tints from the timeline's color map for the selected behavior; called on behavior change, video load, and classifier-mode change. Binary mode passes `None`.

## Shared luminance utility (review follow-up)
Text-on-fill luminance was computed in two places with different formulas (overlay used ITU-R BT.709; the new button code used BT.601). Consolidated into a single **`jabs.ui.colors.is_color_light(color)`** (BT.709, threshold 160). Removed the `Overlay._is_color_light` wrapper and its local threshold; `annotation_overlay` and `floating_id_overlay` now call `is_color_light` directly. The button code uses it too.

## Tests
- `tests/ui/test_main_control_widget.py` — default orange, `None` restore, behavior-color tint, and luminance-based text color.
- `tests/ui/test_colors.py` — `is_color_light` dark/light/green-weighting cases.
- Full `tests/ui` suite passes (77); ruff clean.