### PR TITLE
Exclude videos from training: video list UI + persistence (PR 1)

### DIFF
--- a/src/jabs/project/settings_manager.py
+++ b/src/jabs/project/settings_manager.py
@@ -16,6 +16,9 @@ if typing.TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Per-video metadata key marking a video as held out of classifier training.
+EXCLUDE_FROM_TRAINING_KEY = "exclude_from_training"
+
 
 class SettingsManager:
     """Class to manage project properties/settings."""
@@ -136,6 +139,34 @@ class SettingsManager:
             Dictionary of metadata for the specified video, or empty dict if none exists.
         """
         return self._project_info.get("video_files", {}).get(video, {}).get("metadata", {})
+
+    def is_video_excluded(self, video: str) -> bool:
+        """Return whether a video is excluded from classifier training.
+
+        Args:
+            video: Name of the video file.
+
+        Returns:
+            True if the video has been marked to be held out of training.
+        """
+        return bool(self.video_metadata(video).get(EXCLUDE_FROM_TRAINING_KEY, False))
+
+    def set_video_excluded(self, video: str, excluded: bool) -> None:
+        """Mark a video as excluded from (or included in) classifier training.
+
+        The flag is stored in the video's per-video metadata and persisted to the
+        project file. The video's ``video_files`` entry is created if it does not
+        already exist.
+
+        Args:
+            video: Name of the video file.
+            excluded: True to exclude the video from training, False to include it.
+        """
+        video_files = self._project_info.setdefault("video_files", {})
+        video_entry = video_files.setdefault(video, {})
+        metadata = video_entry.setdefault("metadata", {})
+        metadata[EXCLUDE_FROM_TRAINING_KEY] = excluded
+        self.save_project_file()
 
     def remove_video_from_project_file(self, video_name: str, sync=True) -> None:
         """Remove a video entry from the project if it exists.

--- a/src/jabs/ui/main_window/video_list_widget.py
+++ b/src/jabs/ui/main_window/video_list_widget.py
@@ -4,6 +4,11 @@ from jabs.behavior_search import SearchHit
 from jabs.ui.dialogs.message_dialog import MessageDialog
 from jabs.ui.dialogs.video_info_dialog import VideoInfoDialog
 
+# Item data role storing whether a video is excluded from training (bool).
+# Kept separate from the displayed text so it survives text changes (e.g. search
+# hit-count annotations) and drives the row's dimmed/italic styling.
+_EXCLUDED_ROLE = QtCore.Qt.ItemDataRole.UserRole + 1
+
 
 class _VideoListWidget(QtWidgets.QListWidget):
     """QListView that has been modified to not allow deselecting current selection without selecting a new row"""
@@ -21,38 +26,48 @@ class _VideoListWidget(QtWidgets.QListWidget):
             option: QtWidgets.QStyleOptionViewItem,
             index: QtCore.QModelIndex,
         ):
-            """Paints the text.
+            """Paints the row text with selection highlighting and exclusion styling.
 
-            Paints text, highlighting the background and text color
-            for selected items to ensure visibility. For selected rows, fills the
-            background with the highlight color and draws the text using the
-            highlighted text color. For unselected rows, uses the default rendering.
+            Selected rows fill the background with the highlight color and draw the
+            text in the highlighted text color. Videos excluded from training are
+            drawn dimmed (disabled text color) and italic, both when selected and
+            unselected, so the state is always visible.
 
             Args:
                 painter: The QPainter object used for drawing.
                 option: The style options for the item.
                 index: The model index of the item being painted.
             """
-            if option.state & QtWidgets.QStyle.StateFlag.State_Selected:  # type: ignore[attr-defined]
-                painter.save()
+            excluded = bool(index.data(_EXCLUDED_ROLE))
+            selected = bool(option.state & QtWidgets.QStyle.StateFlag.State_Selected)  # type: ignore[attr-defined]
 
-                # Use highlight color from the palette
-                highlight_color = option.palette.color(QtGui.QPalette.ColorRole.Highlight)  # type: ignore[attr-defined]
-                text_color = option.palette.color(QtGui.QPalette.ColorRole.HighlightedText)  # type: ignore[attr-defined]
-
-                # Fill background with current accent color
-                painter.fillRect(option.rect, highlight_color)  # type: ignore[attr-defined]
-
-                # Set pen to highlighted text color
-                painter.setPen(text_color)
-
-                # Draw the text manually
-                text = index.data(QtCore.Qt.ItemDataRole.DisplayRole)
-                rect = option.rect.adjusted(4, 0, -4, 0)  # type: ignore[attr-defined]
-                painter.drawText(rect, QtCore.Qt.AlignmentFlag.AlignVCenter, text)
-                painter.restore()
-            else:
+            # default rendering handles the common (unselected, included) case
+            if not selected and not excluded:
                 super().paint(painter, option, index)
+                return
+
+            painter.save()
+            if selected:
+                painter.fillRect(  # type: ignore[attr-defined]
+                    option.rect, option.palette.color(QtGui.QPalette.ColorRole.Highlight)
+                )
+                pen_color = option.palette.color(QtGui.QPalette.ColorRole.HighlightedText)
+            else:
+                # excluded + unselected: dim with the palette's disabled text color
+                pen_color = option.palette.color(
+                    QtGui.QPalette.ColorGroup.Disabled, QtGui.QPalette.ColorRole.Text
+                )
+
+            font = QtGui.QFont(option.font)  # type: ignore[attr-defined]
+            if excluded:
+                font.setItalic(True)
+            painter.setFont(font)
+            painter.setPen(pen_color)
+
+            text = index.data(QtCore.Qt.ItemDataRole.DisplayRole)
+            rect = option.rect.adjusted(4, 0, -4, 0)  # type: ignore[attr-defined]
+            painter.drawText(rect, QtCore.Qt.AlignmentFlag.AlignVCenter, text)
+            painter.restore()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -177,16 +192,39 @@ class VideoListDockWidget(QtWidgets.QDockWidget):
         if item is None:
             return
 
+        video_name = item.data(QtCore.Qt.ItemDataRole.UserRole)
+
         # create and show the context menu at the mouse position
         menu = QtWidgets.QMenu(self)
         get_info_action = menu.addAction("Get Info")
         copy_video_name_action = menu.addAction("Copy Video Name")
+        exclude_action = menu.addAction("Exclude from Training")
+        exclude_action.setCheckable(True)
+        exclude_action.setChecked(bool(item.data(_EXCLUDED_ROLE)))
+        exclude_action.setEnabled(self._project is not None)
         action = menu.exec(self._file_list.mapToGlobal(pos))
 
         if action == get_info_action:
-            self._show_video_info(item.data(QtCore.Qt.ItemDataRole.UserRole))
+            self._show_video_info(video_name)
         elif action == copy_video_name_action:
-            QtWidgets.QApplication.clipboard().setText(item.data(QtCore.Qt.ItemDataRole.UserRole))
+            QtWidgets.QApplication.clipboard().setText(video_name)
+        elif action == exclude_action:
+            self._set_video_excluded(item, video_name, exclude_action.isChecked())
+
+    def _set_video_excluded(self, item, video_name: str, excluded: bool) -> None:
+        """Persist a video's training-exclusion state and refresh its row styling.
+
+        Args:
+            item: The list item for the video.
+            video_name: The video filename key used in the project.
+            excluded: True to exclude the video from training, False to include it.
+        """
+        if self._project is None:
+            return
+        self._project.settings_manager.set_video_excluded(video_name, excluded)
+        item.setData(_EXCLUDED_ROLE, excluded)
+        # repaint the row to reflect the new dimmed/italic styling
+        self._file_list.viewport().update()
 
     def _show_video_info(self, video_name: str) -> None:
         """Open the VideoInfoDialog for the given video.
@@ -217,6 +255,7 @@ class VideoListDockWidget(QtWidgets.QDockWidget):
         for video in self._project.video_manager.videos:
             item = QtWidgets.QListWidgetItem(video)
             item.setData(QtCore.Qt.ItemDataRole.UserRole, video)
+            item.setData(_EXCLUDED_ROLE, self._project.settings_manager.is_video_excluded(video))
             self._file_list.addItem(item)
 
         if self._project.video_manager.videos:

--- a/src/jabs/ui/main_window/video_list_widget.py
+++ b/src/jabs/ui/main_window/video_list_widget.py
@@ -51,23 +51,47 @@ class _VideoListWidget(QtWidgets.QListWidget):
                 painter.fillRect(  # type: ignore[attr-defined]
                     option.rect, option.palette.color(QtGui.QPalette.ColorRole.Highlight)
                 )
-                pen_color = option.palette.color(QtGui.QPalette.ColorRole.HighlightedText)
-            else:
-                # excluded + unselected: dim with the palette's disabled text color
-                pen_color = option.palette.color(
-                    QtGui.QPalette.ColorGroup.Disabled, QtGui.QPalette.ColorRole.Text
-                )
 
             font = QtGui.QFont(option.font)  # type: ignore[attr-defined]
             if excluded:
                 font.setItalic(True)
             painter.setFont(font)
-            painter.setPen(pen_color)
+            painter.setPen(self._text_pen_color(option.palette, selected, excluded))
 
             text = index.data(QtCore.Qt.ItemDataRole.DisplayRole)
             rect = option.rect.adjusted(4, 0, -4, 0)  # type: ignore[attr-defined]
             painter.drawText(rect, QtCore.Qt.AlignmentFlag.AlignVCenter, text)
             painter.restore()
+
+        @staticmethod
+        def _text_pen_color(
+            palette: QtGui.QPalette, selected: bool, excluded: bool
+        ) -> QtGui.QColor:
+            """Choose the text color for a row given its selected/excluded state.
+
+            Excluded rows use the palette's *disabled* color so they read as dimmed
+            on both the normal and highlight backgrounds (preserving the visual cue
+            even when the row is selected).
+
+            Args:
+                palette: The widget palette to source colors from.
+                selected: Whether the row is selected (highlight background).
+                excluded: Whether the video is excluded from training.
+
+            Returns:
+                The pen color to draw the row text with.
+            """
+            if selected:
+                # dim the highlighted text for excluded rows; otherwise the
+                # standard highlighted text color
+                group = (
+                    QtGui.QPalette.ColorGroup.Disabled
+                    if excluded
+                    else QtGui.QPalette.ColorGroup.Active
+                )
+                return palette.color(group, QtGui.QPalette.ColorRole.HighlightedText)
+            # only excluded rows reach here while unselected; dim with disabled text
+            return palette.color(QtGui.QPalette.ColorGroup.Disabled, QtGui.QPalette.ColorRole.Text)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tests/project/test_settings_manager.py
+++ b/tests/project/test_settings_manager.py
@@ -197,3 +197,39 @@ def test_rename_behavior_updates_selected(mock_project):
     assert "Walking" not in updated_settings["behavior"]
     assert "Walk" in updated_settings["behavior"]
     assert updated_settings["behavior"]["Walk"] == initial_settings["behavior"]["Walking"]
+
+
+def test_is_video_excluded_default_false(mock_project):
+    """A video with no metadata is not excluded by default."""
+    settings_manager = SettingsManager(mock_project.project_paths)
+    assert settings_manager.is_video_excluded("video1.avi") is False
+
+
+def test_set_video_excluded_roundtrip_and_persists(mock_project):
+    """Excluding a video persists to the project file and reloads."""
+    settings_manager = SettingsManager(mock_project.project_paths)
+    settings_manager.set_video_excluded("video1.avi", True)
+
+    assert settings_manager.is_video_excluded("video1.avi") is True
+
+    # a fresh manager reading the saved file sees the same state
+    reloaded = SettingsManager(mock_project.project_paths)
+    assert reloaded.is_video_excluded("video1.avi") is True
+
+
+def test_set_video_excluded_creates_missing_entry(mock_project):
+    """Excluding a video with no prior video_files entry creates one."""
+    settings_manager = SettingsManager(mock_project.project_paths)
+    settings_manager.set_video_excluded("new_video.avi", True)
+
+    video_files = settings_manager.project_settings.get("video_files", {})
+    assert video_files["new_video.avi"]["metadata"]["exclude_from_training"] is True
+
+
+def test_set_video_excluded_toggle_back_to_included(mock_project):
+    """Toggling exclusion off returns the video to included."""
+    settings_manager = SettingsManager(mock_project.project_paths)
+    settings_manager.set_video_excluded("video1.avi", True)
+    settings_manager.set_video_excluded("video1.avi", False)
+
+    assert settings_manager.is_video_excluded("video1.avi") is False

--- a/tests/ui/test_video_list_widget.py
+++ b/tests/ui/test_video_list_widget.py
@@ -1,0 +1,69 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+try:
+    from PySide6.QtCore import Qt
+    from PySide6.QtWidgets import QApplication
+
+    from jabs.ui.main_window.video_list_widget import _EXCLUDED_ROLE, VideoListDockWidget
+
+    SKIP_UI_TESTS = False
+    SKIP_REASON = None
+except ImportError as e:
+    SKIP_UI_TESTS = True
+    SKIP_REASON = f"Qt/UI dependencies not available: {e}"
+
+pytestmark = pytest.mark.skipif(
+    SKIP_UI_TESTS,
+    reason=SKIP_REASON if SKIP_UI_TESTS else "",
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def qapp():
+    """Ensure a QApplication exists for widget tests."""
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    yield app
+
+
+def _mock_project(videos, excluded):
+    """Build a mock project exposing videos and per-video exclusion state."""
+    project = MagicMock()
+    project.video_manager.videos = videos
+    project.settings_manager.is_video_excluded.side_effect = lambda v: v in excluded
+    return project
+
+
+def _item_for(widget, video):
+    """Return the list item whose UserRole matches the given video name."""
+    file_list = widget._file_list
+    for i in range(file_list.count()):
+        item = file_list.item(i)
+        if item.data(Qt.ItemDataRole.UserRole) == video:
+            return item
+    raise AssertionError(f"no list item for {video!r}")
+
+
+def test_set_project_tags_excluded_rows():
+    """set_project marks each row's excluded role from project settings."""
+    widget = VideoListDockWidget()
+    widget.set_project(_mock_project(["a.avi", "b.avi"], excluded={"b.avi"}))
+
+    assert _item_for(widget, "a.avi").data(_EXCLUDED_ROLE) is False
+    assert _item_for(widget, "b.avi").data(_EXCLUDED_ROLE) is True
+
+
+def test_set_video_excluded_persists_and_updates_row():
+    """Toggling exclusion persists via settings_manager and updates the row role."""
+    project = _mock_project(["a.avi"], excluded=set())
+    widget = VideoListDockWidget()
+    widget.set_project(project)
+    item = _item_for(widget, "a.avi")
+
+    widget._set_video_excluded(item, "a.avi", True)
+
+    project.settings_manager.set_video_excluded.assert_called_once_with("a.avi", True)
+    assert item.data(_EXCLUDED_ROLE) is True

--- a/tests/ui/test_video_list_widget.py
+++ b/tests/ui/test_video_list_widget.py
@@ -4,9 +4,14 @@ import pytest
 
 try:
     from PySide6.QtCore import Qt
+    from PySide6.QtGui import QColor, QPalette
     from PySide6.QtWidgets import QApplication
 
-    from jabs.ui.main_window.video_list_widget import _EXCLUDED_ROLE, VideoListDockWidget
+    from jabs.ui.main_window.video_list_widget import (
+        _EXCLUDED_ROLE,
+        VideoListDockWidget,
+        _VideoListWidget,
+    )
 
     SKIP_UI_TESTS = False
     SKIP_REASON = None
@@ -67,3 +72,23 @@ def test_set_video_excluded_persists_and_updates_row():
 
     project.settings_manager.set_video_excluded.assert_called_once_with("a.avi", True)
     assert item.data(_EXCLUDED_ROLE) is True
+
+
+def test_text_pen_color_dims_excluded_rows_in_all_states():
+    """Excluded rows use the disabled palette color whether selected or not."""
+    palette = QPalette()
+    palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Text, QColor("red"))
+    palette.setColor(
+        QPalette.ColorGroup.Disabled, QPalette.ColorRole.HighlightedText, QColor("green")
+    )
+    palette.setColor(
+        QPalette.ColorGroup.Active, QPalette.ColorRole.HighlightedText, QColor("blue")
+    )
+    pen = _VideoListWidget.HighlightTextDelegate._text_pen_color
+
+    # unselected excluded -> dimmed normal text
+    assert pen(palette, selected=False, excluded=True).name() == QColor("red").name()
+    # selected excluded -> dimmed highlighted text (still readable on highlight bg)
+    assert pen(palette, selected=True, excluded=True).name() == QColor("green").name()
+    # selected included -> normal highlighted text
+    assert pen(palette, selected=True, excluded=False).name() == QColor("blue").name()


### PR DESCRIPTION
First of two PRs adding the ability to manually exclude specific videos from classifier training. This PR adds the UI toggle, persistence, and visual indication only — **the flag is inert until PR 2** wires it into feature collection, cross-validation, and the train-button threshold.

## Changes
- **`SettingsManager`**: `is_video_excluded(video)` / `set_video_excluded(video, bool)`, storing `exclude_from_training` in the video's per-video metadata (`video_files[video]["metadata"]`). The setter creates the `video_files` entry defensively if it doesn't exist yet.
- **Video list context menu**: a checkable **"Exclude from Training"** item (unchecked by default) in `VideoListDockWidget`; toggling persists the flag and repaints the row.
- **Visual indication**: excluded videos render **dimmed (palette disabled-text color) + italic** in the list, both when selected and unselected. The excluded state is stored in a custom item data role so it survives the search-hit-count retitling.

<img width="408" height="248" alt="image" src="https://github.com/user-attachments/assets/4ce39ef5-0ba9-4ed5-b8d1-29591cf99b24" />

Excluded videos are indicated visually with dim and italicized text (the italics make it visually distinct even when the video is selected)

## Behavior
- Default mode is unchanged: videos are included unless explicitly excluded.
- No training/CV/threshold behavior changes yet (PR 2).

## Tests
- `test_settings_manager.py`: default-false, round-trip + persistence, entry creation when missing, toggle back.
- `tests/ui/test_video_list_widget.py`: `set_project` tags rows from settings; toggling persists via `set_video_excluded` and updates the row role.
- `tests/ui` + settings tests pass (92); ruff clean.

## Next (PR 2)
Honor the flag: collect all videos but train only on included rows; let excluded videos still be eligible as LOGO CV holdout (never in a training fold); and exclude them from the train-button threshold counts. Threshold-counting semantics for excluded-as-holdout to be finalized in PR 2.