### PR TITLE
Determine closest lixit from mouse centroid instead of nose keypoint

### DIFF
--- a/docs/user-guide/features.md
+++ b/docs/user-guide/features.md
@@ -62,6 +62,10 @@
 * bearing to lixit sine
 * bearing to lixit cosine
 
+When more than one lixit is present, the nearest lixit is selected per frame using the distance
+from the mouse centroid to each lixit tip. Using the centroid rather than a single keypoint (such
+as the nose) keeps this selection stable when individual keypoints are missing from the pose.
+
 ### Water Spout (Lixit) extended (experimental)
 
 Optionally supports extended set of lixit features if the lixit is labeled with three keypoints (tip, left side, right side).

--- a/src/jabs/feature_extraction/features.py
+++ b/src/jabs/feature_extraction/features.py
@@ -35,7 +35,7 @@ FlatFeatureMap: TypeAlias = dict[str, npt.NDArray[np.generic]]
 PerFrameFeatureMap: TypeAlias = dict[str, dict[str, npt.NDArray[np.generic]]]
 WindowFeatureMap: TypeAlias = dict[str, dict[str, dict[str, npt.NDArray[np.generic]]]]
 
-FEATURE_VERSION = 16
+FEATURE_VERSION = 17
 
 _FEATURE_MODULES = [BaseFeatureGroup, SocialFeatureGroup, SegmentationFeatureGroup]
 

--- a/src/jabs/feature_extraction/landmark_features/lixit.py
+++ b/src/jabs/feature_extraction/landmark_features/lixit.py
@@ -12,11 +12,14 @@ class LixitDistanceInfo:
     because we have two feature groups that both need to know which lixit is the closest, we compute that
     information once in this helper class and then pass it to both of the features. The features cannot be merged into
     a single feature because one requires a different set of window feature methods.
+
+    The closest lixit is determined using the mouse centroid (convex hull center) rather than a single
+    keypoint. The centroid is robust to dropout of any individual keypoint (e.g. the nose), which keeps the
+    closest-lixit choice stable in multi-lixit arenas. The per-frame centroid is also cached here and shared
+    with the MouseLixitAngle feature to avoid recomputing it.
     """
 
     def __init__(self, poses: PoseEstimation, pixel_scale: float):
-        # Identify closest lixit
-        self._closest_key = PoseEstimation.KeypointIndex.NOSE
         # Distances include all keypoints
         self._keypoint_indices = list(PoseEstimation.KeypointIndex)
 
@@ -25,6 +28,7 @@ class LixitDistanceInfo:
         self._closest_lixit_idx = {}
         self._cached_distances = {}
         self._cached_bearings = {}
+        self._cached_centroids = {}
 
     def cache_features(self, identity: int):
         """Computes and caches distances and bearings to the closest lixit for a given identity.
@@ -69,17 +73,20 @@ class LixitDistanceInfo:
 
             points, _ = self._poses.get_identity_poses(identity, self._pixel_scale)
 
-            # if there are multiple lixit, we compute the distance from nose to
-            # each one, resulting in a numpy array of shape #frames, #lixit
-            pts = points[:, self._closest_key, :]
+            # Determine the closest lixit using the mouse centroid rather than a single
+            # keypoint. The centroid is robust to dropout of any individual keypoint, which
+            # keeps the choice stable in multi-lixit arenas. Scale it to match the lixit units.
+            centroids = self.get_centroids(identity)
+            if self._pixel_scale is not None:
+                centroids = centroids * self._pixel_scale
+
+            # distance from the centroid to each lixit tip, shape (#frames, #lixit)
             for i in range(num_lixit):
                 # use the tip of the lixit to determine closest
                 ref = lixit[i, 0] if points_per_lixit == 3 else lixit[i]
-                alignment_distances[:, i] = np.sqrt(np.sum((pts - ref) ** 2, axis=1))
+                alignment_distances[:, i] = np.sqrt(np.sum((centroids - ref) ** 2, axis=1))
 
-            self._closest_lixit_idx[identity] = np.argmin(alignment_distances, axis=1).astype(
-                np.uint8
-            )
+            self._closest_lixit_idx[identity] = self._closest_lixit_per_frame(alignment_distances)
 
             if points_per_lixit == 3:
                 # grab just the tip keypoint for determining pairwise distances from pose keypoints to lixit tip
@@ -139,6 +146,83 @@ class LixitDistanceInfo:
         if identity not in self._closest_lixit_idx:
             self.cache_features(identity)
         return self._closest_lixit_idx[identity]
+
+    def get_centroids(self, identity: int) -> np.ndarray:
+        """get per-frame mouse centroids (convex hull centers) for an identity
+
+        The centroid is robust to dropout of any single keypoint and is shared with the
+        MouseLixitAngle feature to avoid recomputing it.
+
+        Args:
+            identity: integer identity to get centroids for
+
+        Returns:
+            np.ndarray of shape (#frames, 2) of centroid coordinates in pixel units; rows
+            are NaN for frames where no centroid is available
+        """
+        if identity not in self._cached_centroids:
+            self._cached_centroids[identity] = self._compute_centroids(identity)
+        return self._cached_centroids[identity]
+
+    def _compute_centroids(self, identity: int) -> np.ndarray:
+        """compute the per-frame mouse centroid (convex hull center) in pixel units
+
+        Args:
+            identity: integer identity to compute centroids for
+
+        Returns:
+            np.ndarray of shape (#frames, 2) of centroid coordinates in pixel units; rows
+            are NaN for frames where the identity is absent or has too few valid keypoints
+            to form a convex hull
+        """
+        centroids = np.full((self._poses.num_frames, 2), np.nan, dtype=np.float32)
+        frame_valid = self._poses.identity_mask(identity)
+        indexes = np.arange(self._poses.num_frames)[frame_valid == 1]
+        convex_hulls = self._poses.get_identity_convex_hulls(identity)
+        for i in indexes:
+            hull = convex_hulls[i]
+            if hull is not None:
+                centroids[i, :] = np.asarray(hull.centroid.xy).squeeze()
+        return centroids
+
+    @staticmethod
+    def _closest_lixit_per_frame(alignment_distances: np.ndarray) -> np.ndarray:
+        """select the closest lixit per frame, filling gaps from the nearest valid frame
+
+        A frame's distances are all NaN only when the mouse centroid is unavailable for
+        that frame (e.g. too few valid keypoints to form a convex hull). Each such frame is
+        filled with the choice from the temporally nearest valid frame, looking both
+        backward and forward (ties prefer the earlier frame). If no frame has a valid
+        centroid, every frame defaults to lixit 0.
+
+        Args:
+            alignment_distances: array of shape (#frames, #lixit) giving the distance from
+                the mouse centroid to each lixit tip (NaN where the centroid is missing)
+
+        Returns:
+            np.ndarray of shape (#frames,) of closest lixit indices as uint8
+        """
+        num_frames = alignment_distances.shape[0]
+        closest = np.zeros(num_frames, dtype=np.uint8)
+
+        valid = ~np.isnan(alignment_distances).all(axis=1)
+        if not valid.any():
+            return closest
+
+        closest[valid] = np.nanargmin(alignment_distances[valid], axis=1).astype(np.uint8)
+
+        # For each frame, find the nearest valid frame on each side, then fill from
+        # whichever side is closer (ties prefer the earlier/previous frame). A missing
+        # side gets a sentinel distance so the other (real) side always wins.
+        frame_indices = np.arange(num_frames)
+        prev_idx = np.maximum.accumulate(np.where(valid, frame_indices, -1))
+        next_idx = np.minimum.accumulate(np.where(valid, frame_indices, num_frames)[::-1])[::-1]
+
+        prev_dist = np.where(prev_idx >= 0, frame_indices - prev_idx, num_frames + 1)
+        next_dist = np.where(next_idx < num_frames, next_idx - frame_indices, num_frames + 1)
+
+        source = np.where(prev_dist <= next_dist, prev_idx, next_idx)
+        return closest[source]
 
     @staticmethod
     def compute_angles(a: np.ndarray, b: np.ndarray, c: np.ndarray) -> np.ndarray:
@@ -277,16 +361,11 @@ class MouseLixitAngle(Feature):
         # Get the poses (keypoint coordinates) for the given identity, scaled by pixel_scale
         points, _ = self._poses.get_identity_poses(identity, self._pixel_scale)
 
-        # get centroids
-        # first, get an array of the indexes of valid frames only
-        frame_valid = self._poses.identity_mask(identity)
-        indexes = np.arange(self._poses.num_frames)[frame_valid == 1]
-
-        # then get centroids for all frames where this identity is present
-        convex_hulls = self._poses.get_identity_convex_hulls(identity)
-        centroids = np.full([self._poses.num_frames, 2], np.nan, dtype=np.float32)
-        for i in indexes:
-            centroids[i, :] = np.asarray(convex_hulls[i].centroid.xy).squeeze()
+        # Reuse the shared mouse centroid (convex hull center) computed by LixitDistanceInfo.
+        # It is returned in pixel units, so scale it to cm to match `points`.
+        centroids = self._cached_distances.get_centroids(identity)
+        if self._pixel_scale is not None:
+            centroids = centroids * self._pixel_scale
 
         # Compute the vector from the nose to the center of the spine for the mouse
         mouse_vectors = points[:, PoseEstimation.KeypointIndex.NOSE, :] - centroids

--- a/src/jabs/resources/docs/user_guide/features.md
+++ b/src/jabs/resources/docs/user_guide/features.md
@@ -62,6 +62,10 @@
 * bearing to lixit sine
 * bearing to lixit cosine
 
+When more than one lixit is present, the nearest lixit is selected per frame using the distance
+from the mouse centroid to each lixit tip. Using the centroid rather than a single keypoint (such
+as the nose) keeps this selection stable when individual keypoints are missing from the pose.
+
 ### Water Spout (Lixit) extended (experimental)
 
 Optionally supports extended set of lixit features if the lixit is labeled with three keypoints (tip, left side, right side).

--- a/tests/feature_extraction/landmark_features/test_lixit_distance.py
+++ b/tests/feature_extraction/landmark_features/test_lixit_distance.py
@@ -1,7 +1,32 @@
 """Tests for lixit distance feature extraction."""
 
+import shutil
+import tempfile
+from pathlib import Path
+
 import numpy as np
 import pytest
+
+import jabs.pose_estimation
+from jabs.feature_extraction.landmark_features import lixit
+from jabs.pose_estimation import PoseEstimation
+
+
+@pytest.fixture
+def fresh_pose_v5():
+    """A fresh PoseEstimationV5 with its own tempdir copy and no lixit set.
+
+    Lets tests install custom lixit positions without mutating the shared,
+    module-scoped ``pose_est_v5_with_static_objects`` fixture.
+
+    Yields:
+        PoseEstimationV5: pose estimation object with no static lixit object.
+    """
+    test_file = Path(__file__).parent.parent.parent / "data" / "sample_pose_est_v5.h5"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        pose_path = Path(tmpdir) / "sample_pose_est_v5.h5"
+        shutil.copy(test_file, pose_path)
+        yield jabs.pose_estimation.open_pose_file(pose_path)
 
 
 def test_dimensions(pose_est_v5_with_static_objects, lixit_distance_features):
@@ -80,3 +105,142 @@ def test_computation(lixit_distance_features):
     # Compare first 10 values
     for i in range(expected.shape[0]):
         assert expected[i] == pytest.approx(actual[i], abs=1e-5)
+
+
+def test_closest_lixit_per_frame_nearest_neighbor():
+    """Gaps are filled from the temporally nearest valid frame, forward or backward.
+
+    Valid choices occur at frame 1 (lixit 0) and frame 6 (lixit 2). The intervening
+    gap splits by proximity to each neighbor; the leading gap is back-filled from
+    frame 1 and the trailing gap is carried forward from frame 6.
+    """
+    nan = np.nan
+    far = [9.0, 9.0, 9.0]
+
+    def closest_to(idx: int) -> list[float]:
+        row = list(far)
+        row[idx] = 1.0
+        return row
+
+    alignment_distances = np.array(
+        [
+            [nan, nan, nan],  # 0 leading gap   -> back-fill from frame 1 -> 0
+            closest_to(0),  # 1 valid          -> 0
+            [nan, nan, nan],  # 2 gap (d1=1,d6=4) -> 0
+            [nan, nan, nan],  # 3 gap (d1=2,d6=3) -> 0
+            [nan, nan, nan],  # 4 gap (d1=3,d6=2) -> 2
+            [nan, nan, nan],  # 5 gap (d1=4,d6=1) -> 2
+            closest_to(2),  # 6 valid          -> 2
+            [nan, nan, nan],  # 7 trailing gap   -> carry forward from frame 6 -> 2
+        ],
+        dtype=np.float32,
+    )
+
+    result = lixit.LixitDistanceInfo._closest_lixit_per_frame(alignment_distances)
+
+    np.testing.assert_array_equal(result, np.array([0, 0, 0, 0, 2, 2, 2, 2], dtype=np.uint8))
+    assert result.dtype == np.uint8
+
+
+def test_closest_lixit_per_frame_tie_prefers_previous():
+    """An equidistant gap frame is filled from the earlier valid frame."""
+    nan = np.nan
+    alignment_distances = np.array(
+        [
+            [1.0, 9.0],  # 0 valid -> 0
+            [nan, nan],  # 1 equidistant to frames 0 and 2 -> tie -> previous -> 0
+            [9.0, 1.0],  # 2 valid -> 1
+        ],
+        dtype=np.float32,
+    )
+
+    result = lixit.LixitDistanceInfo._closest_lixit_per_frame(alignment_distances)
+
+    np.testing.assert_array_equal(result, np.array([0, 0, 1], dtype=np.uint8))
+
+
+def test_closest_lixit_per_frame_all_nan():
+    """When no frame has a centroid, every frame defaults to lixit 0."""
+    alignment_distances = np.full((4, 3), np.nan, dtype=np.float32)
+    result = lixit.LixitDistanceInfo._closest_lixit_per_frame(alignment_distances)
+    np.testing.assert_array_equal(result, np.zeros(4, dtype=np.uint8))
+
+
+def test_compute_centroids_handles_none_hull():
+    """A None convex hull on a present frame yields NaN, not an exception."""
+    from shapely.geometry import MultiPoint
+
+    hull = MultiPoint([(0, 0), (2, 0), (1, 2)]).convex_hull
+
+    class _StubPose:
+        """Minimal pose stand-in exposing only what _compute_centroids needs."""
+
+        num_frames = 3
+
+        # frame 0 present with a hull, frame 1 present but no hull, frame 2 absent
+        def identity_mask(self, identity: int) -> np.ndarray:
+            return np.array([1, 1, 0], dtype=np.uint8)
+
+        def get_identity_convex_hulls(self, identity: int) -> list:
+            return [hull, None, None]
+
+    info = lixit.LixitDistanceInfo(_StubPose(), pixel_scale=1.0)
+    centroids = info.get_centroids(0)
+
+    assert centroids.shape == (3, 2)
+    assert not np.isnan(centroids[0]).any()  # valid hull -> finite centroid
+    assert np.isnan(centroids[1]).all()  # None hull -> NaN, no crash
+    assert np.isnan(centroids[2]).all()  # absent -> NaN
+
+
+def test_centroid_drives_closest_selection(fresh_pose_v5):
+    """The closest lixit is chosen by the mouse centroid, not the nose keypoint.
+
+    Places one lixit on the nose and another on the centroid for a frame where the
+    two are clearly separated. Centroid-based selection must pick the lixit on the
+    centroid, whereas the previous nose-based logic would have picked the other.
+    """
+    pose = fresh_pose_v5
+    pixel_scale = pose.cm_per_pixel
+    info = lixit.LixitDistanceInfo(pose, pixel_scale)
+
+    centroids = info.get_centroids(0)  # pixel units
+    points, _ = pose.get_identity_poses(0)  # pixel units
+    nose = points[:, PoseEstimation.KeypointIndex.NOSE, :]
+
+    # find a frame where nose and centroid are both valid and clearly separated
+    valid = ~np.isnan(centroids).any(axis=1) & ~np.isnan(nose).any(axis=1)
+    separation = np.hypot(*(centroids - nose).T)
+    candidates = np.where(valid & (separation > 5.0))[0]
+    assert candidates.size > 0, "no frame with a clearly separated nose and centroid"
+    frame = int(candidates[0])
+
+    # lixit 0 sits on the nose, lixit 1 sits on the centroid
+    pose.static_objects["lixit"] = np.asarray([nose[frame], centroids[frame]], dtype=np.float64)
+
+    closest = info.get_closest_lixit(0)
+    assert closest[frame] == 1
+
+
+def test_mouse_lixit_angle_runs_with_three_point_lixit(fresh_pose_v5):
+    """MouseLixitAngle produces in-range cosines using the shared centroid.
+
+    Exercises the consolidated centroid path (reused from LixitDistanceInfo) for a
+    three-keypoint lixit.
+    """
+    pose = fresh_pose_v5
+    pixel_scale = pose.cm_per_pixel
+    # three-keypoint lixit: tip, left side, right side
+    pose.static_objects["lixit"] = np.asarray(
+        [[[62, 166], [60, 170], [64, 170]]], dtype=np.float64
+    )
+
+    info = lixit.LixitDistanceInfo(pose, pixel_scale)
+    feature = lixit.MouseLixitAngle(pose, pixel_scale, info)
+    result = feature.per_frame(0)
+
+    assert set(result) == {"centroid - nose", "base-tail - centroid"}
+    for values in result.values():
+        assert values.shape == (pose.num_frames,)
+        finite = values[~np.isnan(values)]
+        assert np.all((finite >= -1.0) & (finite <= 1.0))


### PR DESCRIPTION
## Summary

In multi-lixit arenas, JABS selects the closest lixit per frame to compute the lixit distance and angle features. Previously this selection used the distance from the **nose** keypoint to each lixit tip. When the nose dropped out of the pose, the choice became unstable and could flip between lixit.

This branch switches the closest-lixit selection to use the **mouse centroid** (convex hull center) instead. The centroid is robust to dropout of any individual keypoint, keeping the choice stable across frames.

## Changes

- `LixitDistanceInfo` now picks the closest lixit using centroid-to-tip distance rather than nose-to-tip distance.
- Added per-frame centroid caching in `LixitDistanceInfo`, shared with `MouseLixitAngle` so the convex-hull centroid is computed only once (removes the duplicate centroid computation that previously lived in `MouseLixitAngle.per_frame`).
- Added `_closest_lixit_per_frame`, which fills frames with no valid centroid (too few keypoints to form a convex hull) from the temporally nearest valid frame (ties prefer the earlier frame); falls back to lixit 0 if no frame has a valid centroid.
- Bumped `FEATURE_VERSION` 16 → 17 to invalidate cached features.
- Updated user-guide feature docs (both `docs/user-guide/features.md` and the in-app copy).

## Tests

Added tests in `tests/feature_extraction/landmark_features/test_lixit_distance.py` covering the centroid-based selection and the nearest-valid-frame gap filling, plus a `fresh_pose_v5` fixture that installs custom lixit positions without mutating the shared module-scoped pose fixture.
