### PR TITLE
feat: log project annotations as a zipped MLflow artifact

### DIFF
--- a/docs/user-guide/cli-tools.md
+++ b/docs/user-guide/cli-tools.md
@@ -552,7 +552,8 @@ jabs-cli cross-validation DIRECTORY --behavior BEHAVIOR \
     [--grouping-pattern REGEX] \
     [--classifier {catboost|random_forest|xgboost}] \
     [--report-file FILE] \
-    [--mlflow [ENV_FILE]] [--mlflow-experiment NAME] [--mlflow-tag KEY=VALUE] [--mlflow-no-report]
+    [--mlflow [ENV_FILE]] [--mlflow-experiment NAME] [--mlflow-tag KEY=VALUE] \
+    [--mlflow-no-report] [--mlflow-no-annotations]
 ```
 
 - `DIRECTORY`: Path to the JABS project directory.
@@ -562,7 +563,7 @@ jabs-cli cross-validation DIRECTORY --behavior BEHAVIOR \
 - `--grouping-pattern REGEX`: Regular expression applied to each video filename to derive a grouping key. Only used with `--grouping-strategy filename`. If omitted, the pattern saved in the project is used.
 - `--classifier {catboost|random_forest|xgboost}`: Classifier to evaluate. Defaults to `xgboost`. The available choices depend on which classifier libraries are installed; see [Classifier Types](classifier-types.md).
 - `--report-file FILE`: Where to write the training report. The format is chosen by extension: `.md` (Markdown) or `.json` (JSON). If omitted, a timestamped Markdown file is written to the current directory (`<behavior>_<timestamp>_training_report.md`).
-- `--mlflow`, `--mlflow-experiment`, `--mlflow-tag`, `--mlflow-no-report`: Optional MLflow logging (see [MLflow logging](#mlflow-logging)).
+- `--mlflow`, `--mlflow-experiment`, `--mlflow-tag`, `--mlflow-no-report`, `--mlflow-no-annotations`: Optional MLflow logging (see [MLflow logging](#mlflow-logging)).
 
 ### Grouping strategies
 
@@ -602,7 +603,7 @@ jabs-cli cross-validation /path/to/project --behavior grooming \
 
 ### MLflow logging
 
-The cross-validation command can optionally log each run to an [MLflow](https://mlflow.org/) tracking server, recording aggregate metrics, run parameters, descriptive tags, and the training report as an artifact. This is opt-in and off by default.
+The cross-validation command can optionally log each run to an [MLflow](https://mlflow.org/) tracking server, recording aggregate metrics, run parameters, descriptive tags, and — as artifacts — the training report and a zip of the project's annotations. This is opt-in and off by default.
 
 #### Installing the MLflow extra
 
@@ -688,7 +689,10 @@ Each invocation creates one MLflow run named `<behavior>-cv-<timestamp>`.
 
 **Tags:** auto-derived `behavior`, `classifier`, `cv_grouping_strategy`, and `jabs_git` (the short git SHA of the JABS checkout, when available). Any `--mlflow-tag` entries are merged on top, so a user tag wins over an auto tag with the same key.
 
-**Artifact:** the generated training report file, unless `--mlflow-no-report` is passed.
+**Artifacts:**
+
+- The generated training report file, unless `--mlflow-no-report` is passed.
+- `annotations.zip` — a zip of the project's `jabs/annotations` directory, unless `--mlflow-no-annotations` is passed. This captures the label set the run was computed from, so a run's metrics can be traced back to (and reproduced from) the exact annotations. Unpacking it recreates an `annotations/` directory. It is skipped silently if the project has no annotations directory or the directory is empty.
 
 #### Free-form tags
 
@@ -701,13 +705,18 @@ jabs-cli cross-validation /path/to/project --behavior grooming --mlflow settings
 
 Each entry is `KEY=VALUE`; only the first `=` splits the entry, so values may contain `=`.
 
-#### Skipping the report artifact
+#### Skipping artifacts
 
-To log metrics and parameters only (no report upload):
+Each artifact has its own opt-out flag. To log metrics and parameters only:
 
 ```bash
-jabs-cli cross-validation /path/to/project --behavior grooming --mlflow --mlflow-no-report
+jabs-cli cross-validation /path/to/project --behavior grooming --mlflow \
+    --mlflow-no-report --mlflow-no-annotations
 ```
+
+Pass only `--mlflow-no-annotations` to keep the report but skip the annotations upload — worth doing for a project with a very large annotations directory, since the archive is uploaded on every run.
+
+Archiving the annotations is best-effort: if the zip cannot be written, a warning is logged and the run still gets its metrics, parameters, and report artifact.
 
 #### Exit codes and failure handling
 

--- a/docs/user-guide/cli-tools.md
+++ b/docs/user-guide/cli-tools.md
@@ -692,7 +692,7 @@ Each invocation creates one MLflow run named `<behavior>-cv-<timestamp>`.
 **Artifacts:**
 
 - The generated training report file, unless `--mlflow-no-report` is passed.
-- `annotations.zip` — a zip of the project's `jabs/annotations` directory, unless `--mlflow-no-annotations` is passed. This captures the label set the run was computed from, so a run's metrics can be traced back to (and reproduced from) the exact annotations. Unpacking it recreates an `annotations/` directory. It is skipped silently if the project has no annotations directory or the directory is empty.
+- `annotations.zip` — a zip of the project's `jabs/annotations` directory, unless `--mlflow-no-annotations` is passed. This captures the label set the run was computed from, so a run's metrics can be traced back to (and reproduced from) the exact annotations. Unpacking it recreates an `annotations/` directory. If the project has no annotations directory, or it holds no archivable files, no artifact is uploaded and a warning is logged. Symlinks are not archived (zipping one would store the target's content, publishing files from outside the project); any that are skipped are logged.
 
 #### Free-form tags
 

--- a/src/jabs/classifier/mlflow_logging.py
+++ b/src/jabs/classifier/mlflow_logging.py
@@ -25,6 +25,8 @@ import logging
 import math
 import os
 import subprocess
+import tempfile
+import zipfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -36,6 +38,10 @@ if TYPE_CHECKING:
     from .training_report import TrainingReportData
 
 logger = logging.getLogger(__name__)
+
+#: File name used for the zipped annotations artifact attached to each run. Kept
+#: constant across runs so the artifact is easy to find and compare in the UI.
+ANNOTATIONS_ARCHIVE_NAME = "annotations.zip"
 
 
 def mlflow_available() -> bool:
@@ -128,6 +134,56 @@ def load_env_file(env_file: Path | None, *, override: bool = True) -> dict[str, 
         if override or key not in os.environ:
             os.environ[key] = value
     return values
+
+
+def archive_annotations(annotations_dir: Path, output_path: Path) -> Path | None:
+    """Zip a JABS project's annotations directory for upload as an MLflow artifact.
+
+    Captures the label set the cross-validation run was computed from, so a run's
+    metrics can be traced back to (and reproduced from) the exact annotations.
+
+    Archive members are stored under a single top-level directory named after
+    ``annotations_dir`` (normally ``annotations/``), so unpacking the zip recreates
+    the directory rather than scattering JSON files into the current directory.
+    Files are added in sorted order to keep archives reproducible.
+
+    Args:
+        annotations_dir: The project's ``jabs/annotations`` directory.
+        output_path: Destination path for the ``.zip`` file.
+
+    Returns:
+        ``output_path`` if an archive was written, or None if ``annotations_dir``
+        does not exist or holds no files -- there is then nothing worth uploading.
+
+    Raises:
+        OSError: If reading the annotations or writing the archive fails.
+    """
+    if not annotations_dir.is_dir():
+        logger.warning(
+            "Annotations directory not found, no annotations artifact: %s", annotations_dir
+        )
+        return None
+
+    files = sorted(path for path in annotations_dir.rglob("*") if path.is_file())
+    if not files:
+        logger.warning(
+            "Annotations directory is empty, no annotations artifact: %s", annotations_dir
+        )
+        return None
+
+    root = Path(annotations_dir.name)
+    with zipfile.ZipFile(output_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for path in files:
+            archive.write(path, arcname=str(root / path.relative_to(annotations_dir)))
+
+    logger.info(
+        "Archived %d annotation file(s) from %s into %s (%d bytes)",
+        len(files),
+        annotations_dir,
+        output_path.name,
+        output_path.stat().st_size,
+    )
+    return output_path
 
 
 def _git_sha() -> str | None:
@@ -266,23 +322,29 @@ def log_cross_validation_to_mlflow(
     *,
     report_data: TrainingReportData,
     report_file: Path | None = None,
+    annotations_dir: Path | None = None,
     env_file: Path | None = None,
     experiment_name: str | None = None,
     run_name: str | None = None,
     tags: dict[str, str] | None = None,
     log_report_artifact: bool = True,
+    log_annotations_artifact: bool = True,
 ) -> tuple[str, str]:
     """Create one MLflow run for a cross-validation run and return its ids.
 
     Logs aggregate CV metrics, curated params, auto-derived plus caller tags,
-    and (optionally) the training report as an artifact. Connection config comes
-    from the environment; ``env_file``, if given, is loaded into it first.
+    and (optionally) the training report and a zip of the project's annotations
+    as artifacts. Connection config comes from the environment; ``env_file``, if
+    given, is loaded into it first.
 
     Args:
         report_data: Completed training report data.
         report_file: Path to the saved training report to upload as an artifact.
             Ignored if None or missing on disk, or if ``log_report_artifact`` is
             False.
+        annotations_dir: The project's ``jabs/annotations`` directory, zipped and
+            uploaded as ``annotations.zip``. Ignored if None, if the directory is
+            missing or empty, or if ``log_annotations_artifact`` is False.
         env_file: Optional ``.env`` file with ``MLFLOW_*`` connection settings.
             If None, connection config comes from the ambient environment.
         experiment_name: Explicit MLflow experiment name. If None, the experiment is
@@ -294,12 +356,15 @@ def log_cross_validation_to_mlflow(
         tags: Caller-supplied run tags; merged over the auto-derived tags (so a
             user tag with the same key wins).
         log_report_artifact: Whether to upload the training report artifact.
+        log_annotations_artifact: Whether to upload the zipped annotations artifact.
 
     Returns:
         A ``(run_id, tracking_uri)`` tuple for the created MLflow run.
 
     Raises:
-        MlflowLoggingError: If the ``mlflow`` package is not installed.
+        MlflowLoggingError: If the ``mlflow`` package is not installed. A failure
+            to archive the annotations is *not* fatal: it is logged as a warning
+            and the run keeps its metrics, params, and report artifact.
     """
     try:
         import mlflow
@@ -339,6 +404,24 @@ def log_cross_validation_to_mlflow(
 
         if log_report_artifact and report_file is not None and Path(report_file).is_file():
             mlflow.log_artifact(str(report_file))
+
+        if log_annotations_artifact and annotations_dir is not None:
+            # The annotations are supplementary provenance, so a failure to
+            # archive them must not cost the run its metrics, params, or report.
+            try:
+                with tempfile.TemporaryDirectory() as staging_dir:
+                    archive = archive_annotations(
+                        Path(annotations_dir), Path(staging_dir) / ANNOTATIONS_ARCHIVE_NAME
+                    )
+                    if archive is not None:
+                        mlflow.log_artifact(str(archive))
+            except OSError:
+                logger.warning(
+                    "Failed to archive annotations from %s; run %s has no annotations artifact",
+                    annotations_dir,
+                    run.info.run_id,
+                    exc_info=True,
+                )
 
         run_id = run.info.run_id
 

--- a/src/jabs/classifier/mlflow_logging.py
+++ b/src/jabs/classifier/mlflow_logging.py
@@ -147,13 +147,19 @@ def archive_annotations(annotations_dir: Path, output_path: Path) -> Path | None
     the directory rather than scattering JSON files into the current directory.
     Files are added in sorted order to keep archives reproducible.
 
+    Symlinks are **not** archived, and neither are files reached through one. The
+    archive is uploaded to a tracking server, so it must contain only what really
+    lives in the project: zipping a symlink stores the *target's* content, which
+    would publish files from outside the project. Skipped symlinks are logged.
+
     Args:
         annotations_dir: The project's ``jabs/annotations`` directory.
         output_path: Destination path for the ``.zip`` file.
 
     Returns:
         ``output_path`` if an archive was written, or None if ``annotations_dir``
-        does not exist or holds no files -- there is then nothing worth uploading.
+        does not exist or holds no archivable files -- there is then nothing worth
+        uploading.
 
     Raises:
         OSError: If reading the annotations or writing the archive fails.
@@ -164,10 +170,31 @@ def archive_annotations(annotations_dir: Path, output_path: Path) -> Path | None
         )
         return None
 
-    files = sorted(path for path in annotations_dir.rglob("*") if path.is_file())
+    real_root = annotations_dir.resolve()
+    files: list[Path] = []
+    skipped_links = 0
+    for path in sorted(annotations_dir.rglob("*")):
+        # Skip symlinks themselves, and any entry whose real location falls
+        # outside the annotations directory -- the latter guards against a
+        # directory symlink being traversed (which pathlib does not currently do,
+        # but is not contractually guaranteed across Python versions).
+        if path.is_symlink() or not path.resolve().is_relative_to(real_root):
+            skipped_links += 1
+            continue
+        if path.is_file():
+            files.append(path)
+
+    if skipped_links:
+        logger.warning(
+            "Skipped %d symlinked entr%s under %s: symlinks are not archived",
+            skipped_links,
+            "y" if skipped_links == 1 else "ies",
+            annotations_dir,
+        )
+
     if not files:
         logger.warning(
-            "Annotations directory is empty, no annotations artifact: %s", annotations_dir
+            "No archivable annotation files in %s, no annotations artifact", annotations_dir
         )
         return None
 

--- a/src/jabs/resources/docs/user_guide/cli-tools.md
+++ b/src/jabs/resources/docs/user_guide/cli-tools.md
@@ -552,7 +552,8 @@ jabs-cli cross-validation DIRECTORY --behavior BEHAVIOR \
     [--grouping-pattern REGEX] \
     [--classifier {catboost|random_forest|xgboost}] \
     [--report-file FILE] \
-    [--mlflow [ENV_FILE]] [--mlflow-experiment NAME] [--mlflow-tag KEY=VALUE] [--mlflow-no-report]
+    [--mlflow [ENV_FILE]] [--mlflow-experiment NAME] [--mlflow-tag KEY=VALUE] \
+    [--mlflow-no-report] [--mlflow-no-annotations]
 ```
 
 - `DIRECTORY`: Path to the JABS project directory.
@@ -562,7 +563,7 @@ jabs-cli cross-validation DIRECTORY --behavior BEHAVIOR \
 - `--grouping-pattern REGEX`: Regular expression applied to each video filename to derive a grouping key. Only used with `--grouping-strategy filename`. If omitted, the pattern saved in the project is used.
 - `--classifier {catboost|random_forest|xgboost}`: Classifier to evaluate. Defaults to `xgboost`. The available choices depend on which classifier libraries are installed; see [Classifier Types](classifier-types.md).
 - `--report-file FILE`: Where to write the training report. The format is chosen by extension: `.md` (Markdown) or `.json` (JSON). If omitted, a timestamped Markdown file is written to the current directory (`<behavior>_<timestamp>_training_report.md`).
-- `--mlflow`, `--mlflow-experiment`, `--mlflow-tag`, `--mlflow-no-report`: Optional MLflow logging (see [MLflow logging](#mlflow-logging)).
+- `--mlflow`, `--mlflow-experiment`, `--mlflow-tag`, `--mlflow-no-report`, `--mlflow-no-annotations`: Optional MLflow logging (see [MLflow logging](#mlflow-logging)).
 
 ### Grouping strategies
 
@@ -602,7 +603,7 @@ jabs-cli cross-validation /path/to/project --behavior grooming \
 
 ### MLflow logging
 
-The cross-validation command can optionally log each run to an [MLflow](https://mlflow.org/) tracking server, recording aggregate metrics, run parameters, descriptive tags, and the training report as an artifact. This is opt-in and off by default.
+The cross-validation command can optionally log each run to an [MLflow](https://mlflow.org/) tracking server, recording aggregate metrics, run parameters, descriptive tags, and — as artifacts — the training report and a zip of the project's annotations. This is opt-in and off by default.
 
 #### Installing the MLflow extra
 
@@ -688,7 +689,10 @@ Each invocation creates one MLflow run named `<behavior>-cv-<timestamp>`.
 
 **Tags:** auto-derived `behavior`, `classifier`, `cv_grouping_strategy`, and `jabs_git` (the short git SHA of the JABS checkout, when available). Any `--mlflow-tag` entries are merged on top, so a user tag wins over an auto tag with the same key.
 
-**Artifact:** the generated training report file, unless `--mlflow-no-report` is passed.
+**Artifacts:**
+
+- The generated training report file, unless `--mlflow-no-report` is passed.
+- `annotations.zip` — a zip of the project's `jabs/annotations` directory, unless `--mlflow-no-annotations` is passed. This captures the label set the run was computed from, so a run's metrics can be traced back to (and reproduced from) the exact annotations. Unpacking it recreates an `annotations/` directory. It is skipped silently if the project has no annotations directory or the directory is empty.
 
 #### Free-form tags
 
@@ -701,13 +705,18 @@ jabs-cli cross-validation /path/to/project --behavior grooming --mlflow settings
 
 Each entry is `KEY=VALUE`; only the first `=` splits the entry, so values may contain `=`.
 
-#### Skipping the report artifact
+#### Skipping artifacts
 
-To log metrics and parameters only (no report upload):
+Each artifact has its own opt-out flag. To log metrics and parameters only:
 
 ```bash
-jabs-cli cross-validation /path/to/project --behavior grooming --mlflow --mlflow-no-report
+jabs-cli cross-validation /path/to/project --behavior grooming --mlflow \
+    --mlflow-no-report --mlflow-no-annotations
 ```
+
+Pass only `--mlflow-no-annotations` to keep the report but skip the annotations upload — worth doing for a project with a very large annotations directory, since the archive is uploaded on every run.
+
+Archiving the annotations is best-effort: if the zip cannot be written, a warning is logged and the run still gets its metrics, parameters, and report artifact.
 
 #### Exit codes and failure handling
 

--- a/src/jabs/resources/docs/user_guide/cli-tools.md
+++ b/src/jabs/resources/docs/user_guide/cli-tools.md
@@ -692,7 +692,7 @@ Each invocation creates one MLflow run named `<behavior>-cv-<timestamp>`.
 **Artifacts:**
 
 - The generated training report file, unless `--mlflow-no-report` is passed.
-- `annotations.zip` — a zip of the project's `jabs/annotations` directory, unless `--mlflow-no-annotations` is passed. This captures the label set the run was computed from, so a run's metrics can be traced back to (and reproduced from) the exact annotations. Unpacking it recreates an `annotations/` directory. It is skipped silently if the project has no annotations directory or the directory is empty.
+- `annotations.zip` — a zip of the project's `jabs/annotations` directory, unless `--mlflow-no-annotations` is passed. This captures the label set the run was computed from, so a run's metrics can be traced back to (and reproduced from) the exact annotations. Unpacking it recreates an `annotations/` directory. If the project has no annotations directory, or it holds no archivable files, no artifact is uploaded and a warning is logged. Symlinks are not archived (zipping one would store the target's content, publishing files from outside the project); any that are skipped are logged.
 
 #### Free-form tags
 

--- a/src/jabs/scripts/cli/cli.py
+++ b/src/jabs/scripts/cli/cli.py
@@ -364,7 +364,8 @@ def prune(ctx: click.Context, directory: Path, behavior: str | None):
     default=None,
     metavar="ENV_FILE",
     help="Enable opt-in MLflow logging of the cross-validation results (aggregate "
-    "metrics, params, and the training report artifact). Optionally takes a path to a "
+    "metrics, params, the training report artifact, and a zip of the project's "
+    "annotations). Optionally takes a path to a "
     ".env file holding MLFLOW_* settings (tracking URI, experiment, auth, TLS); with no "
     "path, those are read from the ambient environment. Absent leaves the command's "
     "behavior unchanged. Requires the optional 'mlflow' extra "
@@ -392,8 +393,14 @@ def prune(ctx: click.Context, directory: Path, behavior: str | None):
     "--mlflow-no-report",
     "mlflow_no_report",
     is_flag=True,
-    help="With --mlflow, skip uploading the training report artifact (metrics + params "
-    "only). No-op without --mlflow.",
+    help="With --mlflow, skip uploading the training report artifact. No-op without --mlflow.",
+)
+@click.option(
+    "--mlflow-no-annotations",
+    "mlflow_no_annotations",
+    is_flag=True,
+    help="With --mlflow, skip uploading the zipped jabs/annotations directory. "
+    "No-op without --mlflow.",
 )
 @click.pass_context
 def cross_validation(
@@ -409,6 +416,7 @@ def cross_validation(
     mlflow_experiment: str | None,
     mlflow_tags: tuple[str, ...],
     mlflow_no_report: bool,
+    mlflow_no_annotations: bool,
 ):
     """Run leave-one-group-out cross-validation for a JABS project."""
     if report_file is not None and report_file.suffix.lower() not in {".md", ".json"}:
@@ -471,6 +479,7 @@ def cross_validation(
             mlflow_experiment=mlflow_experiment,
             mlflow_tags=parsed_mlflow_tags,
             mlflow_log_report=not mlflow_no_report,
+            mlflow_log_annotations=not mlflow_no_annotations,
         )
     except MlflowLoggingError:
         # Cross-validation and the report succeeded; only the optional MLflow

--- a/src/jabs/scripts/cli/cross_validation.py
+++ b/src/jabs/scripts/cli/cross_validation.py
@@ -35,6 +35,7 @@ def run_cross_validation(
     mlflow_experiment: str | None = None,
     mlflow_tags: dict[str, str] | None = None,
     mlflow_log_report: bool = True,
+    mlflow_log_annotations: bool = True,
 ) -> None:
     """Run cross-validation for a JABS project from the command line.
 
@@ -64,6 +65,9 @@ def run_cross_validation(
           over the auto-derived tags.
         mlflow_log_report (bool): Whether to upload the training report as an MLflow
           artifact. Only used when ``mlflow_enabled`` is True.
+        mlflow_log_annotations (bool): Whether to upload a zip of the project's
+          ``jabs/annotations`` directory as an MLflow artifact, capturing the labels
+          the run was computed from. Only used when ``mlflow_enabled`` is True.
 
     Raises:
         MlflowLoggingError: If MLflow logging is requested but fails. The
@@ -259,10 +263,12 @@ def run_cross_validation(
             run_id, tracking_uri = log_cross_validation_to_mlflow(
                 report_data=training_data,
                 report_file=report_file,
+                annotations_dir=project.annotation_dir,
                 env_file=mlflow_env_file,
                 experiment_name=mlflow_experiment,
                 tags=mlflow_tags,
                 log_report_artifact=mlflow_log_report,
+                log_annotations_artifact=mlflow_log_annotations,
             )
         except Exception as e:
             console.print(f"\nWarning: MLflow logging failed: {e}", style="bold yellow")

--- a/tests/classifier/test_mlflow_logging.py
+++ b/tests/classifier/test_mlflow_logging.py
@@ -329,19 +329,81 @@ def test_archive_annotations_creates_zip(annotations_dir: Path, tmp_path: Path) 
         assert archive.read("annotations/video1.json") == b'{"labels": 1}'
 
 
-def test_archive_annotations_missing_dir_returns_none(tmp_path: Path) -> None:
-    """A project with no annotations directory yields no archive (and no error)."""
-    assert archive_annotations(tmp_path / "absent", tmp_path / "annotations.zip") is None
+def test_archive_annotations_missing_dir_returns_none(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A project with no annotations directory yields no archive, with a warning."""
+    with caplog.at_level("WARNING"):
+        assert archive_annotations(tmp_path / "absent", tmp_path / "annotations.zip") is None
+
     assert not (tmp_path / "annotations.zip").exists()
+    assert "not found" in caplog.text
 
 
-def test_archive_annotations_empty_dir_returns_none(tmp_path: Path) -> None:
-    """An annotations directory with no files yields no archive."""
+def test_archive_annotations_empty_dir_returns_none(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An annotations directory with no files yields no archive, with a warning."""
     empty = tmp_path / "annotations"
     empty.mkdir()
 
-    assert archive_annotations(empty, tmp_path / "annotations.zip") is None
+    with caplog.at_level("WARNING"):
+        assert archive_annotations(empty, tmp_path / "annotations.zip") is None
+
     assert not (tmp_path / "annotations.zip").exists()
+    assert "No archivable annotation files" in caplog.text
+
+
+def test_archive_annotations_excludes_symlinked_file(
+    annotations_dir: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A symlinked annotation file is not archived, so its target is not uploaded."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret.json"
+    secret.write_text('{"secret": true}')
+    (annotations_dir / "linked.json").symlink_to(secret)
+    output = tmp_path / "annotations.zip"
+
+    with caplog.at_level("WARNING"):
+        assert archive_annotations(annotations_dir, output) == output
+
+    with zipfile.ZipFile(output) as archive:
+        names = archive.namelist()
+        assert "annotations/linked.json" not in names
+        assert b'{"secret": true}' not in b"".join(archive.read(name) for name in names)
+    assert "Skipped 1 symlinked entry" in caplog.text
+
+
+def test_archive_annotations_excludes_symlinked_directory(
+    annotations_dir: Path, tmp_path: Path
+) -> None:
+    """A symlinked directory is not traversed, so files outside are not archived."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.json").write_text('{"secret": true}')
+    (annotations_dir / "linked_dir").symlink_to(outside, target_is_directory=True)
+    output = tmp_path / "annotations.zip"
+
+    assert archive_annotations(annotations_dir, output) == output
+
+    with zipfile.ZipFile(output) as archive:
+        assert not any("secret" in name or "linked_dir" in name for name in archive.namelist())
+
+
+def test_archive_annotations_survives_symlink_cycle(annotations_dir: Path, tmp_path: Path) -> None:
+    """A self-referential symlink neither hangs the walk nor lands in the archive."""
+    (annotations_dir / "loop").symlink_to(annotations_dir, target_is_directory=True)
+    output = tmp_path / "annotations.zip"
+
+    assert archive_annotations(annotations_dir, output) == output
+
+    with zipfile.ZipFile(output) as archive:
+        assert sorted(archive.namelist()) == [
+            "annotations/archive/video3.json",
+            "annotations/video1.json",
+            "annotations/video2.json",
+        ]
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/classifier/test_mlflow_logging.py
+++ b/tests/classifier/test_mlflow_logging.py
@@ -7,6 +7,7 @@ The actual MLflow client is never imported here; tests that exercise
 
 import os
 import sys
+import zipfile
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -18,6 +19,7 @@ from jabs.classifier import mlflow_logging
 from jabs.classifier.mlflow_logging import (
     MlflowLoggingError,
     aggregate_cv_metrics,
+    archive_annotations,
     build_params,
     build_tags,
     load_env_file,
@@ -94,6 +96,7 @@ class _FakeMlflow:
         self.params: dict[str, str] = {}
         self.tags: dict[str, str] = {}
         self.artifacts: list[str] = []
+        self.artifact_members: dict[str, list[str]] = {}
 
     def set_experiment(self, name: str) -> None:
         self.experiment = name
@@ -113,6 +116,12 @@ class _FakeMlflow:
 
     def log_artifact(self, path: str) -> None:
         self.artifacts.append(path)
+        # Capture zip contents at call time: the annotations archive is staged in
+        # a temporary directory that is removed once the logger returns, so the
+        # file no longer exists by the time assertions run.
+        if zipfile.is_zipfile(path):
+            with zipfile.ZipFile(path) as archive:
+                self.artifact_members[Path(path).name] = sorted(archive.namelist())
 
     def get_tracking_uri(self) -> str:
         return "file:///tmp/mlruns"
@@ -288,6 +297,54 @@ def test_resolve_experiment_name_explicit_wins(
 
 
 # --------------------------------------------------------------------------- #
+# archive_annotations
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def annotations_dir(tmp_path: Path) -> Path:
+    """A jabs/annotations directory holding two annotation files and a subdirectory."""
+    annotations = tmp_path / "jabs" / "annotations"
+    annotations.mkdir(parents=True)
+    (annotations / "video1.json").write_text('{"labels": 1}')
+    (annotations / "video2.json").write_text('{"labels": 2}')
+    nested = annotations / "archive"
+    nested.mkdir()
+    (nested / "video3.json").write_text('{"labels": 3}')
+    return annotations
+
+
+def test_archive_annotations_creates_zip(annotations_dir: Path, tmp_path: Path) -> None:
+    """Every file is archived under a single top-level annotations/ directory."""
+    output = tmp_path / "annotations.zip"
+
+    result = archive_annotations(annotations_dir, output)
+
+    assert result == output
+    assert output.is_file()
+    with zipfile.ZipFile(output) as archive:
+        assert sorted(archive.namelist()) == [
+            "annotations/archive/video3.json",
+            "annotations/video1.json",
+            "annotations/video2.json",
+        ]
+        assert archive.read("annotations/video1.json") == b'{"labels": 1}'
+
+
+def test_archive_annotations_missing_dir_returns_none(tmp_path: Path) -> None:
+    """A project with no annotations directory yields no archive (and no error)."""
+    assert archive_annotations(tmp_path / "absent", tmp_path / "annotations.zip") is None
+    assert not (tmp_path / "annotations.zip").exists()
+
+
+def test_archive_annotations_empty_dir_returns_none(tmp_path: Path) -> None:
+    """An annotations directory with no files yields no archive."""
+    empty = tmp_path / "annotations"
+    empty.mkdir()
+
+    assert archive_annotations(empty, tmp_path / "annotations.zip") is None
+    assert not (tmp_path / "annotations.zip").exists()
+
+
+# --------------------------------------------------------------------------- #
 # log_cross_validation_to_mlflow
 # --------------------------------------------------------------------------- #
 def test_log_cross_validation_to_mlflow(
@@ -340,6 +397,91 @@ def test_log_cross_validation_skips_artifact_when_disabled(
     )
 
     assert fake.artifacts == []
+
+
+def test_log_cross_validation_uploads_annotations_archive(
+    binary_report: TrainingReportData,
+    annotations_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The annotations directory is zipped and uploaded alongside the report."""
+    fake = _FakeMlflow()
+    monkeypatch.setitem(sys.modules, "mlflow", fake)
+    report_file = tmp_path / "report.md"
+    report_file.write_text("# report")
+
+    log_cross_validation_to_mlflow(
+        report_data=binary_report,
+        report_file=report_file,
+        annotations_dir=annotations_dir,
+    )
+
+    assert [Path(a).name for a in fake.artifacts] == ["report.md", "annotations.zip"]
+    # the archive still existed (and held the annotations) when it was uploaded
+    assert fake.artifact_members["annotations.zip"] == [
+        "annotations/archive/video3.json",
+        "annotations/video1.json",
+        "annotations/video2.json",
+    ]
+
+
+def test_log_cross_validation_skips_annotations_when_disabled(
+    binary_report: TrainingReportData,
+    annotations_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With log_annotations_artifact=False, no annotations archive is uploaded."""
+    fake = _FakeMlflow()
+    monkeypatch.setitem(sys.modules, "mlflow", fake)
+
+    log_cross_validation_to_mlflow(
+        report_data=binary_report,
+        annotations_dir=annotations_dir,
+        log_annotations_artifact=False,
+    )
+
+    assert fake.artifacts == []
+
+
+def test_log_cross_validation_without_annotations_dir(
+    binary_report: TrainingReportData, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Omitting annotations_dir logs the run without an annotations archive."""
+    fake = _FakeMlflow()
+    monkeypatch.setitem(sys.modules, "mlflow", fake)
+
+    log_cross_validation_to_mlflow(report_data=binary_report)
+
+    assert fake.artifacts == []
+
+
+def test_log_cross_validation_tolerates_annotations_failure(
+    binary_report: TrainingReportData,
+    annotations_dir: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failure to archive annotations leaves the rest of the run logged."""
+    fake = _FakeMlflow()
+    monkeypatch.setitem(sys.modules, "mlflow", fake)
+
+    def boom(*args: object, **kwargs: object) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(mlflow_logging, "archive_annotations", boom)
+    report_file = tmp_path / "report.md"
+    report_file.write_text("# report")
+
+    run_id, _ = log_cross_validation_to_mlflow(
+        report_data=binary_report,
+        report_file=report_file,
+        annotations_dir=annotations_dir,
+    )
+
+    assert run_id == "run-123"
+    assert [Path(a).name for a in fake.artifacts] == ["report.md"]
+    assert fake.metrics["cv_accuracy_mean"] == pytest.approx(0.85)
 
 
 def test_log_cross_validation_missing_mlflow_raises(

--- a/tests/scripts/test_cross_validation_cli.py
+++ b/tests/scripts/test_cross_validation_cli.py
@@ -117,6 +117,7 @@ def test_mlflow_absent_disables_logging(tmp_path: Path, run_cv_spy: mock.Mock) -
     assert kwargs["mlflow_enabled"] is False
     assert kwargs["mlflow_env_file"] is None
     assert kwargs["mlflow_log_report"] is True
+    assert kwargs["mlflow_log_annotations"] is True
 
 
 def test_mlflow_bare_flag_enables_ambient(
@@ -203,6 +204,18 @@ def test_mlflow_no_report_flag(
 
     assert result.exit_code == 0, result.output
     assert run_cv_spy.call_args.kwargs["mlflow_log_report"] is False
+
+
+def test_mlflow_no_annotations_flag(
+    tmp_path: Path, run_cv_spy: mock.Mock, mlflow_installed: None
+) -> None:
+    """--mlflow-no-annotations disables the annotations archive upload only."""
+    result = _invoke(tmp_path, "--mlflow", "--mlflow-no-annotations")
+
+    assert result.exit_code == 0, result.output
+    kwargs = run_cv_spy.call_args.kwargs
+    assert kwargs["mlflow_log_annotations"] is False
+    assert kwargs["mlflow_log_report"] is True
 
 
 def test_mlflow_experiment_forwarded(


### PR DESCRIPTION
## Summary

`jabs-cli cross-validation --mlflow` now zips the project's `jabs/annotations` directory and uploads it as an `annotations.zip` run artifact, alongside the training report. This captures the label set a run's metrics were computed from, so a run can be traced back to (and reproduced from) the exact annotations.

## Changes

- **`jabs/classifier/mlflow_logging.py`** — new `archive_annotations()` helper. Zips with `ZIP_DEFLATED`, storing members under a single top-level `annotations/` prefix so unpacking recreates the directory rather than scattering JSON into the cwd. Files are added in sorted order for reproducible archives. Returns `None` (no error) when the directory is missing or empty.
- `log_cross_validation_to_mlflow()` gained `annotations_dir` and `log_annotations_artifact`; the archive is staged in a `TemporaryDirectory` inside the run and logged as `annotations.zip` — a constant name, so the artifact is easy to find and compare across runs.
- **`jabs/scripts/cli/cross_validation.py`** — passes `project.annotation_dir` through, plus a `mlflow_log_annotations` parameter.
- **`jabs/scripts/cli/cli.py`** — new `--mlflow-no-annotations` opt-out flag.
- **Docs** — synopsis, options list, "What gets logged", and the skip-artifacts section updated in both the online docs and the in-app user guide copy.

## Notes for review

Two judgment calls worth a look:

1. **New `--mlflow-no-annotations` flag.** `--mlflow-no-report` already existed and its help text promised "metrics + params only", so an unconditional second artifact would have contradicted it. A skip flag also matters for projects with a large annotations directory, since the archive uploads on every run. The `--mlflow-no-report` help text was updated to drop the now-inaccurate parenthetical.
2. **Archiving is best-effort.** An `OSError` while zipping logs a warning and the run keeps its metrics, params, and report artifact, consistent with this module's existing stance that a logging failure never costs you the results. The alternative would be exit code 3 on a run whose metrics already landed.

## Testing

- 7 new unit tests: archive contents/prefix, missing directory, empty directory, upload alongside the report, both opt-out paths, and archive-failure tolerance. Plus a CLI test for the new flag.
- The fake mlflow client now captures zip members *at `log_artifact` time*, since the staging directory is gone by the time assertions run — this is what proves the archive is still on disk when uploaded.
- Full root suite passes (875 tests); ruff check and format clean.
- Verified end to end against a live MLflow tracking server.
