### PR TITLE
Use a small Material triangle for settings expander disclosure icon

### DIFF
--- a/src/jabs/ui/settings_dialog/collapsible_section.py
+++ b/src/jabs/ui/settings_dialog/collapsible_section.py
@@ -1,6 +1,10 @@
-from PySide6.QtCore import Signal
+from PySide6.QtCore import QSize, Signal
 from PySide6.QtGui import Qt
 from PySide6.QtWidgets import QFrame, QSizePolicy, QToolButton, QVBoxLayout, QWidget
+from qt_material_icons import MaterialIcon
+
+# Pixel size of the disclosure triangle.
+_INDICATOR_SIZE = 16
 
 
 class CollapsibleSection(QWidget):
@@ -16,10 +20,18 @@ class CollapsibleSection(QWidget):
     def __init__(self, title: str, content: QWidget, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self._content = content
+
+        # Disclosure indicator: a small Material triangle that points to the side when
+        # collapsed and down when expanded. qt_material_icons renders in the palette
+        # text color, so it follows the application theme.
+        self._collapsed_icon = MaterialIcon("arrow_right")
+        self._expanded_icon = MaterialIcon("arrow_drop_down")
+
         self._toggle_btn = QToolButton(self)
         self._toggle_btn.setStyleSheet("QToolButton { border: none; }")
         self._toggle_btn.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
-        self._toggle_btn.setArrowType(Qt.ArrowType.RightArrow)
+        self._toggle_btn.setIconSize(QSize(_INDICATOR_SIZE, _INDICATOR_SIZE))
+        self._toggle_btn.setIcon(self._collapsed_icon)
         self._toggle_btn.setText(title)
         self._toggle_btn.setCheckable(True)
         self._toggle_btn.setChecked(False)
@@ -43,9 +55,7 @@ class CollapsibleSection(QWidget):
 
     def _on_toggled(self, checked: bool) -> None:
         """Handle toggling the collapsible section."""
-        self._toggle_btn.setArrowType(
-            Qt.ArrowType.DownArrow if checked else Qt.ArrowType.RightArrow
-        )
+        self._toggle_btn.setIcon(self._expanded_icon if checked else self._collapsed_icon)
         self._content.setVisible(checked)
         self._content.updateGeometry()
 

--- a/src/jabs/ui/settings_dialog/collapsible_section.py
+++ b/src/jabs/ui/settings_dialog/collapsible_section.py
@@ -1,5 +1,4 @@
-from PySide6.QtCore import QSize, Signal
-from PySide6.QtGui import Qt
+from PySide6.QtCore import QSize, Qt, Signal
 from PySide6.QtWidgets import QFrame, QSizePolicy, QToolButton, QVBoxLayout, QWidget
 from qt_material_icons import MaterialIcon
 
@@ -30,6 +29,8 @@ class CollapsibleSection(QWidget):
         self._toggle_btn = QToolButton(self)
         self._toggle_btn.setStyleSheet("QToolButton { border: none; }")
         self._toggle_btn.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
+        # Only the Material disclosure icon is shown; never the style's native arrow.
+        self._toggle_btn.setArrowType(Qt.ArrowType.NoArrow)
         self._toggle_btn.setIconSize(QSize(_INDICATOR_SIZE, _INDICATOR_SIZE))
         self._toggle_btn.setIcon(self._collapsed_icon)
         self._toggle_btn.setText(title)

--- a/src/jabs/ui/settings_dialog/collapsible_section.py
+++ b/src/jabs/ui/settings_dialog/collapsible_section.py
@@ -3,7 +3,7 @@ from PySide6.QtWidgets import QFrame, QSizePolicy, QToolButton, QVBoxLayout, QWi
 from qt_material_icons import MaterialIcon
 
 # Pixel size of the disclosure triangle.
-_INDICATOR_SIZE = 16
+_INDICATOR_SIZE = 18
 
 
 class CollapsibleSection(QWidget):

--- a/tests/ui/test_settings_dialog.py
+++ b/tests/ui/test_settings_dialog.py
@@ -7,11 +7,13 @@ from jabs.core.constants import CLASSIFIER_MODE_KEY
 from jabs.core.enums import ClassifierMode
 
 try:
-    from PySide6.QtWidgets import QApplication
+    from PySide6.QtGui import Qt
+    from PySide6.QtWidgets import QApplication, QLabel
 
     from jabs.ui.settings_dialog.classifier_mode_settings_group import (
         ClassifierModeSettingsGroup,
     )
+    from jabs.ui.settings_dialog.collapsible_section import CollapsibleSection
     from jabs.ui.settings_dialog.settings_dialog import _OverlapCheckThread
 
     SKIP_UI_TESTS = False
@@ -81,3 +83,19 @@ def test_classifier_mode_group_roundtrips_enum_not_label() -> None:
 
     group.set_values({CLASSIFIER_MODE_KEY: ClassifierMode.BINARY.value})
     assert group.get_values() == {CLASSIFIER_MODE_KEY: ClassifierMode.BINARY}
+
+
+def test_collapsible_section_toggles_disclosure_icon() -> None:
+    """The disclosure indicator swaps between the collapsed and expanded icons."""
+    section = CollapsibleSection("More info", QLabel("content"))
+
+    # No native arrow is drawn; only the Material disclosure icon is shown.
+    assert section._toggle_btn.arrowType() == Qt.ArrowType.NoArrow
+    collapsed_key = section._toggle_btn.icon().cacheKey()
+
+    section.set_expanded(True)
+    expanded_key = section._toggle_btn.icon().cacheKey()
+    assert expanded_key != collapsed_key
+
+    section.set_expanded(False)
+    assert section._toggle_btn.icon().cacheKey() == collapsed_key

--- a/tests/ui/test_settings_dialog.py
+++ b/tests/ui/test_settings_dialog.py
@@ -7,7 +7,7 @@ from jabs.core.constants import CLASSIFIER_MODE_KEY
 from jabs.core.enums import ClassifierMode
 
 try:
-    from PySide6.QtGui import Qt
+    from PySide6.QtCore import Qt
     from PySide6.QtWidgets import QApplication, QLabel
 
     from jabs.ui.settings_dialog.classifier_mode_settings_group import (


### PR DESCRIPTION
The collapsible "More info" sections in the settings dialogs used `QToolButton.setArrowType()`, which draws the Qt style's arrow primitive — chunky and not easily sized.

This swaps it for a small **Material disclosure triangle** in the shared `CollapsibleSection` widget:
- `arrow_right` when collapsed, `arrow_drop_down` when expanded, at **16px**.
- Uses the already-bundled `qt_material_icons`, which renders in the palette text color, so it follows the application theme (matching how sibling dialogs already use `MaterialIcon`).
- The native arrow is removed (`arrowType` is now `NoArrow`); the toggle/resize behavior is otherwise unchanged.

Because it's the shared widget, every settings "More info" expander updates consistently.

## Tests
- Added `test_collapsible_section_toggles_disclosure_icon`: verifies the icon swaps on expand and reverts on collapse, and that no native arrow is drawn.
- Settings-dialog tests pass; lint and format clean.

It's a visual tweak, so a quick look in the GUI confirms the appearance; the toggle behavior is covered by the test.