### PR TITLE
Sync in-app gui.md: add Export Frame Ctrl+E shortcut

### DIFF
--- a/src/jabs/resources/docs/user_guide/gui.md
+++ b/src/jabs/resources/docs/user_guide/gui.md
@@ -115,7 +115,7 @@ Clicking the video or moving the mouse off the video frame will dismiss the slid
 - **JABS→Quit JABS:** Quit Program
 - **File→Open Project:** Select a project directory to open. If a project is already opened, it will be closed and the newly selected project will be opened.
 - **File→Open Recent:** Submenu to open recently opened projects.
-- **File→Export Frame:** Export the current paused video frame as a PNG image at the original video resolution. A checkbox on the save dialog optionally saves a second copy, suffixed `-overlay.png`, with the pose and (when available) segmentation overlays. The export is disabled during playback and remembers the last export directory and the overlay-copy setting.
+- **File→Export Frame:** Export the current paused video frame as a PNG image at the original video resolution. A checkbox on the save dialog optionally saves a second copy, suffixed `-overlay.png`, with the pose and (when available) segmentation overlays. The export is disabled during playback and remembers the last export directory and the overlay-copy setting. Shortcut: Ctrl+E / ⌘E.
 - **File→Export Training Data:** Create a file with the information needed to share a classifier. This exported file is written to the project directory and has the form `<Behavior_Name>_training_<YYYYMMDD_hhmmss>.h5`. This file is used as one input for the `jabs-classify` script.
 - **File→Archive Behavior:** Remove behavior and its labels from project. Labels are archived in the `jabs/archive` directory.
 - **File→Prune Project:** Remove videos and pose files that are not labeled.


### PR DESCRIPTION
## Summary

The two mirrored copies of the GUI user guide had drifted by one line: the online `docs/user-guide/gui.md` documents the Export Frame keyboard shortcut, but the in-app `src/jabs/resources/docs/user_guide/gui.md` mirror (shipped as package resources and rendered in the app's help) was missing it. This adds the sentence to the mirror so both copies match.

## Verification

- The shortcut is real: `menu_builder.py:229` binds the Export Frame action via `QKeySequence("Ctrl+E")` (rendered ⌘E on macOS), so the online copy was correct and the in-app mirror was stale.
- `diff docs/user-guide/gui.md src/jabs/resources/docs/user_guide/gui.md` is now empty — the two copies are byte-identical again.

## Context

Noticed while merging `main` into `feature/cv-filename-pattern-grouping`; the drift predates that branch and is unrelated to it, so it's fixed here on its own. Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)