### PR TITLE
feat: show spinner during jabs-classify train

### DIFF
--- a/src/jabs/scripts/classify.py
+++ b/src/jabs/scripts/classify.py
@@ -16,6 +16,7 @@ import h5py
 import joblib
 import numpy as np
 import pandas as pd
+from rich.console import Console
 from rich.progress import BarColumn, Progress, TextColumn
 from sklearn.exceptions import InconsistentVersionWarning
 
@@ -113,9 +114,11 @@ def train_multiclass(
     Returns:
         Trained ``MultiClassClassifier`` instance.
     """
-    classifier = MultiClassClassifier.from_training_file(
-        training_file, classifier_type=classifier_type
-    )
+    console = Console()
+    with console.status("Training multi-class classifier...", spinner="dots"):
+        classifier = MultiClassClassifier.from_training_file(
+            training_file, classifier_type=classifier_type
+        )
     classifier_settings = classifier.project_settings
 
     print("Training multi-class classifier for:", ", ".join(classifier.behavior_names))
@@ -309,7 +312,9 @@ def train(training_file: Path, classifier_type: ClassifierType | None = None) ->
     Returns:
         Trained ``Classifier`` instance.
     """
-    classifier = Classifier.from_training_file(training_file, classifier_type=classifier_type)
+    console = Console()
+    with console.status("Training classifier...", spinner="dots"):
+        classifier = Classifier.from_training_file(training_file, classifier_type=classifier_type)
     classifier_settings = classifier.project_settings
 
     print("Training classifier for:", classifier.behavior_name)


### PR DESCRIPTION
## Summary

`jabs-classify train` (and `jabs-classify classify --training`) previously produced no output while a classifier trained — nothing appeared in the terminal until training finished and the settings were printed. On larger training sets this made it look like the command had hung.

This wraps the training call in a Rich spinner (`console.status(..., spinner="dots")`) so it's clear that work is happening.

## Details

- The slow work happens inside `Classifier.from_training_file()` / `MultiClassClassifier.from_training_file()`, which load the data and run `.fit()`. The spinner now wraps those calls in `train()` and `train_multiclass()`.
- Placing it there covers both entry points: `jabs-classify train` and `jabs-classify classify --training`.
- Settings are still printed immediately after training, unchanged.
- Matches the existing `console.status(..., spinner="dots")` convention already used in `compute_features.py`, `sample_frames.py`, `cross_validation.py`, and `cli.py`.
- Non-TTY output (piping/redirecting to a log) degrades gracefully — Rich detects the non-terminal and emits no animation or escape codes.

## Testing

- `ruff check` + `ruff format --check` pass
- Existing `tests/scripts/test_classify.py` passes