### PR TITLE
Sync uv.lock with 0.45.0 version bump

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1678,7 +1678,7 @@ wheels = [
 
 [[package]]
 name = "jabs-behavior"
-version = "0.44.2"
+version = "0.45.0"
 source = { editable = "packages/jabs-behavior" }
 dependencies = [
     { name = "jsonschema" },
@@ -1722,7 +1722,7 @@ test = [
 
 [[package]]
 name = "jabs-behavior-classifier"
-version = "0.44.2"
+version = "0.45.0"
 source = { editable = "." }
 dependencies = [
     { name = "argparse-formatter" },
@@ -1834,7 +1834,7 @@ test = [
 
 [[package]]
 name = "jabs-core"
-version = "0.44.2"
+version = "0.45.0"
 source = { editable = "packages/jabs-core" }
 dependencies = [
     { name = "h5py" },
@@ -1892,7 +1892,7 @@ test = [
 
 [[package]]
 name = "jabs-io"
-version = "0.44.2"
+version = "0.45.0"
 source = { editable = "packages/jabs-io" }
 dependencies = [
     { name = "jabs-core" },
@@ -1961,7 +1961,7 @@ test = [
 
 [[package]]
 name = "jabs-vision"
-version = "0.44.2"
+version = "0.45.0"
 source = { editable = "packages/jabs-vision" }
 dependencies = [
     { name = "hydra-core" },


### PR DESCRIPTION
The 0.45.0 release bumped the version in the workspace `pyproject.toml` files, but `uv.lock` was not regenerated, so it still pinned `0.44.2` for the editable workspace packages.

This syncs the lockfile: `jabs-behavior`, `jabs-behavior-classifier`, `jabs-core`, `jabs-io`, and `jabs-vision` go `0.44.2 → 0.45.0`. There are no dependency-resolution changes — `uv lock --check` passes against the current manifests.