### PR TITLE
Document actual test mocking convention (monkeypatch + unittest.mock)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,7 +265,10 @@ Every module should have a **clear, single responsibility**. If a module docstri
 
 ### Framework & Tools
 
-- **pytest** (plain functions, no unittest-style classes), **pytest-cov**, **pytest-mock**
+- **pytest** (plain functions, no unittest-style classes), **pytest-cov**
+- **Mocking:** use the built-in **`monkeypatch`** fixture and the standard-library
+  **`unittest.mock`**. `pytest-mock` (the `mocker` fixture) is **not** a dependency — do
+  not use it.
 - Run coverage: `uv run pytest --cov=src/jabs --cov-report=term-missing`
 
 ### Test Organization
@@ -287,14 +290,24 @@ def test_normalize_distance_basic() -> None:
     result = normalize_distance(distance=50.0, arena_diameter=100.0)
     assert result == pytest.approx(0.5)
 
-# Mock external dependencies — never hit filesystem, network, or GPU in unit tests
-def test_classifier_predict(mocker: MockerFixture) -> None:
-    mock_model = mocker.Mock()
+# Mock external dependencies — never hit filesystem, network, or GPU in unit tests.
+# Use unittest.mock for standalone mocks; use monkeypatch to patch module-level symbols.
+from unittest import mock
+
+def test_classifier_predict() -> None:
+    mock_model = mock.Mock()
     mock_model.predict.return_value = np.array([0, 1, 0])
     classifier = BehaviorClassifier(model=mock_model)
     predictions = classifier.predict(features)
     mock_model.predict.assert_called_once()
     assert len(predictions) == 3
+
+# Patch a function/attribute for the duration of one test (auto-undone) with monkeypatch
+def test_export_calls_save(monkeypatch) -> None:
+    save_spy = mock.Mock()
+    monkeypatch.setattr("jabs.io.save", save_spy)
+    export_training_data(project)
+    save_spy.assert_called_once()
 
 # Use fixtures extensively for shared setup (in conftest.py)
 @pytest.fixture


### PR DESCRIPTION
## Summary

CLAUDE.md's Testing section lists `pytest-mock` as a tool and shows a `mocker: MockerFixture` example, but `pytest-mock` is **not** declared in any `pyproject.toml` and is not installed — the `mocker` fixture raises "fixture 'mocker' not found". This aligns the documentation with the actual, already-consistent convention.

## Why docs, not the dependency

The codebase already mocks consistently without pytest-mock:

- **0** of 105 test files use `mocker`
- **29** use `unittest.mock`, **13** use `monkeypatch`

`unittest.mock` + the built-in `monkeypatch` fixture are stdlib / pytest built-ins and already the de-facto standard here. Adopting `pytest-mock` would mean adding the dep to all **5** workspace `test` groups and either a mixed convention or a 42-file migration for marginal ergonomic gain. The actual problem was the doc, not a missing tool.

## Changes

- Remove `pytest-mock` from the Framework & Tools list; add an explicit "Mocking" bullet pointing to `monkeypatch` + `unittest.mock` and noting `mocker` is not available.
- Rewrite the `mocker: MockerFixture` example to use `unittest.mock.Mock`, plus a short `monkeypatch.setattr(...)` example for patching module-level symbols.

Docs-only; no code or tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)