### PR TITLE
Add feature cache status scanning with train/classify warnings

### DIFF
--- a/containers/docker/Dockerfile.pose
+++ b/containers/docker/Dockerfile.pose
@@ -25,10 +25,11 @@ COPY packages/jabs-core ./packages/jabs-core
 COPY packages/jabs-io ./packages/jabs-io
 COPY packages/jabs-vision ./packages/jabs-vision
 
-# Install jabs-vision (with the HRNet extra) and its workspace deps, incl. h5py.
+# Install jabs-vision (with the HRNet extra) and its workspace deps. h5py comes in
+# as a required dependency of jabs-io.
 RUN uv pip install --system \
       "./packages/jabs-core" \
-      "./packages/jabs-io[h5py]" \
+      "./packages/jabs-io" \
       "./packages/jabs-vision[hrnet_msfork]"
 
 ENTRYPOINT ["jabs-pose"]

--- a/docs/user-guide/gui.md
+++ b/docs/user-guide/gui.md
@@ -26,7 +26,7 @@ Right-click a video name to open a context menu:
 
 <img src="imgs/video-context-menu.png" alt="Video list context menu" width=300 />
 
-- **Get Info:** Open a dialog showing details about the video and its associated pose file.
+- **Get Info:** Open a dialog showing details about the video, its associated pose file, and its cached features (the cache directory, cached window sizes, storage format, size on disk, and whether the cache is out of date).
 - **Copy Video Name:** Copy the video's filename to the clipboard.
 - **Classify Video:** Run the trained classifier for the current behavior on just this video, rather than every video the way the **Classify** button does. This item is only available once a classifier has been trained for the current behavior (if none is ready, JABS prompts you to train one first). When classification finishes, JABS displays the new predictions, switching to the video if it is not already the active one.
 - **Exclude from Training:** Toggle whether the video is held out of classifier training (unchecked by default). When a video is excluded:
@@ -48,6 +48,12 @@ Right-click a video name to open a context menu:
 - **Symmetric Behavior Toggle:** Tells the classifier that the behavior is symmetric. A symmetric behavior is when left and right features are interchangeable.
 - **All k-fold Toggle:** Uses the maximum number of cross validation folds. Useful when you wish to compare classifier performance and may have an outlier that can be held-out.
 - **Cross Validation Slider:** Number of "Leave One Out" cross validation iterations to run while training.
+
+### Feature Computation
+
+Training and classification both need extracted features for the selected window size. When a project is opened, JABS scans the project's feature cache in the background to find out which videos already have them. If features are missing when you click **Train** or **Classify**, JABS warns you first: the run will still work, but the features are computed as it goes, which can take several minutes per video. You can continue anyway or cancel and precompute features for the whole project with the `jabs-features` command line tool.
+
+Training needs features only for the subjects you have labeled, while classification needs them for every subject in every video it processes, so **Classify** may warn when **Train** does not. Computed features are cached, so the warning goes away once a run has computed them. Use **Get Info** in the video list's right-click menu to see exactly what is cached for a video.
 
 ### Choosing a Classifier Type
 

--- a/docs/user-guide/gui.md
+++ b/docs/user-guide/gui.md
@@ -51,7 +51,7 @@ Right-click a video name to open a context menu:
 
 ### Feature Computation
 
-Training and classification both need extracted features for the selected window size. When a project is opened, JABS scans the project's feature cache in the background to find out which videos already have them. If features are missing when you click **Train** or **Classify**, JABS warns you first: the run will still work, but the features are computed as it goes, which can take several minutes per video. You can continue anyway or cancel and precompute features for the whole project with the `jabs-features` command line tool.
+Training and classification both need extracted features for the selected window size. When a project is opened, JABS scans the project's feature cache in the background to find out which videos already have them. If features are missing when you click **Train** or **Classify**, JABS warns you first: the run will still work, but the features are computed as it goes, which can take several minutes per video. You can continue anyway, or cancel and precompute features for the whole project with the `jabs-init` command line tool (`jabs-init -w <window size> <project directory>`).
 
 Training needs features only for the subjects you have labeled, while classification needs them for every subject in every video it processes, so **Classify** may warn when **Train** does not. Computed features are cached, so the warning goes away once a run has computed them. Use **Get Info** in the video list's right-click menu to see exactly what is cached for a video.
 

--- a/packages/jabs-io/README.md
+++ b/packages/jabs-io/README.md
@@ -28,8 +28,8 @@ save(data_instance, 'frames.parquet')
 | `nwb`     | `pynwb`, `ndx-pose` | NWB pose file read/write  |
 | `parquet` | `pyarrow`           | Parquet feature cache I/O |
 
-`jabs-io` depends on `jabs-core`, which requires `h5py` directly, so HDF5 support is
-always available with no extra needed. `pyarrow` is also a direct dependency of
+HDF5 is not an extra: `h5py` is a required dependency, since pose files, prediction
+files and the default feature cache are all HDF5. `pyarrow` is a direct dependency of
 `jabs-behavior-classifier`, so the `parquet` backend is available automatically when
 `jabs-io` is installed as part of the full JABS application. The `nwb` extra must
 always be installed explicitly:

--- a/packages/jabs-io/pyproject.toml
+++ b/packages/jabs-io/pyproject.toml
@@ -15,6 +15,10 @@ authors = [
 dependencies = [
     "jabs-core",
     "numpy>=2.0.0,<3.0.0",
+    # HDF5 is fundamental to JABS: pose files, prediction files and the default
+    # feature cache are all HDF5, and most modules in this package import h5py
+    # unconditionally. Declared directly rather than relied on transitively.
+    "h5py>=3.10.0,<4.0.0",
 ]
 
 [tool.uv.sources]
@@ -48,9 +52,6 @@ nwb = [
     "ndx-pose>=0.2.2",
     "ndx-multisubjects>=0.1.1",
     "pynwb>=3.1.3",
-]
-h5py = [
-    "h5py>=3.15.1",
 ]
 parquet = [
     "pyarrow>=18.0.0",

--- a/packages/jabs-io/src/jabs/io/base.py
+++ b/packages/jabs-io/src/jabs/io/base.py
@@ -16,10 +16,7 @@ except ImportError:
     pa = None
     pq = None
 
-try:
-    import h5py
-except ImportError:
-    h5py = None
+import h5py
 
 StorageType = TypeVar("StorageType")
 DomainType = TypeVar("DomainType")
@@ -186,12 +183,6 @@ class HDF5Adapter(Adapter):
 
     Concrete adapters must implement ``_write_one`` and ``_read_one``.
     """
-
-    def __init__(self):
-        if h5py is None:
-            raise ImportError(
-                "h5py is required to use HDF5. Install jabs-io with the 'h5py' extra."
-            )
 
     @abstractmethod
     def _write_one(self, data, group) -> None:

--- a/packages/jabs-io/src/jabs/io/feature_cache/__init__.py
+++ b/packages/jabs-io/src/jabs/io/feature_cache/__init__.py
@@ -7,7 +7,16 @@ from pathlib import Path
 
 from jabs.core.enums import CacheFormat
 
+from .inspection import IdentityCacheInfo, inspect_identity_cache
+
 logger = logging.getLogger(__name__)
+
+__all__ = [
+    "IdentityCacheInfo",
+    "clear_cache",
+    "detect_cache_format",
+    "inspect_identity_cache",
+]
 
 
 def detect_cache_format(identity_dir: Path) -> CacheFormat | None:

--- a/packages/jabs-io/src/jabs/io/feature_cache/inspection.py
+++ b/packages/jabs-io/src/jabs/io/feature_cache/inspection.py
@@ -99,14 +99,25 @@ def inspect_identity_cache(identity_dir: Path) -> IdentityCacheInfo | None:
 
 
 def _directory_size(directory: Path) -> int:
-    """Return the total size in bytes of the files directly inside a directory."""
+    """Return the total size in bytes of the files directly inside a directory.
+
+    Best effort: a directory or file that cannot be read (unreadable, or removed
+    while the scan is walking it) contributes nothing rather than failing the
+    inspection, which reports far more than just the size.
+    """
+    try:
+        paths = list(directory.iterdir())
+    except OSError:
+        logger.debug("Could not list cache directory %s", directory, exc_info=True)
+        return 0
+
     total = 0
-    for path in directory.iterdir():
-        if path.is_file():
-            try:
+    for path in paths:
+        try:
+            if path.is_file():
                 total += path.stat().st_size
-            except OSError:
-                logger.debug("Could not stat cache file %s", path, exc_info=True)
+        except OSError:
+            logger.debug("Could not stat cache file %s", path, exc_info=True)
     return total
 
 

--- a/packages/jabs-io/src/jabs/io/feature_cache/inspection.py
+++ b/packages/jabs-io/src/jabs/io/feature_cache/inspection.py
@@ -1,0 +1,176 @@
+"""Read-only inspection of an on-disk feature cache.
+
+Describes what a per-identity cache directory contains (storage format, the
+metadata it was written with, and which window sizes are available) without
+loading any feature data.
+
+Inspection deliberately performs none of the validation the readers in this
+package do: it reports what is on disk and leaves interpretation (is this
+feature version current? does this pose hash still match the pose file?) to the
+caller. This makes it safe to use for cheap, bulk status reporting such as
+scanning an entire project.
+
+Note:
+    Like :func:`~jabs.io.feature_cache.detect_cache_format`, the on-disk
+    filenames are written as literals here rather than imported from the
+    backend modules. They are stable on-disk format contracts; changing one
+    constitutes a format-breaking change requiring a versioned migration, so
+    drift is not a practical risk.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+import h5py
+
+from jabs.core.enums import CacheFormat
+
+logger = logging.getLogger(__name__)
+
+_HDF5_FILENAME = "features.h5"
+_HDF5_PER_FRAME_GROUP = "features/per_frame"
+_HDF5_FEATURES_GROUP = "features"
+_HDF5_WINDOW_GROUP_PREFIX = "window_features_"
+
+_PARQUET_METADATA_FILENAME = "metadata.json"
+_PARQUET_PER_FRAME_FILENAME = "per_frame.parquet"
+_PARQUET_WINDOW_FILENAME_TEMPLATE = "window_{size}.parquet"
+
+
+@dataclass(frozen=True)
+class IdentityCacheInfo:
+    """Summary of the feature cache stored in one per-identity directory.
+
+    Attributes:
+        directory: The per-identity cache directory that was inspected.
+        identity: Identity index recorded in the cache metadata.
+        cache_format: Storage format the cache was written in.
+        feature_version: Value of ``FEATURE_VERSION`` at the time the cache was
+            written. Compare against the current value to detect a stale cache.
+        pose_hash: Hash of the pose file the features were computed from.
+        num_frames: Frame count recorded in the cache.
+        distance_scale_factor: Pixels-to-cm scale factor the cache was computed
+            with, or ``None`` when the cache does not use cm units.
+        window_sizes: Window sizes whose features are present on disk and
+            loadable.
+        per_frame_present: Whether per-frame features are present. A cache
+            missing them is incomplete and will be recomputed on next use.
+        size_bytes: Total size on disk of all files in the cache directory.
+    """
+
+    directory: Path
+    identity: int
+    cache_format: CacheFormat
+    feature_version: int
+    pose_hash: str
+    num_frames: int
+    distance_scale_factor: float | None
+    window_sizes: frozenset[int]
+    per_frame_present: bool
+    size_bytes: int
+
+
+def inspect_identity_cache(identity_dir: Path) -> IdentityCacheInfo | None:
+    """Inspect one per-identity cache directory.
+
+    Checks for the Parquet sentinel (``metadata.json``) first, then the HDF5
+    cache file, matching the precedence used by
+    :func:`~jabs.io.feature_cache.detect_cache_format`.
+
+    Args:
+        identity_dir: Per-identity cache directory to inspect.
+
+    Returns:
+        An :class:`IdentityCacheInfo` describing the cache, or ``None`` when no
+        cache is present or its metadata cannot be read (for example a
+        truncated file, or a cache being written concurrently). An unreadable
+        cache is reported the same way as an absent one because both mean the
+        features would have to be recomputed.
+    """
+    if (identity_dir / _PARQUET_METADATA_FILENAME).exists():
+        return _inspect_parquet_cache(identity_dir)
+    if (identity_dir / _HDF5_FILENAME).exists():
+        return _inspect_hdf5_cache(identity_dir)
+    return None
+
+
+def _directory_size(directory: Path) -> int:
+    """Return the total size in bytes of the files directly inside a directory."""
+    total = 0
+    for path in directory.iterdir():
+        if path.is_file():
+            try:
+                total += path.stat().st_size
+            except OSError:
+                logger.debug("Could not stat cache file %s", path, exc_info=True)
+    return total
+
+
+def _inspect_hdf5_cache(identity_dir: Path) -> IdentityCacheInfo | None:
+    """Inspect an HDF5 (``features.h5``) cache directory."""
+    path = identity_dir / _HDF5_FILENAME
+    try:
+        with h5py.File(path, "r") as f:
+            window_sizes: set[int] = set()
+            if _HDF5_FEATURES_GROUP in f:
+                for key in f[_HDF5_FEATURES_GROUP]:
+                    if key.startswith(_HDF5_WINDOW_GROUP_PREFIX):
+                        suffix = key[len(_HDF5_WINDOW_GROUP_PREFIX) :]
+                        if suffix.isdigit():
+                            window_sizes.add(int(suffix))
+            scale = f.attrs.get("distance_scale_factor", None)
+            return IdentityCacheInfo(
+                directory=identity_dir,
+                identity=int(f.attrs["identity"]),
+                cache_format=CacheFormat.HDF5,
+                feature_version=int(f.attrs["version"]),
+                pose_hash=str(f.attrs["pose_hash"]),
+                num_frames=int(f.attrs["num_frames"]),
+                distance_scale_factor=float(scale) if scale is not None else None,
+                window_sizes=frozenset(window_sizes),
+                per_frame_present=_HDF5_PER_FRAME_GROUP in f,
+                size_bytes=_directory_size(identity_dir),
+            )
+    except (OSError, KeyError, TypeError, ValueError):
+        logger.debug("Could not inspect HDF5 feature cache at %s", path, exc_info=True)
+        return None
+
+
+def _inspect_parquet_cache(identity_dir: Path) -> IdentityCacheInfo | None:
+    """Inspect a Parquet cache directory.
+
+    Only window sizes that are both registered in ``metadata.json`` and backed
+    by an existing ``window_{size}.parquet`` file are reported, so the result
+    reflects what could actually be loaded. A registered size whose file is
+    missing (for example an interrupted write) is omitted.
+    """
+    path = identity_dir / _PARQUET_METADATA_FILENAME
+    try:
+        with path.open(encoding="utf-8") as f:
+            raw: dict = json.load(f)
+
+        window_sizes = {
+            size
+            for size in (int(s) for s in raw["cached_window_sizes"])
+            if (identity_dir / _PARQUET_WINDOW_FILENAME_TEMPLATE.format(size=size)).exists()
+        }
+        scale = raw["distance_scale_factor"]
+        return IdentityCacheInfo(
+            directory=identity_dir,
+            identity=int(raw["identity"]),
+            cache_format=CacheFormat.PARQUET,
+            feature_version=int(raw["feature_version"]),
+            pose_hash=str(raw["pose_hash"]),
+            num_frames=int(raw["num_frames"]),
+            distance_scale_factor=float(scale) if scale is not None else None,
+            window_sizes=frozenset(window_sizes),
+            per_frame_present=(identity_dir / _PARQUET_PER_FRAME_FILENAME).exists(),
+            size_bytes=_directory_size(identity_dir),
+        )
+    except (OSError, KeyError, TypeError, ValueError):
+        logger.debug("Could not inspect Parquet feature cache at %s", path, exc_info=True)
+        return None

--- a/packages/jabs-io/tests/feature_cache/test_inspection.py
+++ b/packages/jabs-io/tests/feature_cache/test_inspection.py
@@ -188,3 +188,24 @@ def test_inspect_prefers_parquet_when_both_formats_present(tmp_path):
 
     assert info is not None
     assert info.cache_format == CacheFormat.PARQUET
+
+
+def test_inspect_survives_an_unreadable_cache_directory(tmp_path, monkeypatch):
+    """A directory listing failure while sizing the cache does not fail inspection.
+
+    Size is one field of many; a cache directory that becomes unreadable (or is
+    removed) mid-scan must not abort a project-wide scan.
+    """
+    identity_dir = tmp_path / "0"
+    _write_cache(identity_dir, CacheFormat.HDF5, window_sizes=(5,), identity=0)
+
+    def _deny_listing(_self):
+        raise PermissionError("cache directory is not readable")
+
+    monkeypatch.setattr(Path, "iterdir", _deny_listing)
+
+    info = inspect_identity_cache(identity_dir)
+
+    assert info is not None
+    assert info.window_sizes == frozenset({5})
+    assert info.size_bytes == 0

--- a/packages/jabs-io/tests/feature_cache/test_inspection.py
+++ b/packages/jabs-io/tests/feature_cache/test_inspection.py
@@ -1,0 +1,190 @@
+"""Tests for read-only feature cache inspection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from jabs.core.enums import CacheFormat
+from jabs.core.types import FeatureCacheMetadata, PerFrameCacheData
+from jabs.io.feature_cache import inspect_identity_cache
+from jabs.io.feature_cache.hdf5 import HDF5FeatureCacheWriter
+from jabs.io.feature_cache.parquet import ParquetFeatureCacheWriter
+
+_N_FRAMES = 20
+_FEATURE_VERSION = 11
+_POSE_HASH = "abc123"
+
+
+def _metadata(**overrides) -> FeatureCacheMetadata:
+    """Return cache metadata with test defaults."""
+    return FeatureCacheMetadata(
+        feature_version=overrides.get("feature_version", _FEATURE_VERSION),
+        identity=overrides.get("identity", 2),
+        num_frames=overrides.get("num_frames", _N_FRAMES),
+        pose_hash=overrides.get("pose_hash", _POSE_HASH),
+        distance_scale_factor=overrides.get("distance_scale_factor"),
+    )
+
+
+def _per_frame_data() -> PerFrameCacheData:
+    """Return minimal per-frame cache data."""
+    rng = np.random.default_rng(seed=7)
+    return PerFrameCacheData(
+        frame_valid=np.ones(_N_FRAMES, dtype=np.uint8),
+        features={"mod feat": rng.standard_normal(_N_FRAMES)},
+    )
+
+
+def _window_data() -> dict[str, np.ndarray]:
+    """Return minimal window feature data."""
+    rng = np.random.default_rng(seed=8)
+    return {"mod mean feat": rng.standard_normal(_N_FRAMES)}
+
+
+def _write_cache(
+    identity_dir: Path,
+    cache_format: CacheFormat,
+    window_sizes: tuple[int, ...] = (),
+    **metadata_overrides,
+) -> None:
+    """Write a cache in the requested format with the given window sizes."""
+    writer = (
+        ParquetFeatureCacheWriter()
+        if cache_format == CacheFormat.PARQUET
+        else HDF5FeatureCacheWriter()
+    )
+    metadata = _metadata(**metadata_overrides)
+    writer.write_per_frame(identity_dir, metadata, _per_frame_data())
+    for size in window_sizes:
+        writer.write_window(identity_dir, metadata, size, _window_data())
+
+
+@pytest.mark.parametrize(
+    "cache_format", [CacheFormat.HDF5, CacheFormat.PARQUET], ids=["hdf5", "parquet"]
+)
+def test_inspect_reports_metadata_and_window_sizes(tmp_path, cache_format):
+    """Inspection reports the metadata and window sizes written to the cache."""
+    identity_dir = tmp_path / "2"
+    _write_cache(identity_dir, cache_format, window_sizes=(5, 10))
+
+    info = inspect_identity_cache(identity_dir)
+
+    assert info is not None
+    assert info.directory == identity_dir
+    assert info.cache_format == cache_format
+    assert info.identity == 2
+    assert info.feature_version == _FEATURE_VERSION
+    assert info.pose_hash == _POSE_HASH
+    assert info.num_frames == _N_FRAMES
+    assert info.window_sizes == frozenset({5, 10})
+    assert info.per_frame_present is True
+    assert info.distance_scale_factor is None
+    assert info.size_bytes > 0
+
+
+@pytest.mark.parametrize(
+    "cache_format", [CacheFormat.HDF5, CacheFormat.PARQUET], ids=["hdf5", "parquet"]
+)
+def test_inspect_reports_no_window_sizes_when_none_cached(tmp_path, cache_format):
+    """A cache with only per-frame features reports an empty window size set."""
+    identity_dir = tmp_path / "0"
+    _write_cache(identity_dir, cache_format, identity=0)
+
+    info = inspect_identity_cache(identity_dir)
+
+    assert info is not None
+    assert info.window_sizes == frozenset()
+
+
+@pytest.mark.parametrize(
+    "cache_format", [CacheFormat.HDF5, CacheFormat.PARQUET], ids=["hdf5", "parquet"]
+)
+def test_inspect_reports_distance_scale_factor(tmp_path, cache_format):
+    """The distance scale factor a cache was computed with is reported."""
+    identity_dir = tmp_path / "1"
+    _write_cache(identity_dir, cache_format, identity=1, distance_scale_factor=0.25)
+
+    info = inspect_identity_cache(identity_dir)
+
+    assert info is not None
+    assert info.distance_scale_factor == pytest.approx(0.25)
+
+
+def test_inspect_missing_cache_returns_none(tmp_path):
+    """A directory with no cache files yields None."""
+    empty = tmp_path / "0"
+    empty.mkdir()
+
+    assert inspect_identity_cache(empty) is None
+
+
+def test_inspect_nonexistent_directory_returns_none(tmp_path):
+    """A directory that does not exist yields None rather than raising."""
+    assert inspect_identity_cache(tmp_path / "does-not-exist") is None
+
+
+def test_inspect_unreadable_hdf5_returns_none(tmp_path):
+    """A features.h5 that is not a valid HDF5 file yields None."""
+    identity_dir = tmp_path / "0"
+    identity_dir.mkdir()
+    (identity_dir / "features.h5").write_text("not hdf5")
+
+    assert inspect_identity_cache(identity_dir) is None
+
+
+def test_inspect_malformed_metadata_json_returns_none(tmp_path):
+    """A metadata.json that is not valid JSON yields None."""
+    identity_dir = tmp_path / "0"
+    identity_dir.mkdir()
+    (identity_dir / "metadata.json").write_text("{not json")
+
+    assert inspect_identity_cache(identity_dir) is None
+
+
+def test_inspect_metadata_json_missing_field_returns_none(tmp_path):
+    """A metadata.json missing a required field yields None."""
+    identity_dir = tmp_path / "0"
+    identity_dir.mkdir()
+    (identity_dir / "metadata.json").write_text(json.dumps({"identity": 0}))
+
+    assert inspect_identity_cache(identity_dir) is None
+
+
+def test_inspect_omits_registered_window_size_with_missing_file(tmp_path):
+    """A registered Parquet window size whose file is gone is not reported."""
+    identity_dir = tmp_path / "0"
+    _write_cache(identity_dir, CacheFormat.PARQUET, window_sizes=(5, 10), identity=0)
+    (identity_dir / "window_10.parquet").unlink()
+
+    info = inspect_identity_cache(identity_dir)
+
+    assert info is not None
+    assert info.window_sizes == frozenset({5})
+
+
+def test_inspect_reports_missing_parquet_per_frame_features(tmp_path):
+    """A Parquet cache without per_frame.parquet reports per_frame_present False."""
+    identity_dir = tmp_path / "0"
+    _write_cache(identity_dir, CacheFormat.PARQUET, identity=0)
+    (identity_dir / "per_frame.parquet").unlink()
+
+    info = inspect_identity_cache(identity_dir)
+
+    assert info is not None
+    assert info.per_frame_present is False
+
+
+def test_inspect_prefers_parquet_when_both_formats_present(tmp_path):
+    """metadata.json takes precedence, matching detect_cache_format()."""
+    identity_dir = tmp_path / "0"
+    _write_cache(identity_dir, CacheFormat.HDF5, identity=0)
+    _write_cache(identity_dir, CacheFormat.PARQUET, identity=0)
+
+    info = inspect_identity_cache(identity_dir)
+
+    assert info is not None
+    assert info.cache_format == CacheFormat.PARQUET

--- a/src/jabs/project/__init__.py
+++ b/src/jabs/project/__init__.py
@@ -1,6 +1,12 @@
 """jabs project module"""
 
 from .export_training import export_training_data, export_training_data_multiclass
+from .feature_cache_status import (
+    VideoFeatureCacheStatus,
+    scan_project_feature_cache,
+    scan_project_video_feature_cache,
+    scan_video_feature_cache,
+)
 from .project import Project
 from .project_pruning import get_videos_to_prune
 from .read_training import load_multiclass_training_data, load_training_data
@@ -12,10 +18,14 @@ __all__ = [
     "Project",
     "TimelineAnnotations",
     "TrackLabels",
+    "VideoFeatureCacheStatus",
     "VideoLabels",
     "export_training_data",
     "export_training_data_multiclass",
     "get_videos_to_prune",
     "load_multiclass_training_data",
     "load_training_data",
+    "scan_project_feature_cache",
+    "scan_project_video_feature_cache",
+    "scan_video_feature_cache",
 ]

--- a/src/jabs/project/feature_cache_status.py
+++ b/src/jabs/project/feature_cache_status.py
@@ -80,6 +80,19 @@ class VideoFeatureCacheStatus:
         return len({info.identity for info in self.identity_caches})
 
     @property
+    def identities_missing_per_frame(self) -> tuple[int, ...]:
+        """Sorted identities whose caches hold no per-frame features.
+
+        Evaluated per identity rather than per cache directory: an identity with
+        caches under several pose-hash subdirectories only needs per-frame
+        features in one of them, matching how :attr:`window_sizes` merges.
+        """
+        present: dict[int, bool] = {}
+        for info in self.identity_caches:
+            present[info.identity] = present.get(info.identity, False) or info.per_frame_present
+        return tuple(sorted(identity for identity, found in present.items() if not found))
+
+    @property
     def is_complete(self) -> bool:
         """Whether every identity in the video has per-frame features cached.
 
@@ -88,8 +101,9 @@ class VideoFeatureCacheStatus:
         """
         if self.expected_identity_count is None or not self.has_cached_features:
             return False
-        return self.cached_identity_count >= self.expected_identity_count and all(
-            info.per_frame_present for info in self.identity_caches
+        return (
+            self.cached_identity_count >= self.expected_identity_count
+            and not self.identities_missing_per_frame
         )
 
     @property
@@ -144,7 +158,12 @@ class VideoFeatureCacheStatus:
         More than one format means the cache is mixed, which can happen when a
         project's cache format setting changed without clearing the cache.
         """
-        return tuple(sorted({info.cache_format for info in self.identity_caches}, key=str))
+        return tuple(
+            sorted(
+                {info.cache_format for info in self.identity_caches},
+                key=lambda cache_format: cache_format.value,
+            )
+        )
 
     @property
     def feature_versions(self) -> tuple[int, ...]:

--- a/src/jabs/project/feature_cache_status.py
+++ b/src/jabs/project/feature_cache_status.py
@@ -1,0 +1,328 @@
+"""Per-video status of a JABS project's on-disk feature cache.
+
+Aggregates the per-identity cache summaries produced by
+:func:`jabs.io.feature_cache.inspect_identity_cache` into one status object per
+video, answering the questions a user asks about a project's cache: are
+features cached for this video, for which window sizes, in which format, and is
+what is on disk still current?
+
+Scanning only reads small metadata files (HDF5 attributes or ``metadata.json``),
+never feature data, so a whole project can be scanned quickly. Nothing here
+validates a cache against its pose file: doing so would require hashing every
+pose file, which is far too expensive for a status scan. A cache whose pose file
+has changed is therefore still reported as present; it will be detected and
+recomputed when the features are actually loaded.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Collection, Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from jabs.core.enums import CacheFormat
+from jabs.core.utils import pose_file_stem
+from jabs.io.feature_cache import IdentityCacheInfo, inspect_identity_cache
+
+if TYPE_CHECKING:
+    from .project import Project
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class VideoFeatureCacheStatus:
+    """Status of the cached features for a single video.
+
+    Attributes:
+        video: Video filename this status describes.
+        cache_dir: Directory holding this video's cached features
+            (``<project>/jabs/features/<video stem>``). May not exist.
+        identity_caches: Per-identity cache summaries found under ``cache_dir``,
+            ordered by identity. Identities with no cache are absent. More than
+            one entry can share an identity when caches exist under multiple
+            pose-hash subdirectories (written by the CLI tools' ``--use-pose-hash``
+            option).
+        current_feature_version: The running application's ``FEATURE_VERSION``,
+            used to decide whether the cached features are stale.
+        expected_identity_count: Number of identities in the video, or ``None``
+            when unknown. Used to report whether every identity is cached.
+    """
+
+    video: str
+    cache_dir: Path
+    identity_caches: tuple[IdentityCacheInfo, ...]
+    current_feature_version: int
+    expected_identity_count: int | None = None
+
+    def _window_sizes_by_identity(self) -> dict[int, frozenset[int]]:
+        """Group the cached window sizes by identity.
+
+        Caches for the same identity under different pose-hash subdirectories
+        are merged, so an identity counts as having a window size if any of its
+        caches provides it.
+        """
+        grouped: dict[int, set[int]] = {}
+        for info in self.identity_caches:
+            grouped.setdefault(info.identity, set()).update(info.window_sizes)
+        return {identity: frozenset(sizes) for identity, sizes in grouped.items()}
+
+    @property
+    def has_cached_features(self) -> bool:
+        """Whether any identity has cached features."""
+        return bool(self.identity_caches)
+
+    @property
+    def cached_identity_count(self) -> int:
+        """Number of distinct identities with a cache present."""
+        return len({info.identity for info in self.identity_caches})
+
+    @property
+    def is_complete(self) -> bool:
+        """Whether every identity in the video has per-frame features cached.
+
+        ``False`` when the identity count is unknown, so callers can treat this
+        as "known to be complete" rather than "not known to be incomplete".
+        """
+        if self.expected_identity_count is None or not self.has_cached_features:
+            return False
+        return self.cached_identity_count >= self.expected_identity_count and all(
+            info.per_frame_present for info in self.identity_caches
+        )
+
+    @property
+    def window_sizes(self) -> tuple[int, ...]:
+        """Sorted window sizes cached for every identity that has a cache.
+
+        These are the window sizes that can be loaded from the cache for the
+        whole video. Note the qualifier: when only some identities are cached
+        (see :attr:`is_complete`), this reflects only those identities.
+        """
+        sets = list(self._window_sizes_by_identity().values())
+        if not sets:
+            return ()
+        return tuple(sorted(frozenset.intersection(*sets)))
+
+    def has_window_features(
+        self, window_size: int, identities: Collection[int] | None = None
+    ) -> bool:
+        """Whether cached features cover a window size for the given identities.
+
+        Used to decide whether features would have to be computed on demand.
+
+        Args:
+            window_size: Window size the features are needed for.
+            identities: Identities that need features. When ``None``, every
+                identity in the video is required, which means ``False`` is
+                returned if the identity count is unknown. An empty collection
+                means nothing is needed, so the answer is ``True``.
+
+        Returns:
+            True when every required identity has this window size cached.
+        """
+        cached = self._window_sizes_by_identity()
+        if identities is None:
+            if self.expected_identity_count is None:
+                return False
+            identities = range(self.expected_identity_count)
+        return all(window_size in cached.get(identity, frozenset()) for identity in identities)
+
+    @property
+    def partial_window_sizes(self) -> tuple[int, ...]:
+        """Sorted window sizes cached for some, but not all, cached identities."""
+        sets = list(self._window_sizes_by_identity().values())
+        if not sets:
+            return ()
+        return tuple(sorted(frozenset.union(*sets) - frozenset.intersection(*sets)))
+
+    @property
+    def cache_formats(self) -> tuple[CacheFormat, ...]:
+        """Distinct storage formats found, sorted by value.
+
+        More than one format means the cache is mixed, which can happen when a
+        project's cache format setting changed without clearing the cache.
+        """
+        return tuple(sorted({info.cache_format for info in self.identity_caches}, key=str))
+
+    @property
+    def feature_versions(self) -> tuple[int, ...]:
+        """Sorted distinct feature versions the caches were written with."""
+        return tuple(sorted({info.feature_version for info in self.identity_caches}))
+
+    @property
+    def is_stale(self) -> bool:
+        """Whether any cache was written by a different feature version.
+
+        A stale cache is discarded and recomputed the next time features are
+        needed.
+        """
+        return any(version != self.current_feature_version for version in self.feature_versions)
+
+    @property
+    def cm_units(self) -> bool | None:
+        """Whether the caches were computed in cm units.
+
+        Returns:
+            ``True`` when every cache carries a distance scale factor, ``False``
+            when none do, and ``None`` when the caches disagree or there are
+            none. A mismatch with the project's current unit setting causes the
+            cache to be recomputed.
+        """
+        if not self.identity_caches:
+            return None
+        scaled = {info.distance_scale_factor is not None for info in self.identity_caches}
+        if len(scaled) != 1:
+            return None
+        return scaled.pop()
+
+    @property
+    def size_bytes(self) -> int:
+        """Total size on disk of every cache file found for this video."""
+        return sum(info.size_bytes for info in self.identity_caches)
+
+
+def _iter_identity_dirs(video_cache_dir: Path) -> Iterator[Path]:
+    """Yield the per-identity cache directories for one video.
+
+    Handles both on-disk layouts: the flat ``features/<video>/<identity>`` used
+    by the GUI, and ``features/<video>/<pose hash>/<identity>`` written when the
+    CLI tools are run with ``--use-pose-hash``.
+
+    Args:
+        video_cache_dir: The ``features/<video stem>`` directory to walk.
+
+    Yields:
+        Directories whose name is an identity index, in name order.
+    """
+    try:
+        children = sorted(video_cache_dir.iterdir())
+    except OSError:
+        logger.debug("Could not list feature cache directory %s", video_cache_dir, exc_info=True)
+        return
+
+    for child in children:
+        if not child.is_dir():
+            continue
+        if child.name.isdigit():
+            yield child
+            continue
+        # a pose-hash subdirectory: its own children are the identity directories
+        try:
+            grandchildren = sorted(child.iterdir())
+        except OSError:
+            logger.debug("Could not list feature cache directory %s", child, exc_info=True)
+            continue
+        for grandchild in grandchildren:
+            if grandchild.is_dir() and grandchild.name.isdigit():
+                yield grandchild
+
+
+def scan_video_feature_cache(
+    feature_dir: Path,
+    video: str,
+    current_feature_version: int,
+    expected_identity_count: int | None = None,
+) -> VideoFeatureCacheStatus:
+    """Inspect the cached features for one video.
+
+    Args:
+        feature_dir: The project's features directory.
+        video: Video filename (or pose filename) to scan the cache for.
+        current_feature_version: The running application's ``FEATURE_VERSION``.
+        expected_identity_count: Number of identities in the video, when known.
+
+    Returns:
+        The video's cache status. A video with no cache yields a status whose
+        ``has_cached_features`` is ``False``; missing directories are not an
+        error.
+    """
+    cache_dir = feature_dir / pose_file_stem(video)
+    caches: list[IdentityCacheInfo] = []
+    if cache_dir.is_dir():
+        for identity_dir in _iter_identity_dirs(cache_dir):
+            info = inspect_identity_cache(identity_dir)
+            if info is not None:
+                caches.append(info)
+
+    return VideoFeatureCacheStatus(
+        video=video,
+        cache_dir=cache_dir,
+        identity_caches=tuple(sorted(caches, key=lambda info: (info.identity, info.directory))),
+        current_feature_version=current_feature_version,
+        expected_identity_count=expected_identity_count,
+    )
+
+
+def scan_project_video_feature_cache(project: Project, video: str) -> VideoFeatureCacheStatus:
+    """Inspect the cached features for one video of a project.
+
+    Convenience wrapper that supplies the project's features directory, the
+    running ``FEATURE_VERSION``, and the video's identity count.
+
+    Args:
+        project: Project the video belongs to.
+        video: Video filename.
+
+    Returns:
+        The video's cache status.
+    """
+    # imported here rather than at module scope: jabs.feature_extraction imports
+    # jabs.project, so a module-level import would be circular.
+    from jabs.feature_extraction import FEATURE_VERSION
+
+    try:
+        identity_count = project.video_manager.get_video_identity_count(video)
+    except (KeyError, ValueError):
+        logger.debug("Identity count unavailable for %s", video, exc_info=True)
+        identity_count = None
+
+    return scan_video_feature_cache(
+        project.feature_dir,
+        video,
+        current_feature_version=FEATURE_VERSION,
+        expected_identity_count=identity_count,
+    )
+
+
+def scan_project_feature_cache(
+    project: Project, should_continue: Callable[[], bool] | None = None
+) -> dict[str, VideoFeatureCacheStatus]:
+    """Inspect the cached features for every video in a project.
+
+    This only reads cache metadata, but it touches every per-identity cache
+    directory in the project, so callers in the GUI should run it off the main
+    thread.
+
+    Args:
+        project: Project to scan.
+        should_continue: Optional predicate checked before each video; the scan
+            stops early and returns partial results when it returns ``False``.
+            Lets a caller running the scan in a thread abandon it, for example at
+            application shutdown.
+
+    Returns:
+        Mapping of video filename to its cache status. Every video in the project
+        is present, including those with no cached features, unless the scan
+        stopped early.
+    """
+    statuses: dict[str, VideoFeatureCacheStatus] = {}
+    videos = list(project.video_manager.videos)
+    for video in videos:
+        if should_continue is not None and not should_continue():
+            logger.debug(
+                "Feature cache scan stopped early after %d of %d videos",
+                len(statuses),
+                len(videos),
+            )
+            return statuses
+        statuses[video] = scan_project_video_feature_cache(project, video)
+
+    cached = sum(1 for status in statuses.values() if status.has_cached_features)
+    logger.info(
+        "Feature cache scan complete: %d of %d videos have cached features",
+        cached,
+        len(statuses),
+    )
+    return statuses

--- a/src/jabs/project/feature_cache_status.py
+++ b/src/jabs/project/feature_cache_status.py
@@ -73,7 +73,9 @@ class VideoFeatureCacheStatus:
             grouped.setdefault(info.identity, set()).update(info.window_sizes)
         return {identity: frozenset(sizes) for identity, sizes in grouped.items()}
 
-    def _loadable_window_sizes_by_identity(self) -> dict[int, frozenset[int]]:
+    def _loadable_window_sizes_by_identity(
+        self, expects_cm: bool | None = None
+    ) -> dict[int, frozenset[int]]:
         """Group by identity the window sizes that would actually load.
 
         A cache only counts when it was written by the current feature version and
@@ -84,12 +86,20 @@ class VideoFeatureCacheStatus:
         Sizes are only merged across an identity's pose-hash subdirectories from
         caches that pass those checks, so a window size present only in a stale
         directory does not count because a sibling directory happens to be current.
+
+        Args:
+            expects_cm: Whether the run will compute features in cm units. A cache
+                built in the other unit is discarded and recomputed, so it does not
+                count. ``None`` skips the check, for callers that do not know which
+                units will be used.
         """
         grouped: dict[int, set[int]] = {}
         for info in self.identity_caches:
             loadable = (
                 info.per_frame_present and info.feature_version == self.current_feature_version
             )
+            if loadable and expects_cm is not None:
+                loadable = (info.distance_scale_factor is not None) == expects_cm
             grouped.setdefault(info.identity, set()).update(
                 info.window_sizes if loadable else frozenset()
             )
@@ -146,19 +156,23 @@ class VideoFeatureCacheStatus:
         return tuple(sorted(frozenset.intersection(*sets)))
 
     def has_window_features(
-        self, window_size: int, identities: Collection[int] | None = None
+        self,
+        window_size: int,
+        identities: Collection[int] | None = None,
+        *,
+        expects_cm: bool | None = None,
     ) -> bool:
         """Whether cached features cover a window size for the given identities.
 
         Used to decide whether features would have to be computed on demand, so
-        only caches that would actually load count: a stale one, or one missing its
-        per-frame features, is recomputed on use and is therefore not coverage.
+        only caches that would actually load count: one that is stale, missing its
+        per-frame features, or built in the other distance unit is recomputed on
+        use and is therefore not coverage.
 
-        Two causes of recomputation cannot be detected from a status scan, so this
+        One cause of recomputation cannot be detected from a status scan, so this
         can still answer ``True`` for a cache that will be rebuilt: a pose file that
-        changed since the cache was written (detecting it would mean hashing every
-        pose file), and a distance-unit setting that no longer matches the cache
-        (compare :attr:`cm_units` against the run's settings to catch that).
+        changed since the cache was written, since detecting that would mean hashing
+        every pose file.
 
         Args:
             window_size: Window size the features are needed for.
@@ -166,12 +180,14 @@ class VideoFeatureCacheStatus:
                 identity in the video is required, which means ``False`` is
                 returned if the identity count is unknown. An empty collection
                 means nothing is needed, so the answer is ``True``.
+            expects_cm: Whether the run will compute features in cm units for this
+                video. ``None`` (the default) skips the unit check.
 
         Returns:
             True when every required identity has this window size cached in a
             form that can be loaded.
         """
-        cached = self._loadable_window_sizes_by_identity()
+        cached = self._loadable_window_sizes_by_identity(expects_cm)
         if identities is None:
             if self.expected_identity_count is None:
                 return False

--- a/src/jabs/project/feature_cache_status.py
+++ b/src/jabs/project/feature_cache_status.py
@@ -60,6 +60,10 @@ class VideoFeatureCacheStatus:
     def _window_sizes_by_identity(self) -> dict[int, frozenset[int]]:
         """Group the cached window sizes by identity.
 
+        Reports what is on disk, whether or not it could still be loaded; see
+        :meth:`_loadable_window_sizes_by_identity` for the stricter view used to
+        answer coverage questions.
+
         Caches for the same identity under different pose-hash subdirectories
         are merged, so an identity counts as having a window size if any of its
         caches provides it.
@@ -67,6 +71,28 @@ class VideoFeatureCacheStatus:
         grouped: dict[int, set[int]] = {}
         for info in self.identity_caches:
             grouped.setdefault(info.identity, set()).update(info.window_sizes)
+        return {identity: frozenset(sizes) for identity, sizes in grouped.items()}
+
+    def _loadable_window_sizes_by_identity(self) -> dict[int, frozenset[int]]:
+        """Group by identity the window sizes that would actually load.
+
+        A cache only counts when it was written by the current feature version and
+        holds per-frame features: ``IdentityFeatures`` discards a cache whose
+        version differs and recomputes it, and window features are recomputed
+        along with the per-frame features they accompany.
+
+        Sizes are only merged across an identity's pose-hash subdirectories from
+        caches that pass those checks, so a window size present only in a stale
+        directory does not count because a sibling directory happens to be current.
+        """
+        grouped: dict[int, set[int]] = {}
+        for info in self.identity_caches:
+            loadable = (
+                info.per_frame_present and info.feature_version == self.current_feature_version
+            )
+            grouped.setdefault(info.identity, set()).update(
+                info.window_sizes if loadable else frozenset()
+            )
         return {identity: frozenset(sizes) for identity, sizes in grouped.items()}
 
     @property
@@ -124,7 +150,15 @@ class VideoFeatureCacheStatus:
     ) -> bool:
         """Whether cached features cover a window size for the given identities.
 
-        Used to decide whether features would have to be computed on demand.
+        Used to decide whether features would have to be computed on demand, so
+        only caches that would actually load count: a stale one, or one missing its
+        per-frame features, is recomputed on use and is therefore not coverage.
+
+        Two causes of recomputation cannot be detected from a status scan, so this
+        can still answer ``True`` for a cache that will be rebuilt: a pose file that
+        changed since the cache was written (detecting it would mean hashing every
+        pose file), and a distance-unit setting that no longer matches the cache
+        (compare :attr:`cm_units` against the run's settings to catch that).
 
         Args:
             window_size: Window size the features are needed for.
@@ -134,9 +168,10 @@ class VideoFeatureCacheStatus:
                 means nothing is needed, so the answer is ``True``.
 
         Returns:
-            True when every required identity has this window size cached.
+            True when every required identity has this window size cached in a
+            form that can be loaded.
         """
-        cached = self._window_sizes_by_identity()
+        cached = self._loadable_window_sizes_by_identity()
         if identities is None:
             if self.expected_identity_count is None:
                 return False

--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -5,7 +5,7 @@ import json
 import logging
 import shutil
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Collection, Iterable, Mapping
 from concurrent.futures import as_completed
 from datetime import datetime
 from pathlib import Path
@@ -34,6 +34,10 @@ from jabs.pose_estimation import (
 )
 
 from . import pose_attribute_cache
+from .feature_cache_status import (
+    VideoFeatureCacheStatus,
+    scan_project_video_feature_cache,
+)
 from .feature_manager import FeatureManager
 from .parallel_workers import (
     BinaryFeatureLoadJobSpec,
@@ -198,6 +202,12 @@ class Project:
         self._paths.create_directories(validate=validate_project_dir)
         self._total_project_identities = 0
         self._enabled_extended_features = {}
+
+        # In-memory feature cache status, keyed by video filename. Populated by
+        # whoever scans the cache (the GUI does so in the background when a
+        # project is opened) and refreshed per video on demand. Not persisted:
+        # the on-disk cache can change outside JABS.
+        self._feature_cache_status: dict[str, VideoFeatureCacheStatus] = {}
 
         # Capture whether project.json exists before SettingsManager loads it.
         # Used below to choose the cache_format default: Parquet for brand-new projects,
@@ -498,6 +508,132 @@ class Project:
                     for identity_dir in sub.iterdir():
                         if identity_dir.is_dir():
                             clear_cache(identity_dir)
+
+        self.invalidate_feature_cache_status()
+
+    @property
+    def feature_cache_status(self) -> Mapping[str, VideoFeatureCacheStatus]:
+        """Feature cache status per video, as far as it is currently known.
+
+        Videos that have not been scanned are absent. Use
+        :meth:`refresh_feature_cache_status` to scan one video, or
+        :func:`~jabs.project.scan_project_feature_cache` (off the main thread in
+        the GUI) followed by :meth:`set_feature_cache_status` for the whole
+        project.
+        """
+        return self._feature_cache_status
+
+    def set_feature_cache_status(self, statuses: Mapping[str, VideoFeatureCacheStatus]) -> None:
+        """Replace the stored feature cache status.
+
+        Args:
+            statuses: Per-video status, keyed by video filename, as returned by
+                :func:`~jabs.project.scan_project_feature_cache`.
+        """
+        self._feature_cache_status = dict(statuses)
+
+    def refresh_feature_cache_status(self, video: str) -> VideoFeatureCacheStatus:
+        """Re-scan one video's feature cache and store the result.
+
+        Args:
+            video: Video filename.
+
+        Returns:
+            The video's current cache status.
+        """
+        status = scan_project_video_feature_cache(self, video)
+        self._feature_cache_status[video] = status
+        return status
+
+    def invalidate_feature_cache_status(self, videos: Iterable[str] | None = None) -> None:
+        """Discard stored cache status so it is re-scanned when next needed.
+
+        Call this after anything writes to or removes from the feature cache
+        (feature extraction during training or classification, clearing the
+        cache) so later queries do not act on stale information.
+
+        Args:
+            videos: Videos to forget, or ``None`` to forget every video.
+        """
+        if videos is None:
+            self._feature_cache_status.clear()
+            return
+        for video in videos:
+            self._feature_cache_status.pop(video, None)
+
+    def videos_missing_window_features(
+        self,
+        window_size: int,
+        *,
+        videos: Iterable[str] | None = None,
+        identities: Mapping[str, Collection[int]] | None = None,
+    ) -> list[str]:
+        """Return videos whose cached features do not cover a window size.
+
+        Features for these videos would be computed on demand (and cached) the
+        next time they are needed. Videos with no stored status are scanned
+        here, so the answer does not depend on a project-wide scan having run.
+
+        Args:
+            window_size: Window size the features are needed for.
+            videos: Videos to check; defaults to every video in the project.
+                Ignored when ``identities`` is given.
+            identities: Per-video identities that need features, which also
+                selects the videos to check. Use this when only some identities
+                matter (training only reads features for labeled identities).
+                When omitted, every identity of each video must have the window
+                size cached.
+
+        Returns:
+            The subset of checked videos needing feature computation, in the
+            order they were checked.
+        """
+        if identities is not None:
+            to_check: list[str] = list(identities)
+        elif videos is not None:
+            to_check = list(videos)
+        else:
+            to_check = list(self._video_manager.videos)
+
+        missing: list[str] = []
+        for video in to_check:
+            status = self._feature_cache_status.get(video)
+            if status is None:
+                status = self.refresh_feature_cache_status(video)
+            required = identities.get(video) if identities is not None else None
+            if not status.has_window_features(window_size, required):
+                missing.append(video)
+        return missing
+
+    def labeled_identities(self, behaviors: Collection[str]) -> dict[str, set[int]]:
+        """Map each annotated video to the identities labeled for any behavior.
+
+        Mirrors what the training feature collectors actually read: an identity
+        with no labels for the requested behaviors contributes no training rows,
+        so its features are never extracted.
+
+        Args:
+            behaviors: Behavior names to consider.
+
+        Returns:
+            Mapping of video filename to labeled identity indexes. Videos with no
+            labels for any of ``behaviors`` are omitted.
+        """
+        labeled: dict[str, set[int]] = {}
+        for video in self._video_manager.videos:
+            annotations = self._video_manager.load_annotations(video)
+            if annotations is None:
+                continue
+            identities: set[int] = set()
+            # both fragmented and unfragmented blocks are consulted: either one
+            # being present means the identity carries labels for the behavior
+            for key in ("labels", "unfragmented_labels"):
+                for identity, behavior_labels in (annotations.get(key) or {}).items():
+                    if any(behavior_labels.get(behavior) for behavior in behaviors):
+                        identities.add(int(identity))
+            if identities:
+                labeled[video] = identities
+        return labeled
 
     def get_derived_file_paths(self, video_name: str) -> list[Path]:
         """Return a list of paths for files derived from a given video.

--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -567,6 +567,7 @@ class Project:
         *,
         videos: Iterable[str] | None = None,
         identities: Mapping[str, Collection[int]] | None = None,
+        cm_units: bool | None = None,
     ) -> list[str]:
         """Return videos whose cached features do not cover a window size.
 
@@ -583,6 +584,9 @@ class Project:
                 matter (training only reads features for labeled identities).
                 When omitted, every identity of each video must have the window
                 size cached.
+            cm_units: Whether the run will request cm units. A cache built in the
+                other unit is discarded and recomputed, so it does not count as
+                cached. ``None`` skips the unit check.
 
         Returns:
             The subset of checked videos needing feature computation, in the
@@ -601,7 +605,15 @@ class Project:
             if status is None:
                 status = self.refresh_feature_cache_status(video)
             required = identities.get(video) if identities is not None else None
-            if not status.has_window_features(window_size, required):
+            # cm units are only used for a video whose pose file provides the
+            # scale factor; without one, features are computed in pixels whatever
+            # the setting says
+            expects_cm = (
+                cm_units and self._video_manager.video_has_cm_per_pixel(video)
+                if cm_units is not None
+                else None
+            )
+            if not status.has_window_features(window_size, required, expects_cm=expects_cm):
                 missing.append(video)
         return missing
 

--- a/src/jabs/project/video_manager.py
+++ b/src/jabs/project/video_manager.py
@@ -56,6 +56,9 @@ class VideoManager:
         self._settings_manager = settings_manager
         self._videos = []
         self._video_identity_count = {}
+        # whether each video's pose file carries a cm_per_pixel scale, which decides
+        # whether features for it can actually be computed in cm units
+        self._video_has_cm_per_pixel: dict[str, bool] = {}
         self._total_project_identities = 0
         self._pose_path_cache = {}  # Cache mapping video names to their pose file paths to avoid repeated lookups
 
@@ -178,6 +181,21 @@ class VideoManager:
         """
         return self._video_identity_count.get(video_name, 0)
 
+    def video_has_cm_per_pixel(self, video_name: str) -> bool:
+        """Whether a video's pose file carries a cm_per_pixel scale factor.
+
+        Features for a video without one are always computed in pixels, whatever
+        the project's distance unit setting says.
+
+        Args:
+            video_name: Name of the video file
+
+        Returns:
+            True if the pose file provides a cm_per_pixel scale. Unknown videos
+            report False.
+        """
+        return self._video_has_cm_per_pixel.get(video_name, False)
+
     def get_cached_pose_path(self, video_name: str) -> Path:
         """Get pose path for a video, using cache to avoid repeated lookups.
 
@@ -196,7 +214,7 @@ class VideoManager:
         return self._pose_path_cache[video_name]
 
     def _load_video_metadata(self, scan_results: "dict[str, VideoScanResult]") -> None:
-        """Load identity counts from pre-scanned metadata.
+        """Load identity counts and cm scale availability from pre-scanned metadata.
 
         Args:
             scan_results: Per-video metadata from the project scan, keyed by
@@ -206,6 +224,7 @@ class VideoManager:
             nidentities = scan_results[video]["identity_count"]
             self._video_identity_count[video] = nidentities
             self._total_project_identities += nidentities
+            self._video_has_cm_per_pixel[video] = scan_results[video]["has_cm_per_pixel"]
 
     def _validate_video_frame_counts(self, scan_results: "dict[str, VideoScanResult]") -> None:
         """Ensure video and pose file frame counts match.

--- a/src/jabs/resources/docs/user_guide/gui.md
+++ b/src/jabs/resources/docs/user_guide/gui.md
@@ -26,7 +26,7 @@ Right-click a video name to open a context menu:
 
 <img src="imgs/video-context-menu.png" alt="Video list context menu" width=300 />
 
-- **Get Info:** Open a dialog showing details about the video and its associated pose file.
+- **Get Info:** Open a dialog showing details about the video, its associated pose file, and its cached features (the cache directory, cached window sizes, storage format, size on disk, and whether the cache is out of date).
 - **Copy Video Name:** Copy the video's filename to the clipboard.
 - **Classify Video:** Run the trained classifier for the current behavior on just this video, rather than every video the way the **Classify** button does. This item is only available once a classifier has been trained for the current behavior (if none is ready, JABS prompts you to train one first). When classification finishes, JABS displays the new predictions, switching to the video if it is not already the active one.
 - **Exclude from Training:** Toggle whether the video is held out of classifier training (unchecked by default). When a video is excluded:
@@ -48,6 +48,12 @@ Right-click a video name to open a context menu:
 - **Symmetric Behavior Toggle:** Tells the classifier that the behavior is symmetric. A symmetric behavior is when left and right features are interchangeable.
 - **All k-fold Toggle:** Uses the maximum number of cross validation folds. Useful when you wish to compare classifier performance and may have an outlier that can be held-out.
 - **Cross Validation Slider:** Number of "Leave One Out" cross validation iterations to run while training.
+
+### Feature Computation
+
+Training and classification both need extracted features for the selected window size. When a project is opened, JABS scans the project's feature cache in the background to find out which videos already have them. If features are missing when you click **Train** or **Classify**, JABS warns you first: the run will still work, but the features are computed as it goes, which can take several minutes per video. You can continue anyway or cancel and precompute features for the whole project with the `jabs-features` command line tool.
+
+Training needs features only for the subjects you have labeled, while classification needs them for every subject in every video it processes, so **Classify** may warn when **Train** does not. Computed features are cached, so the warning goes away once a run has computed them. Use **Get Info** in the video list's right-click menu to see exactly what is cached for a video.
 
 ### Choosing a Classifier Type
 

--- a/src/jabs/resources/docs/user_guide/gui.md
+++ b/src/jabs/resources/docs/user_guide/gui.md
@@ -51,7 +51,7 @@ Right-click a video name to open a context menu:
 
 ### Feature Computation
 
-Training and classification both need extracted features for the selected window size. When a project is opened, JABS scans the project's feature cache in the background to find out which videos already have them. If features are missing when you click **Train** or **Classify**, JABS warns you first: the run will still work, but the features are computed as it goes, which can take several minutes per video. You can continue anyway or cancel and precompute features for the whole project with the `jabs-features` command line tool.
+Training and classification both need extracted features for the selected window size. When a project is opened, JABS scans the project's feature cache in the background to find out which videos already have them. If features are missing when you click **Train** or **Classify**, JABS warns you first: the run will still work, but the features are computed as it goes, which can take several minutes per video. You can continue anyway, or cancel and precompute features for the whole project with the `jabs-init` command line tool (`jabs-init -w <window size> <project directory>`).
 
 Training needs features only for the subjects you have labeled, while classification needs them for every subject in every video it processes, so **Classify** may warn when **Train** does not. Computed features are cached, so the warning goes away once a run has computed them. Use **Get Info** in the video list's right-click menu to see exactly what is cached for a video.
 

--- a/src/jabs/ui/dialogs/video_info_dialog.py
+++ b/src/jabs/ui/dialogs/video_info_dialog.py
@@ -226,9 +226,11 @@ class VideoInfoDialog(QDialog):
 
         form.addRow("Size on disk:", QLabel(format_byte_size(status.size_bytes)))
 
-        if any(not info.per_frame_present for info in status.identity_caches):
+        if missing_per_frame := status.identities_missing_per_frame:
+            identity_list = ", ".join(str(identity) for identity in missing_per_frame)
             form.addRow(
-                "Warning:", QLabel("Per-frame features are missing for one or more identities")
+                "Warning:",
+                QLabel(f"Per-frame features are missing for identities: {identity_list}"),
             )
 
     def sizeHint(self) -> QSize:

--- a/src/jabs/ui/dialogs/video_info_dialog.py
+++ b/src/jabs/ui/dialogs/video_info_dialog.py
@@ -19,6 +19,12 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from jabs.project import VideoFeatureCacheStatus
+from jabs.ui.feature_cache_text import (
+    format_byte_size,
+    format_cache_formats,
+    format_window_sizes,
+)
 from jabs.video_reader import VideoReader
 
 logger = logging.getLogger(__name__)
@@ -33,6 +39,9 @@ class VideoInfoDialog(QDialog):
         video_path: Absolute path to the video file.
         pose_path: Absolute path to the pose file.
         identity_count: Number of identities tracked in this video.
+        feature_cache_status: Status of this video's cached features. When
+            ``None``, the feature cache section reports that the status could
+            not be determined.
         parent: Parent widget for the dialog.
     """
 
@@ -41,6 +50,7 @@ class VideoInfoDialog(QDialog):
         video_path: Path,
         pose_path: Path,
         identity_count: int | None = None,
+        feature_cache_status: VideoFeatureCacheStatus | None = None,
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent)
@@ -98,6 +108,10 @@ class VideoInfoDialog(QDialog):
         pose_form.addRow("File:", QLabel(pose_path.name))
         layout.addLayout(pose_form)
 
+        # Model metadata is rendered after the feature cache section: it is the
+        # tallest element, so it belongs at the bottom of the dialog.
+        model_metadata: str | None = None
+
         # if this looks like a JABS style hdf5 pose file:
         #   look for static objects and the model_metadata_json attribute
         if re.search(r"pose_est_v\d+\.h5$", pose_path.name):
@@ -120,15 +134,7 @@ class VideoInfoDialog(QDialog):
                                 "Pose file model metadata is not valid JSON: %s", pose_path
                             )
                         else:
-                            metadata_label = QLabel("<b>Model Metadata</b>")
-                            layout.addWidget(metadata_label)
-                            text_view = QPlainTextEdit(formatted)
-                            text_view.setReadOnly(True)
-                            text_view.setMinimumHeight(150)
-                            text_view.setFont(
-                                QFontDatabase.systemFont(QFontDatabase.SystemFont.FixedFont)
-                            )
-                            layout.addWidget(text_view)
+                            model_metadata = formatted
 
             except OSError:
                 logger.exception("Could not open pose file for info: %s", pose_path)
@@ -137,10 +143,93 @@ class VideoInfoDialog(QDialog):
                 logger.exception("Missing expected key in pose file %s: %s", pose_path, e)
                 pose_form.addRow("Pose file:", QLabel("Unable to parse pose file"))
 
+        self._add_feature_cache_section(layout, feature_cache_status)
+
+        if model_metadata is not None:
+            layout.addWidget(QLabel("<b>Model Metadata</b>"))
+            text_view = QPlainTextEdit(model_metadata)
+            text_view.setReadOnly(True)
+            text_view.setMinimumHeight(150)
+            text_view.setFont(QFontDatabase.systemFont(QFontDatabase.SystemFont.FixedFont))
+            layout.addWidget(text_view)
+
         close_button = QPushButton("Close")
         close_button.clicked.connect(self.accept)
         close_button.setDefault(True)
         layout.addWidget(close_button, alignment=Qt.AlignmentFlag.AlignRight)
+
+    @staticmethod
+    def _path_label(path: Path) -> QLabel:
+        """Build a selectable, wrapping label for a filesystem path."""
+        label = QLabel(str(path))
+        label.setWordWrap(True)
+        label.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        return label
+
+    def _add_feature_cache_section(
+        self, layout: QVBoxLayout, status: VideoFeatureCacheStatus | None
+    ) -> None:
+        """Add a section describing this video's cached features.
+
+        Args:
+            layout: Dialog layout to append the section to.
+            status: The video's feature cache status, or ``None`` when it could
+                not be determined.
+        """
+        separator = QFrame()
+        separator.setFrameShape(QFrame.Shape.HLine)
+        separator.setFrameShadow(QFrame.Shadow.Sunken)
+        layout.addWidget(separator)
+        layout.addWidget(QLabel("<b>Feature Cache</b>"))
+
+        form = QFormLayout()
+        form.setLabelAlignment(Qt.AlignmentFlag.AlignLeft)
+        form.setFormAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
+        layout.addLayout(form)
+
+        if status is None:
+            form.addRow("Status:", QLabel("Unable to determine"))
+            return
+
+        form.addRow("Directory:", self._path_label(status.cache_dir))
+
+        if not status.has_cached_features:
+            form.addRow("Cached features:", QLabel("None"))
+            return
+
+        identities = str(status.cached_identity_count)
+        if status.expected_identity_count is not None:
+            identities = f"{status.cached_identity_count} of {status.expected_identity_count}"
+            if not status.is_complete:
+                identities += " (incomplete)"
+        form.addRow("Identities cached:", QLabel(identities))
+
+        form.addRow("Window sizes:", QLabel(format_window_sizes(status.window_sizes)))
+        if status.partial_window_sizes:
+            form.addRow(
+                "Partial window sizes:",
+                QLabel(
+                    f"{format_window_sizes(status.partial_window_sizes)} "
+                    "(cached for some identities only)"
+                ),
+            )
+
+        form.addRow("Format:", QLabel(format_cache_formats(status.cache_formats)))
+
+        versions = ", ".join(str(version) for version in status.feature_versions)
+        if status.is_stale:
+            versions += f" (out of date, current is {status.current_feature_version})"
+        form.addRow("Feature version:", QLabel(versions))
+
+        if status.cm_units is not None:
+            form.addRow("Distance units:", QLabel("cm" if status.cm_units else "pixels"))
+
+        form.addRow("Size on disk:", QLabel(format_byte_size(status.size_bytes)))
+
+        if any(not info.per_frame_present for info in status.identity_caches):
+            form.addRow(
+                "Warning:", QLabel("Per-frame features are missing for one or more identities")
+            )
 
     def sizeHint(self) -> QSize:
         """Provide size hint for the dialog.

--- a/src/jabs/ui/feature_cache_scan_thread.py
+++ b/src/jabs/ui/feature_cache_scan_thread.py
@@ -1,0 +1,59 @@
+"""Background scan of a project's feature cache."""
+
+import logging
+
+from PySide6.QtCore import QObject, QThread, Signal, SignalInstance
+
+from jabs.project import Project, scan_project_feature_cache
+
+logger = logging.getLogger(__name__)
+
+
+class FeatureCacheScanThread(QThread):
+    """Scans a project's on-disk feature cache without blocking the GUI.
+
+    The scan only reads cache metadata, but it touches every per-identity cache
+    directory in the project, which on a network filesystem is slow enough to be
+    worth keeping off the main thread.
+
+    Args:
+        project: Project whose feature cache should be scanned.
+        parent: Parent object; owns this thread for lifetime purposes.
+    """
+
+    # emits (project, dict[str, VideoFeatureCacheStatus]). The project is included
+    # so a receiver can discard results that arrive after a different project has
+    # been opened.
+    scan_complete: SignalInstance = Signal(object, object)
+
+    def __init__(self, project: Project, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+        self._project = project
+        self._should_terminate = False
+
+    def request_termination(self) -> None:
+        """Request the scan to stop at the next video boundary.
+
+        Partial results are discarded: nothing is emitted once termination has
+        been requested. Safe to call from the main Qt GUI thread; assignment to a
+        boolean is atomic in CPython, so no additional synchronization is needed
+        (the same approach used by the training and classification threads).
+        """
+        self._should_terminate = True
+
+    def run(self) -> None:
+        """Scan the project's feature cache and emit the per-video status."""
+        try:
+            statuses = scan_project_feature_cache(
+                self._project, should_continue=lambda: not self._should_terminate
+            )
+        except Exception:
+            # A failed scan only costs the cache status display, so log it and
+            # leave the status unknown rather than surfacing an error dialog.
+            logger.exception("Feature cache scan failed")
+            return
+
+        if self._should_terminate:
+            logger.debug("Feature cache scan terminated before completing")
+            return
+        self.scan_complete.emit(self._project, statuses)

--- a/src/jabs/ui/feature_cache_text.py
+++ b/src/jabs/ui/feature_cache_text.py
@@ -1,0 +1,66 @@
+"""Human-readable text for feature cache status.
+
+Used by the video info dialog's feature cache section. Deliberately free of Qt
+imports: these are pure string helpers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from jabs.core.enums import CacheFormat
+
+_SIZE_UNITS = ("bytes", "KiB", "MiB", "GiB", "TiB")
+
+_CACHE_FORMAT_NAMES = {CacheFormat.HDF5: "HDF5", CacheFormat.PARQUET: "Parquet"}
+
+
+def format_byte_size(num_bytes: int) -> str:
+    """Format a byte count for display.
+
+    Args:
+        num_bytes: Size in bytes.
+
+    Returns:
+        The size scaled to the largest unit that leaves a value of at least one,
+        for example ``"842 bytes"``, ``"12.4 MiB"``.
+    """
+    size = float(num_bytes)
+    for unit in _SIZE_UNITS:
+        if size < 1024 or unit == _SIZE_UNITS[-1]:
+            if unit == "bytes":
+                return f"{int(size)} bytes"
+            return f"{size:.1f} {unit}"
+        size /= 1024
+    # unreachable: the loop always returns on the last unit
+    raise AssertionError  # pragma: no cover
+
+
+def format_window_sizes(sizes: Sequence[int]) -> str:
+    """Format a collection of window sizes as a comma-separated list.
+
+    Args:
+        sizes: Window sizes, in the order they should be displayed.
+
+    Returns:
+        The sizes joined by commas, or ``"none"`` when empty.
+    """
+    return ", ".join(str(size) for size in sizes) if sizes else "none"
+
+
+def format_cache_formats(formats: Sequence[CacheFormat]) -> str:
+    """Format the storage formats found in a cache for display.
+
+    Args:
+        formats: Distinct cache formats found.
+
+    Returns:
+        The format's display name, or ``"Mixed (HDF5, Parquet)"`` style text when
+        more than one format is present. Empty input yields ``"unknown"``.
+    """
+    names = [_CACHE_FORMAT_NAMES.get(fmt, str(fmt)) for fmt in formats]
+    if not names:
+        return "unknown"
+    if len(names) == 1:
+        return names[0]
+    return f"Mixed ({', '.join(names)})"

--- a/src/jabs/ui/main_window/central_widget.py
+++ b/src/jabs/ui/main_window/central_widget.py
@@ -1008,22 +1008,9 @@ class CentralWidget(QtWidgets.QWidget):
 
         self._ensure_classifier_for_mode()
 
-        # training only reads features for labeled identities, so only those need
-        # to be cached to avoid computing features during the run
         window_size = self._feature_window_size()
-        labeled_identities = self._project.labeled_identities(self._training_behaviors())
-        if not self._confirm_on_demand_features(
-            self._project.videos_missing_window_features(
-                window_size, identities=labeled_identities
-            ),
-            window_size,
-            "training",
-        ):
+        if not self._confirm_training_features(window_size):
             return
-
-        # these are the only videos whose features this run can compute, so they
-        # are the only ones whose cache status goes stale
-        self._training_cache_targets = list(labeled_identities)
 
         # reset training report
         self._training_report_markdown = None
@@ -1073,6 +1060,38 @@ class CentralWidget(QtWidgets.QWidget):
 
         # start training thread
         self._training_thread.start()
+
+    def _confirm_training_features(self, window_size: int) -> bool:
+        """Check the feature cache for the videos training will read, and warn if needed.
+
+        Training only reads features for labeled identities, so only those need to
+        be cached to avoid computing features mid-run. Working out which identities
+        those are means reading every annotation file, so it is only done when the
+        cheaper whole-video check finds something missing: when every identity of
+        every video is cached, no subset of them can be missing.
+
+        Records the videos this run may compute features for, so only their cache
+        status is invalidated when it finishes.
+
+        Args:
+            window_size: Window size the run will extract features for.
+
+        Returns:
+            True if training should go ahead.
+        """
+        if not self._project.videos_missing_window_features(window_size):
+            self._training_cache_targets = []
+            return True
+
+        labeled_identities = self._project.labeled_identities(self._training_behaviors())
+        missing = self._project.videos_missing_window_features(
+            window_size, identities=labeled_identities
+        )
+        if not self._confirm_on_demand_features(missing, window_size, "training"):
+            return False
+
+        self._training_cache_targets = list(labeled_identities)
+        return True
 
     def _training_behaviors(self) -> list[str]:
         """Behaviors whose labels the next training run will use.
@@ -1304,7 +1323,7 @@ class CentralWidget(QtWidgets.QWidget):
         self.feature_cache_changed.emit()
 
     def _cleanup_classify_thread(self) -> None:
-        """clean up the training thread"""
+        """clean up the classification thread"""
         if self._classify_thread:
             self._classify_thread.deleteLater()
             self._classify_thread = None

--- a/src/jabs/ui/main_window/central_widget.py
+++ b/src/jabs/ui/main_window/central_widget.py
@@ -56,6 +56,10 @@ class CentralWidget(QtWidgets.QWidget):
     # auto-switch to a single video after it is classified from the context menu.
     request_video_selection = QtCore.Signal(str)
 
+    # Emitted when a run may have written to the feature cache, so the project's
+    # cache status can be rebuilt off the main thread.
+    feature_cache_changed = QtCore.Signal()
+
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
@@ -103,6 +107,9 @@ class CentralWidget(QtWidgets.QWidget):
         # videos targeted by the in-flight classification run (None == all videos),
         # used to decide how the completion handler updates the display
         self._classification_targets: list[str] | None = None
+        # videos the in-flight training run may compute features for (None == not
+        # known, so every video's cache status is invalidated when it finishes)
+        self._training_cache_targets: list[str] | None = None
         self._training_report_markdown: str | None = None
         self._training_report_dialog: TrainingReportDialog | None = None
 
@@ -1004,15 +1011,19 @@ class CentralWidget(QtWidgets.QWidget):
         # training only reads features for labeled identities, so only those need
         # to be cached to avoid computing features during the run
         window_size = self._feature_window_size()
+        labeled_identities = self._project.labeled_identities(self._training_behaviors())
         if not self._confirm_on_demand_features(
             self._project.videos_missing_window_features(
-                window_size,
-                identities=self._project.labeled_identities(self._training_behaviors()),
+                window_size, identities=labeled_identities
             ),
             window_size,
             "training",
         ):
             return
+
+        # these are the only videos whose features this run can compute, so they
+        # are the only ones whose cache status goes stale
+        self._training_cache_targets = list(labeled_identities)
 
         # reset training report
         self._training_report_markdown = None
@@ -1284,18 +1295,23 @@ class CentralWidget(QtWidgets.QWidget):
         if self._training_thread:
             self._training_thread.deleteLater()
             self._training_thread = None
-        # training caches any features it had to compute, including on a canceled
-        # or failed run, so the project's cache status is now out of date
-        self._project.invalidate_feature_cache_status()
+        # Training caches any features it had to compute, including on a canceled
+        # or failed run, so the status of the videos it read is out of date. Only
+        # those are dropped; the signal then rebuilds the whole status in the
+        # background, so the next train/classify check does not scan on this thread.
+        self._project.invalidate_feature_cache_status(self._training_cache_targets)
+        self._training_cache_targets = None
+        self.feature_cache_changed.emit()
 
     def _cleanup_classify_thread(self) -> None:
         """clean up the training thread"""
         if self._classify_thread:
             self._classify_thread.deleteLater()
             self._classify_thread = None
-        # classification caches any features it had to compute, including on a
-        # canceled or failed run, so the project's cache status is now out of date
-        self._project.invalidate_feature_cache_status()
+        # Same as _cleanup_training_thread, for the videos this run classified
+        # (``None`` means every video was targeted, so every status is dropped).
+        self._project.invalidate_feature_cache_status(self._classification_targets)
+        self.feature_cache_changed.emit()
 
     def _update_training_progress(self, step: int) -> None:
         """update progress bar with the number of completed tasks"""

--- a/src/jabs/ui/main_window/central_widget.py
+++ b/src/jabs/ui/main_window/central_widget.py
@@ -1079,13 +1079,14 @@ class CentralWidget(QtWidgets.QWidget):
         Returns:
             True if training should go ahead.
         """
-        if not self._project.videos_missing_window_features(window_size):
+        cm_units = self._feature_cm_units()
+        if not self._project.videos_missing_window_features(window_size, cm_units=cm_units):
             self._training_cache_targets = []
             return True
 
         labeled_identities = self._project.labeled_identities(self._training_behaviors())
         missing = self._project.videos_missing_window_features(
-            window_size, identities=labeled_identities
+            window_size, identities=labeled_identities, cm_units=cm_units
         )
         if not self._confirm_on_demand_features(missing, window_size, "training"):
             return False
@@ -1103,22 +1104,44 @@ class CentralWidget(QtWidgets.QWidget):
             return [MULTICLASS_NONE_BEHAVIOR, *self._controls.behaviors]
         return [self._controls.current_behavior]
 
-    def _feature_window_size(self) -> int:
-        """Window size that feature extraction will use for the current mode.
+    def _feature_op_settings(self) -> dict:
+        """Feature-extraction settings the next run will use.
 
-        Binary mode uses the current behavior's window size, which the window size
-        control keeps in sync. Multi-class mode shares one settings bundle across
-        behaviors, taken from the classifier when it has one and from the project
-        defaults otherwise, mirroring what the training and classify strategies do.
+        Binary mode uses the current behavior's settings. Multi-class mode shares
+        one bundle across behaviors, taken from the classifier when it has one and
+        from the project defaults otherwise, mirroring what the training and
+        classify strategies do.
         """
         if self._project.settings_manager.classifier_mode == ClassifierMode.MULTICLASS:
             settings = None
             if isinstance(self._classifier, MultiClassClassifier):
                 settings = self._classifier.project_settings
-            if not settings:
-                settings = self._project.get_project_defaults()
-            return int(settings.get("window_size", jabs.feature_extraction.DEFAULT_WINDOW_SIZE))
+            return settings or self._project.get_project_defaults()
+        return self._project.settings_manager.get_behavior(self._controls.current_behavior)
+
+    def _feature_window_size(self) -> int:
+        """Window size that feature extraction will use for the current mode.
+
+        Read from the window size control in binary mode, which is kept in sync
+        with the behavior's setting; multi-class mode takes it from the shared
+        settings bundle.
+        """
+        if self._project.settings_manager.classifier_mode == ClassifierMode.MULTICLASS:
+            return int(
+                self._feature_op_settings().get(
+                    "window_size", jabs.feature_extraction.DEFAULT_WINDOW_SIZE
+                )
+            )
         return self._window_size
+
+    def _feature_cm_units(self) -> bool:
+        """Whether the next run will ask for features in cm units.
+
+        ``IdentityFeatures`` treats the setting as a plain flag (the stored value is
+        a ``ProjectDistanceUnit``, whose ``PIXEL`` member is 0), so the same
+        truthiness test is used here.
+        """
+        return bool(self._feature_op_settings().get("cm_units", False))
 
     def _confirm_on_demand_features(
         self, videos_missing_features: list[str], window_size: int, action: str
@@ -1388,7 +1411,9 @@ class CentralWidget(QtWidgets.QWidget):
         # cached features to avoid computing features during the run
         window_size = self._feature_window_size()
         if not self._confirm_on_demand_features(
-            self._project.videos_missing_window_features(window_size, videos=videos),
+            self._project.videos_missing_window_features(
+                window_size, videos=videos, cm_units=self._feature_cm_units()
+            ),
             window_size,
             "classification",
         ):

--- a/src/jabs/ui/main_window/central_widget.py
+++ b/src/jabs/ui/main_window/central_widget.py
@@ -1148,8 +1148,9 @@ class CentralWidget(QtWidgets.QWidget):
                 f"Cached features for window size <b>{window_size}</b> were not found for "
                 f"<b>{count} {videos}</b>. JABS will compute them during {action}, which "
                 "can take several minutes per video.<br><br>"
-                "Features can be computed ahead of time with the <b>jabs-features</b> "
-                f"command line tool.<br><br>Continue with {action}?"
+                "Features can be computed ahead of time with the <b>jabs-init</b> command "
+                f"line tool: <tt>jabs-init -w {window_size} &lt;project directory&gt;</tt>"
+                f"<br><br>Continue with {action}?"
             ),
             details="Videos needing feature computation:\n" + "\n".join(videos_missing_features),
         )

--- a/src/jabs/ui/main_window/central_widget.py
+++ b/src/jabs/ui/main_window/central_widget.py
@@ -1001,6 +1001,19 @@ class CentralWidget(QtWidgets.QWidget):
 
         self._ensure_classifier_for_mode()
 
+        # training only reads features for labeled identities, so only those need
+        # to be cached to avoid computing features during the run
+        window_size = self._feature_window_size()
+        if not self._confirm_on_demand_features(
+            self._project.videos_missing_window_features(
+                window_size,
+                identities=self._project.labeled_identities(self._training_behaviors()),
+            ),
+            window_size,
+            "training",
+        ):
+            return
+
         # reset training report
         self._training_report_markdown = None
 
@@ -1049,6 +1062,67 @@ class CentralWidget(QtWidgets.QWidget):
 
         # start training thread
         self._training_thread.start()
+
+    def _training_behaviors(self) -> list[str]:
+        """Behaviors whose labels the next training run will use.
+
+        Multi-class training trains on every behavior plus the reserved "None"
+        class; binary training uses only the current behavior.
+        """
+        if self._project.settings_manager.classifier_mode == ClassifierMode.MULTICLASS:
+            return [MULTICLASS_NONE_BEHAVIOR, *self._controls.behaviors]
+        return [self._controls.current_behavior]
+
+    def _feature_window_size(self) -> int:
+        """Window size that feature extraction will use for the current mode.
+
+        Binary mode uses the current behavior's window size, which the window size
+        control keeps in sync. Multi-class mode shares one settings bundle across
+        behaviors, taken from the classifier when it has one and from the project
+        defaults otherwise, mirroring what the training and classify strategies do.
+        """
+        if self._project.settings_manager.classifier_mode == ClassifierMode.MULTICLASS:
+            settings = None
+            if isinstance(self._classifier, MultiClassClassifier):
+                settings = self._classifier.project_settings
+            if not settings:
+                settings = self._project.get_project_defaults()
+            return int(settings.get("window_size", jabs.feature_extraction.DEFAULT_WINDOW_SIZE))
+        return self._window_size
+
+    def _confirm_on_demand_features(
+        self, videos_missing_features: list[str], window_size: int, action: str
+    ) -> bool:
+        """Warn that features are not cached and let the user cancel.
+
+        Args:
+            videos_missing_features: Videos whose features for ``window_size``
+                are not cached and would be computed during the run.
+            window_size: Window size the features are needed for.
+            action: What is about to run, used in the prompt ("training" or
+                "classification").
+
+        Returns:
+            True to go ahead: either everything needed is already cached, or the
+            user chose to continue anyway.
+        """
+        if not videos_missing_features:
+            return True
+
+        count = len(videos_missing_features)
+        videos = "video" if count == 1 else "videos"
+        return MessageDialog.confirm(
+            self,
+            title="Features Not Cached",
+            message=(
+                f"Cached features for window size <b>{window_size}</b> were not found for "
+                f"<b>{count} {videos}</b>. JABS will compute them during {action}, which "
+                "can take several minutes per video.<br><br>"
+                "Features can be computed ahead of time with the <b>jabs-features</b> "
+                f"command line tool.<br><br>Continue with {action}?"
+            ),
+            details="Videos needing feature computation:\n" + "\n".join(videos_missing_features),
+        )
 
     def _ensure_classifier_for_mode(self) -> None:
         """Ensure the active classifier instance matches the current classifier mode."""
@@ -1210,12 +1284,18 @@ class CentralWidget(QtWidgets.QWidget):
         if self._training_thread:
             self._training_thread.deleteLater()
             self._training_thread = None
+        # training caches any features it had to compute, including on a canceled
+        # or failed run, so the project's cache status is now out of date
+        self._project.invalidate_feature_cache_status()
 
     def _cleanup_classify_thread(self) -> None:
         """clean up the training thread"""
         if self._classify_thread:
             self._classify_thread.deleteLater()
             self._classify_thread = None
+        # classification caches any features it had to compute, including on a
+        # canceled or failed run, so the project's cache status is now out of date
+        self._project.invalidate_feature_cache_status()
 
     def _update_training_progress(self, step: int) -> None:
         """update progress bar with the number of completed tasks"""
@@ -1261,6 +1341,16 @@ class CentralWidget(QtWidgets.QWidget):
         # make sure video playback is stopped
         self._player_widget.stop()
         self._ensure_classifier_for_mode()
+
+        # every identity of every target video is classified, so all of them need
+        # cached features to avoid computing features during the run
+        window_size = self._feature_window_size()
+        if not self._confirm_on_demand_features(
+            self._project.videos_missing_window_features(window_size, videos=videos),
+            window_size,
+            "classification",
+        ):
+            return
 
         self._classification_targets = videos
         current_video = self._loaded_video.name if self._loaded_video else ""

--- a/src/jabs/ui/main_window/central_widget.py
+++ b/src/jabs/ui/main_window/central_widget.py
@@ -1324,13 +1324,19 @@ class CentralWidget(QtWidgets.QWidget):
         self.feature_cache_changed.emit()
 
     def _cleanup_classify_thread(self) -> None:
-        """clean up the classification thread"""
+        """clean up the classification thread
+
+        Owns the end of the run's lifecycle, including clearing the target list:
+        this runs on the completion, cancel and failure paths, so leaving the
+        targets set would keep stale state on the widget after a canceled run.
+        """
         if self._classify_thread:
             self._classify_thread.deleteLater()
             self._classify_thread = None
         # Same as _cleanup_training_thread, for the videos this run classified
         # (``None`` means every video was targeted, so every status is dropped).
         self._project.invalidate_feature_cache_status(self._classification_targets)
+        self._classification_targets = None
         self.feature_cache_changed.emit()
 
     def _update_training_progress(self, step: int) -> None:
@@ -1416,12 +1422,12 @@ class CentralWidget(QtWidgets.QWidget):
 
     def _classify_thread_complete(self, output: dict, elapsed_ms: int) -> None:
         """update the gui when the classification is complete"""
+        # read before the cleanup below, which clears the targets
         targets = self._classification_targets
         loaded_video = self._loaded_video.name if self._loaded_video else None
 
         self._cleanup_progress_dialog()
         self._cleanup_classify_thread()
-        self._classification_targets = None
         self.status_message.emit(
             f"Classification Complete. Elapsed time: {elapsed_ms / 1000:.1f}s", 20000
         )

--- a/src/jabs/ui/main_window/central_widget.py
+++ b/src/jabs/ui/main_window/central_widget.py
@@ -1173,6 +1173,7 @@ class CentralWidget(QtWidgets.QWidget):
                 "can take several minutes per video.<br><br>"
                 "Features can be computed ahead of time with the <b>jabs-init</b> command "
                 f"line tool: <tt>jabs-init -w {window_size} &lt;project directory&gt;</tt>"
+                f"<br>See <tt>jabs-init --help</tt> for more options."
                 f"<br><br>Continue with {action}?"
             ),
             details="Videos needing feature computation:\n" + "\n".join(videos_missing_features),

--- a/src/jabs/ui/main_window/main_window.py
+++ b/src/jabs/ui/main_window/main_window.py
@@ -31,9 +31,13 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# How long to wait at shutdown for a running feature cache scan, so the thread is
-# not destroyed mid-run. The scan is short; this is only a safety margin.
+# How long to wait at shutdown for a running feature cache scan to stop on its own,
+# so the thread is not destroyed mid-run. The scan is short; this is only a safety
+# margin.
 _FEATURE_CACHE_SCAN_SHUTDOWN_WAIT_MS = 2000
+
+# How long to wait after forcing a scan thread that ignored the cooperative stop.
+_FEATURE_CACHE_SCAN_TERMINATE_WAIT_MS = 1000
 
 
 class MainWindow(QtWidgets.QMainWindow):
@@ -392,6 +396,38 @@ class MainWindow(QtWidgets.QMainWindow):
             return
         self._start_feature_cache_scan()
 
+    def _stop_feature_cache_scan(self) -> None:
+        """Make sure no feature cache scan is running before the window is destroyed.
+
+        A QThread destroyed while still running aborts the process, and the scan
+        thread is a child of this window, so it has to be finished by the time the
+        window goes away.
+
+        The cooperative stop is checked between videos, which cannot interrupt a
+        filesystem call that is not responding. Rather than block the quit
+        indefinitely on a wedged mount, an unresponsive scan is forced: it only
+        reads cache metadata, so terminating it cannot corrupt project data, and a
+        failed cache scan costs nothing but the status it would have produced.
+        """
+        thread = self._feature_cache_scan_thread
+        if thread is None:
+            return
+
+        thread.request_termination()
+        if thread.wait(_FEATURE_CACHE_SCAN_SHUTDOWN_WAIT_MS):
+            return
+
+        logger.warning(
+            "Feature cache scan did not stop within %d ms (unresponsive storage?); "
+            "terminating the thread",
+            _FEATURE_CACHE_SCAN_SHUTDOWN_WAIT_MS,
+        )
+        thread.terminate()
+        if not thread.wait(_FEATURE_CACHE_SCAN_TERMINATE_WAIT_MS):
+            # Nothing further can be done from here; log it so the cause of a
+            # noisy exit is on the record.
+            logger.error("Feature cache scan thread could not be stopped before shutdown")
+
     def _start_feature_cache_scan(self) -> None:
         """Start a feature cache scan thread for the current project."""
         # parented to this window so it stays alive while running, and deleted
@@ -529,14 +565,12 @@ class MainWindow(QtWidgets.QMainWindow):
 
         Ensures proper cleanup of the process pool before the application exits.
         The pre-initialized process pool is shut down in a non-blocking manner. A
-        feature cache scan still in flight is asked to stop and briefly waited on,
-        so its thread is not destroyed mid-run.
+        feature cache scan still in flight is stopped first, so its thread is not
+        destroyed mid-run (see :meth:`_stop_feature_cache_scan`).
         """
         # drop any queued rescan first so the finished thread does not start one
         self._feature_cache_scan_pending = False
-        if self._feature_cache_scan_thread is not None:
-            self._feature_cache_scan_thread.request_termination()
-            self._feature_cache_scan_thread.wait(_FEATURE_CACHE_SCAN_SHUTDOWN_WAIT_MS)
+        self._stop_feature_cache_scan()
         logger.debug("[MainWindow] closeEvent: shutting down process pool")
         self._process_pool.shutdown(wait=False, cancel_futures=True)
         super().closeEvent(event)

--- a/src/jabs/ui/main_window/main_window.py
+++ b/src/jabs/ui/main_window/main_window.py
@@ -1,6 +1,7 @@
 import logging
 import traceback
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from PySide6 import QtCore, QtGui, QtWidgets
 from PySide6.QtCore import QEvent, Qt
@@ -16,6 +17,7 @@ from ..constants import (
 )
 from ..dialogs import MessageDialog
 from ..dialogs.progress_dialog import create_progress_dialog
+from ..feature_cache_scan_thread import FeatureCacheScanThread
 from ..player_widget import PlayerWidget
 from ..project_loader_thread import ProjectLoaderThread
 from .central_widget import CentralWidget
@@ -24,7 +26,14 @@ from .menu_builder import MenuBuilder
 from .menu_handlers import MenuHandlers
 from .video_list_widget import VideoListDockWidget
 
+if TYPE_CHECKING:
+    from jabs.project import Project, VideoFeatureCacheStatus
+
 logger = logging.getLogger(__name__)
+
+# How long to wait at shutdown for a running feature cache scan, so the thread is
+# not destroyed mid-run. The scan is short; this is only a safety margin.
+_FEATURE_CACHE_SCAN_SHUTDOWN_WAIT_MS = 2000
 
 
 class MainWindow(QtWidgets.QMainWindow):
@@ -64,6 +73,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._app_name_long = app_name_long
         self._project = None
         self._project_loader_thread = None
+        self._feature_cache_scan_thread: FeatureCacheScanThread | None = None
         self._progress_dialog = None
         self._user_guide_window = None
         self._previous_identity_overlay_mode = PlayerWidget.IdentityOverlayMode.FLOATING
@@ -347,9 +357,57 @@ class MainWindow(QtWidgets.QMainWindow):
         # update the recent project menu
         self._add_recent_project(self._project.project_paths.project_dir)
 
+        # find out which videos already have cached features, without blocking
+        self.refresh_feature_cache_status()
+
         self._progress_dialog.close()
         self._progress_dialog.deleteLater()
         self._progress_dialog = None
+
+    def refresh_feature_cache_status(self) -> None:
+        """Scan the current project's feature cache in a background thread.
+
+        The results are stored on the project, where the video info dialog and
+        the train/classify warnings read them. Safe to call whenever the cache
+        may have changed; a scan already in progress is left to finish, and
+        results for a project that is no longer open are discarded.
+        """
+        if self._project is None:
+            return
+        # parented to this window so it stays alive while running, and deleted
+        # once it finishes
+        thread = FeatureCacheScanThread(self._project, parent=self)
+        thread.scan_complete.connect(self._feature_cache_scan_complete)
+        thread.finished.connect(lambda t=thread: self._feature_cache_scan_finished(t))
+        self._feature_cache_scan_thread = thread
+        thread.start()
+
+    def _feature_cache_scan_complete(
+        self, project: "Project", statuses: "dict[str, VideoFeatureCacheStatus]"
+    ) -> None:
+        """Store feature cache scan results on the project.
+
+        Args:
+            project: The project that was scanned. Results for a project that is
+                no longer open are discarded.
+            statuses: Per-video feature cache status keyed by video filename.
+        """
+        if project is not self._project:
+            logger.debug("Discarding feature cache scan results for a closed project")
+            return
+        project.set_feature_cache_status(statuses)
+
+    def _feature_cache_scan_finished(self, thread: FeatureCacheScanThread) -> None:
+        """Release a finished feature cache scan thread.
+
+        Args:
+            thread: The thread that finished. Only clears the tracked reference
+                if it is still the current scan, since a newer scan may have
+                started in the meantime.
+        """
+        if self._feature_cache_scan_thread is thread:
+            self._feature_cache_scan_thread = None
+        thread.deleteLater()
 
     def _project_load_error_callback(self, error: Exception) -> None:
         """Callback function to be called when the project fails to load."""
@@ -435,8 +493,13 @@ class MainWindow(QtWidgets.QMainWindow):
         """Handle the close event for the main window.
 
         Ensures proper cleanup of the process pool before the application exits.
-        The pre-initialized process pool is shut down in a non-blocking manner.
+        The pre-initialized process pool is shut down in a non-blocking manner. A
+        feature cache scan still in flight is asked to stop and briefly waited on,
+        so its thread is not destroyed mid-run.
         """
+        if self._feature_cache_scan_thread is not None:
+            self._feature_cache_scan_thread.request_termination()
+            self._feature_cache_scan_thread.wait(_FEATURE_CACHE_SCAN_SHUTDOWN_WAIT_MS)
         logger.debug("[MainWindow] closeEvent: shutting down process pool")
         self._process_pool.shutdown(wait=False, cancel_futures=True)
         super().closeEvent(event)

--- a/src/jabs/ui/main_window/main_window.py
+++ b/src/jabs/ui/main_window/main_window.py
@@ -74,6 +74,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self._project = None
         self._project_loader_thread = None
         self._feature_cache_scan_thread: FeatureCacheScanThread | None = None
+        # a refresh was requested while a scan was running; it starts when that
+        # scan finishes, keeping at most one scan in flight
+        self._feature_cache_scan_pending = False
         self._progress_dialog = None
         self._user_guide_window = None
         self._previous_identity_overlay_mode = PlayerWidget.IdentityOverlayMode.FLOATING
@@ -371,12 +374,26 @@ class MainWindow(QtWidgets.QMainWindow):
         """Scan the current project's feature cache in a background thread.
 
         The results are stored on the project, where the video info dialog and
-        the train/classify warnings read them. Safe to call whenever the cache
-        may have changed; a scan already in progress is left to finish, and
-        results for a project that is no longer open are discarded.
+        the train/classify warnings read them. Safe to call whenever the cache may
+        have changed; results for a project that is no longer open are discarded.
+
+        Only one scan is ever in flight. When one is already running, it is asked
+        to stop and a replacement is queued for when it does, so repeated calls
+        (project open, clearing the cache, each finished training or
+        classification run) never pile up concurrent passes over the feature
+        directory, and shutdown always has a single thread to wait on.
         """
         if self._project is None:
             return
+        if self._feature_cache_scan_thread is not None:
+            logger.debug("Feature cache scan already running; queueing a rescan")
+            self._feature_cache_scan_pending = True
+            self._feature_cache_scan_thread.request_termination()
+            return
+        self._start_feature_cache_scan()
+
+    def _start_feature_cache_scan(self) -> None:
+        """Start a feature cache scan thread for the current project."""
         # parented to this window so it stays alive while running, and deleted
         # once it finishes
         thread = FeatureCacheScanThread(self._project, parent=self)
@@ -410,7 +427,7 @@ class MainWindow(QtWidgets.QMainWindow):
         project.set_feature_cache_status(statuses)
 
     def _feature_cache_scan_finished(self, thread: FeatureCacheScanThread) -> None:
-        """Release a finished feature cache scan thread.
+        """Release a finished feature cache scan thread, starting any queued rescan.
 
         Args:
             thread: The thread that finished. Only clears the tracked reference
@@ -420,6 +437,12 @@ class MainWindow(QtWidgets.QMainWindow):
         if self._feature_cache_scan_thread is thread:
             self._feature_cache_scan_thread = None
         thread.deleteLater()
+
+        # a refresh requested while this scan was running (its results are stale
+        # or were discarded when it was asked to stop) runs now
+        if self._feature_cache_scan_pending and self._project is not None:
+            self._feature_cache_scan_pending = False
+            self._start_feature_cache_scan()
 
     def _project_load_error_callback(self, error: Exception) -> None:
         """Callback function to be called when the project fails to load."""
@@ -509,6 +532,8 @@ class MainWindow(QtWidgets.QMainWindow):
         feature cache scan still in flight is asked to stop and briefly waited on,
         so its thread is not destroyed mid-run.
         """
+        # drop any queued rescan first so the finished thread does not start one
+        self._feature_cache_scan_pending = False
         if self._feature_cache_scan_thread is not None:
             self._feature_cache_scan_thread.request_termination()
             self._feature_cache_scan_thread.wait(_FEATURE_CACHE_SCAN_SHUTDOWN_WAIT_MS)

--- a/src/jabs/ui/main_window/main_window.py
+++ b/src/jabs/ui/main_window/main_window.py
@@ -109,6 +109,9 @@ class MainWindow(QtWidgets.QMainWindow):
             self._menu_refs.export_training.setEnabled
         )
         self._central_widget.search_results_changed.connect(self.video_list.show_search_results)
+        # a training or classification run may have computed features; rebuild the
+        # project's cache status in the background rather than on the next click
+        self._central_widget.feature_cache_changed.connect(self.refresh_feature_cache_status)
         self._central_widget.bbox_overlay_supported.connect(
             self.menu_handlers.on_bbox_overlay_support_changed
         )
@@ -387,6 +390,12 @@ class MainWindow(QtWidgets.QMainWindow):
     ) -> None:
         """Store feature cache scan results on the project.
 
+        Results replace the project's whole status, so only the most recent scan
+        may be applied: an earlier scan still finishing (for example one started
+        at project open, now superseded by one started after a training run) would
+        otherwise write back what the cache looked like before those features were
+        computed.
+
         Args:
             project: The project that was scanned. Results for a project that is
                 no longer open are discarded.
@@ -394,6 +403,9 @@ class MainWindow(QtWidgets.QMainWindow):
         """
         if project is not self._project:
             logger.debug("Discarding feature cache scan results for a closed project")
+            return
+        if self.sender() is not self._feature_cache_scan_thread:
+            logger.debug("Discarding feature cache scan results from a superseded scan")
             return
         project.set_feature_cache_status(statuses)
 

--- a/src/jabs/ui/main_window/menu_handlers.py
+++ b/src/jabs/ui/main_window/menu_handlers.py
@@ -335,7 +335,10 @@ class MenuHandlers:
             message=f"Are you sure you want to delete all cached feature files?{hint}",
         )
         if result:
+            # clear_feature_cache() discards the project's stored cache status;
+            # rescan so it reflects the now-empty cache
             project.clear_feature_cache()
+            self.window.refresh_feature_cache_status()
             self.window.display_status_message("Feature cache cleared", duration=3000)
 
     # ========== App Menu Handlers ==========

--- a/src/jabs/ui/main_window/video_list_widget.py
+++ b/src/jabs/ui/main_window/video_list_widget.py
@@ -1,8 +1,13 @@
+import logging
+
 from PySide6 import QtCore, QtGui, QtWidgets
 
 from jabs.behavior_search import SearchHit
+from jabs.project import VideoFeatureCacheStatus
 from jabs.ui.dialogs.message_dialog import MessageDialog
 from jabs.ui.dialogs.video_info_dialog import VideoInfoDialog
+
+logger = logging.getLogger(__name__)
 
 # Item data role storing whether a video is excluded from training (bool).
 # Kept separate from the displayed text so it survives text changes (e.g. search
@@ -277,8 +282,37 @@ class VideoListDockWidget(QtWidgets.QDockWidget):
         except ValueError:
             MessageDialog.error(self, "No pose file found for this video.")
             return
-        dialog = VideoInfoDialog(video_path, pose_path, identity_count=identity_count, parent=self)
+        dialog = VideoInfoDialog(
+            video_path,
+            pose_path,
+            identity_count=identity_count,
+            feature_cache_status=self._feature_cache_status(video_name),
+            parent=self,
+        )
         dialog.exec()
+
+    def _feature_cache_status(self, video_name: str) -> VideoFeatureCacheStatus | None:
+        """Return up-to-date feature cache status for one video.
+
+        The project keeps the results of the background scan performed when it was
+        opened, but those can be out of date by the time the user asks for a
+        video's info (features may have been computed, or the cache cleared,
+        since then). Re-scanning a single video only reads a few small metadata
+        files, so it is done on demand to keep the displayed information accurate.
+
+        Args:
+            video_name: The video filename key used in the project.
+
+        Returns:
+            The video's cache status, or ``None`` if it could not be determined.
+        """
+        if self._project is None:
+            return None
+        try:
+            return self._project.refresh_feature_cache_status(video_name)
+        except OSError:
+            logger.warning("Could not scan feature cache for %s", video_name, exc_info=True)
+            return self._project.feature_cache_status.get(video_name)
 
     def set_classify_available(self, available: bool) -> None:
         """Set whether the "Classify Video" context-menu action is available.

--- a/tests/project/test_feature_cache_status.py
+++ b/tests/project/test_feature_cache_status.py
@@ -1,0 +1,370 @@
+"""Tests for per-video feature cache status scanning and aggregation."""
+
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+import pytest
+
+from jabs.core.enums import CacheFormat
+from jabs.core.types import FeatureCacheMetadata, PerFrameCacheData
+from jabs.io.feature_cache import IdentityCacheInfo
+from jabs.io.feature_cache.hdf5 import HDF5FeatureCacheWriter
+from jabs.project.feature_cache_status import (
+    VideoFeatureCacheStatus,
+    scan_project_feature_cache,
+    scan_video_feature_cache,
+)
+
+_N_FRAMES = 10
+_CURRENT_VERSION = 17
+
+
+def _identity_cache(
+    identity: int = 0,
+    window_sizes: frozenset[int] = frozenset(),
+    feature_version: int = _CURRENT_VERSION,
+    cache_format: CacheFormat = CacheFormat.PARQUET,
+    per_frame_present: bool = True,
+    distance_scale_factor: float | None = None,
+    size_bytes: int = 100,
+    directory: Path | None = None,
+) -> IdentityCacheInfo:
+    """Build an IdentityCacheInfo without touching the filesystem."""
+    return IdentityCacheInfo(
+        directory=directory or Path(f"/features/video/{identity}"),
+        identity=identity,
+        cache_format=cache_format,
+        feature_version=feature_version,
+        pose_hash="hash",
+        num_frames=_N_FRAMES,
+        distance_scale_factor=distance_scale_factor,
+        window_sizes=window_sizes,
+        per_frame_present=per_frame_present,
+        size_bytes=size_bytes,
+    )
+
+
+def _status(*caches: IdentityCacheInfo, expected_identity_count: int | None = None):
+    """Build a VideoFeatureCacheStatus around the given identity caches."""
+    return VideoFeatureCacheStatus(
+        video="video.mp4",
+        cache_dir=Path("/features/video"),
+        identity_caches=caches,
+        current_feature_version=_CURRENT_VERSION,
+        expected_identity_count=expected_identity_count,
+    )
+
+
+def _write_hdf5_cache(
+    identity_dir: Path,
+    identity: int,
+    window_sizes: tuple[int, ...] = (),
+    feature_version: int = _CURRENT_VERSION,
+) -> None:
+    """Write a small HDF5 feature cache for one identity."""
+    writer = HDF5FeatureCacheWriter()
+    metadata = FeatureCacheMetadata(
+        feature_version=feature_version,
+        identity=identity,
+        num_frames=_N_FRAMES,
+        pose_hash="posehash",
+    )
+    data = PerFrameCacheData(
+        frame_valid=np.ones(_N_FRAMES, dtype=np.uint8),
+        features={"mod feat": np.zeros(_N_FRAMES)},
+    )
+    writer.write_per_frame(identity_dir, metadata, data)
+    for size in window_sizes:
+        writer.write_window(identity_dir, metadata, size, {"mod mean feat": np.zeros(_N_FRAMES)})
+
+
+# ---------------------------------------------------------------------------
+# VideoFeatureCacheStatus aggregation
+# ---------------------------------------------------------------------------
+
+
+def test_empty_status_reports_nothing_cached():
+    """A status with no identity caches reports no cached features."""
+    status = _status(expected_identity_count=3)
+
+    assert status.has_cached_features is False
+    assert status.cached_identity_count == 0
+    assert status.window_sizes == ()
+    assert status.partial_window_sizes == ()
+    assert status.is_complete is False
+    assert status.is_stale is False
+    assert status.cm_units is None
+    assert status.size_bytes == 0
+
+
+def test_window_sizes_are_intersection_across_identities():
+    """Only window sizes cached for every identity count as available."""
+    status = _status(
+        _identity_cache(identity=0, window_sizes=frozenset({5, 10, 30})),
+        _identity_cache(identity=1, window_sizes=frozenset({5, 10})),
+        _identity_cache(identity=2, window_sizes=frozenset({10})),
+    )
+
+    assert status.window_sizes == (10,)
+    assert status.partial_window_sizes == (5, 30)
+
+
+def test_window_sizes_merge_across_pose_hash_directories():
+    """Caches sharing an identity are merged rather than counted separately."""
+    status = _status(
+        _identity_cache(identity=0, window_sizes=frozenset({5}), directory=Path("/f/v/hash_a/0")),
+        _identity_cache(identity=0, window_sizes=frozenset({10}), directory=Path("/f/v/hash_b/0")),
+        expected_identity_count=1,
+    )
+
+    assert status.cached_identity_count == 1
+    assert status.window_sizes == (5, 10)
+    assert status.partial_window_sizes == ()
+    assert status.is_complete is True
+
+
+def test_has_window_features_requires_every_identity():
+    """With no identities named, every identity in the video must be covered."""
+    status = _status(
+        _identity_cache(identity=0, window_sizes=frozenset({5, 10})),
+        _identity_cache(identity=1, window_sizes=frozenset({5})),
+        expected_identity_count=2,
+    )
+
+    assert status.has_window_features(5) is True
+    assert status.has_window_features(10) is False
+
+
+def test_has_window_features_unknown_identity_count():
+    """Without a known identity count, full coverage cannot be confirmed."""
+    status = _status(_identity_cache(identity=0, window_sizes=frozenset({5})))
+
+    assert status.has_window_features(5) is False
+
+
+def test_has_window_features_for_named_identities():
+    """Naming the identities that matter ignores the uncached ones."""
+    status = _status(
+        _identity_cache(identity=0, window_sizes=frozenset({5})),
+        expected_identity_count=3,
+    )
+
+    assert status.has_window_features(5, [0]) is True
+    assert status.has_window_features(5, [0, 1]) is False
+    # nothing needed, so nothing is missing
+    assert status.has_window_features(5, []) is True
+
+
+def test_has_window_features_without_any_cache():
+    """A video with no cache never covers a window size."""
+    assert _status(expected_identity_count=2).has_window_features(5) is False
+    assert _status().has_window_features(5, [0]) is False
+
+
+@pytest.mark.parametrize(
+    ("cached_identities", "expected_count", "complete"),
+    [(2, 2, True), (1, 2, False), (2, None, False)],
+    ids=["all-cached", "partially-cached", "unknown-identity-count"],
+)
+def test_is_complete_requires_every_identity(cached_identities, expected_count, complete):
+    """is_complete is only True when every known identity has a cache."""
+    caches = tuple(_identity_cache(identity=i) for i in range(cached_identities))
+    status = _status(*caches, expected_identity_count=expected_count)
+
+    assert status.is_complete is complete
+
+
+def test_is_complete_false_when_per_frame_features_missing():
+    """An identity whose per-frame features are absent makes the cache incomplete."""
+    status = _status(
+        _identity_cache(identity=0),
+        _identity_cache(identity=1, per_frame_present=False),
+        expected_identity_count=2,
+    )
+
+    assert status.is_complete is False
+
+
+def test_stale_cache_detected_from_feature_version():
+    """A cache written by another feature version is reported as stale."""
+    status = _status(_identity_cache(feature_version=_CURRENT_VERSION - 1))
+
+    assert status.is_stale is True
+    assert status.feature_versions == (_CURRENT_VERSION - 1,)
+
+
+def test_current_cache_not_stale():
+    """A cache written by the current feature version is not stale."""
+    assert _status(_identity_cache()).is_stale is False
+
+
+def test_mixed_cache_formats_reported():
+    """Both formats are reported when the cache directory is mixed."""
+    status = _status(
+        _identity_cache(identity=0, cache_format=CacheFormat.HDF5),
+        _identity_cache(identity=1, cache_format=CacheFormat.PARQUET),
+    )
+
+    assert set(status.cache_formats) == {CacheFormat.HDF5, CacheFormat.PARQUET}
+
+
+@pytest.mark.parametrize(
+    ("scales", "expected"),
+    [((0.1, 0.1), True), ((None, None), False), ((0.1, None), None)],
+    ids=["cm", "pixels", "mixed"],
+)
+def test_cm_units_reflects_distance_scale_factors(scales, expected):
+    """cm_units is True/False only when every cache agrees."""
+    caches = tuple(
+        _identity_cache(identity=i, distance_scale_factor=scale) for i, scale in enumerate(scales)
+    )
+
+    assert _status(*caches).cm_units is expected
+
+
+def test_size_bytes_sums_identity_caches():
+    """The reported size is the total across every identity cache."""
+    status = _status(
+        _identity_cache(identity=0, size_bytes=100),
+        _identity_cache(identity=1, size_bytes=250),
+    )
+
+    assert status.size_bytes == 350
+
+
+# ---------------------------------------------------------------------------
+# scan_video_feature_cache
+# ---------------------------------------------------------------------------
+
+
+def test_scan_video_finds_flat_layout(tmp_path):
+    """Identity directories directly under the video directory are found."""
+    feature_dir = tmp_path / "features"
+    _write_hdf5_cache(feature_dir / "video1" / "0", identity=0, window_sizes=(5, 10))
+    _write_hdf5_cache(feature_dir / "video1" / "1", identity=1, window_sizes=(5,))
+
+    status = scan_video_feature_cache(
+        feature_dir,
+        "video1.mp4",
+        current_feature_version=_CURRENT_VERSION,
+        expected_identity_count=2,
+    )
+
+    assert status.cache_dir == feature_dir / "video1"
+    assert status.cached_identity_count == 2
+    assert status.window_sizes == (5,)
+    assert status.partial_window_sizes == (10,)
+    assert status.cache_formats == (CacheFormat.HDF5,)
+    assert status.is_complete is True
+
+
+def test_scan_video_finds_pose_hash_layout(tmp_path):
+    """Identity directories nested under a pose-hash directory are found."""
+    feature_dir = tmp_path / "features"
+    _write_hdf5_cache(feature_dir / "video1" / "deadbeef" / "0", identity=0, window_sizes=(5,))
+
+    status = scan_video_feature_cache(
+        feature_dir, "video1.mp4", current_feature_version=_CURRENT_VERSION
+    )
+
+    assert status.cached_identity_count == 1
+    assert status.window_sizes == (5,)
+    assert status.identity_caches[0].directory == feature_dir / "video1" / "deadbeef" / "0"
+
+
+def test_scan_video_accepts_pose_filename(tmp_path):
+    """A pose filename resolves to the same cache directory as the video."""
+    feature_dir = tmp_path / "features"
+    _write_hdf5_cache(feature_dir / "video1" / "0", identity=0)
+
+    status = scan_video_feature_cache(
+        feature_dir, "video1_pose_est_v6.h5", current_feature_version=_CURRENT_VERSION
+    )
+
+    assert status.cache_dir == feature_dir / "video1"
+    assert status.has_cached_features is True
+
+
+def test_scan_video_with_no_cache_directory(tmp_path):
+    """A video with no cache directory reports nothing cached, without error."""
+    feature_dir = tmp_path / "features"
+    feature_dir.mkdir()
+
+    status = scan_video_feature_cache(
+        feature_dir, "video1.mp4", current_feature_version=_CURRENT_VERSION
+    )
+
+    assert status.cache_dir == feature_dir / "video1"
+    assert status.has_cached_features is False
+
+
+def test_scan_video_ignores_stray_files_and_empty_directories(tmp_path):
+    """Files and cache-free directories under the video directory are skipped."""
+    feature_dir = tmp_path / "features"
+    video_dir = feature_dir / "video1"
+    _write_hdf5_cache(video_dir / "0", identity=0)
+    (video_dir / "1").mkdir()  # identity dir with no cache files
+    (video_dir / "notes.txt").write_text("stray file")
+
+    status = scan_video_feature_cache(
+        feature_dir, "video1.mp4", current_feature_version=_CURRENT_VERSION
+    )
+
+    assert status.cached_identity_count == 1
+
+
+# ---------------------------------------------------------------------------
+# scan_project_feature_cache
+# ---------------------------------------------------------------------------
+
+
+def test_scan_project_covers_every_video(tmp_path):
+    """Every project video appears in the result, cached or not."""
+    feature_dir = tmp_path / "features"
+    _write_hdf5_cache(feature_dir / "video1" / "0", identity=0, window_sizes=(5,))
+
+    project = mock.MagicMock()
+    project.feature_dir = feature_dir
+    project.video_manager.videos = ["video1.mp4", "video2.mp4"]
+    project.video_manager.get_video_identity_count.return_value = 1
+
+    statuses = scan_project_feature_cache(project)
+
+    assert set(statuses) == {"video1.mp4", "video2.mp4"}
+    assert statuses["video1.mp4"].window_sizes == (5,)
+    assert statuses["video2.mp4"].has_cached_features is False
+
+
+def test_scan_project_stops_early_when_asked(tmp_path):
+    """A should_continue predicate returning False ends the scan with partial results."""
+    feature_dir = tmp_path / "features"
+    for video in ("video1", "video2", "video3"):
+        _write_hdf5_cache(feature_dir / video / "0", identity=0)
+
+    project = mock.MagicMock()
+    project.feature_dir = feature_dir
+    project.video_manager.videos = ["video1.mp4", "video2.mp4", "video3.mp4"]
+    project.video_manager.get_video_identity_count.return_value = 1
+
+    # allow the first two videos, then stop
+    calls = iter([True, True, False])
+    statuses = scan_project_feature_cache(project, should_continue=lambda: next(calls))
+
+    assert set(statuses) == {"video1.mp4", "video2.mp4"}
+
+
+def test_scan_project_tolerates_unknown_identity_count(tmp_path):
+    """A video whose identity count cannot be read is still scanned."""
+    feature_dir = tmp_path / "features"
+    _write_hdf5_cache(feature_dir / "video1" / "0", identity=0)
+
+    project = mock.MagicMock()
+    project.feature_dir = feature_dir
+    project.video_manager.videos = ["video1.mp4"]
+    project.video_manager.get_video_identity_count.side_effect = ValueError("no pose file")
+
+    status = scan_project_feature_cache(project)["video1.mp4"]
+
+    assert status.expected_identity_count is None
+    assert status.has_cached_features is True

--- a/tests/project/test_feature_cache_status.py
+++ b/tests/project/test_feature_cache_status.py
@@ -475,3 +475,43 @@ def test_current_cache_is_coverage():
     )
 
     assert status.has_window_features(5) is True
+
+
+@pytest.mark.parametrize(
+    ("cached_scale", "expects_cm", "covered"),
+    [
+        (0.12, True, True),
+        (None, False, True),
+        (0.12, False, False),
+        (None, True, False),
+        (0.12, None, True),
+        (None, None, True),
+    ],
+    ids=["cm-cm", "px-px", "cm-cache-px-run", "px-cache-cm-run", "cm-unknown", "px-unknown"],
+)
+def test_coverage_requires_matching_distance_units(cached_scale, expects_cm, covered):
+    """A cache built in the other distance unit is recomputed, so it is not coverage.
+
+    ``expects_cm=None`` means the caller does not know which units the run will use,
+    which skips the check.
+    """
+    status = _status(
+        _identity_cache(
+            identity=0, window_sizes=frozenset({5}), distance_scale_factor=cached_scale
+        ),
+        expected_identity_count=1,
+    )
+
+    assert status.has_window_features(5, expects_cm=expects_cm) is covered
+
+
+def test_unit_mismatch_does_not_hide_the_cache_from_display():
+    """The cache is still described on disk; only coverage changes."""
+    status = _status(
+        _identity_cache(identity=0, window_sizes=frozenset({5}), distance_scale_factor=0.12),
+        expected_identity_count=1,
+    )
+
+    assert status.window_sizes == (5,)
+    assert status.cm_units is True
+    assert status.has_window_features(5, expects_cm=False) is False

--- a/tests/project/test_feature_cache_status.py
+++ b/tests/project/test_feature_cache_status.py
@@ -368,3 +368,42 @@ def test_scan_project_tolerates_unknown_identity_count(tmp_path):
 
     assert status.expected_identity_count is None
     assert status.has_cached_features is True
+
+
+def test_per_frame_features_merged_across_pose_hash_directories():
+    """An identity cached under several pose hashes only needs per-frame features once.
+
+    Matches how window sizes merge: a partially written cache under one pose hash
+    must not make the identity (or the video) look incomplete.
+    """
+    status = _status(
+        _identity_cache(identity=0, per_frame_present=False, directory=Path("/f/v/hash_a/0")),
+        _identity_cache(identity=0, per_frame_present=True, directory=Path("/f/v/hash_b/0")),
+        expected_identity_count=1,
+    )
+
+    assert status.identities_missing_per_frame == ()
+    assert status.is_complete is True
+
+
+def test_identity_with_no_per_frame_features_anywhere_is_reported():
+    """An identity whose only cache lacks per-frame features is named."""
+    status = _status(
+        _identity_cache(identity=0),
+        _identity_cache(identity=1, per_frame_present=False),
+        expected_identity_count=2,
+    )
+
+    assert status.identities_missing_per_frame == (1,)
+    assert status.is_complete is False
+
+
+def test_cache_formats_sorted_by_enum_value():
+    """Formats are ordered by their on-disk value, not by the enum's repr."""
+    status = _status(
+        _identity_cache(identity=0, cache_format=CacheFormat.PARQUET),
+        _identity_cache(identity=1, cache_format=CacheFormat.HDF5),
+    )
+
+    assert status.cache_formats == (CacheFormat.HDF5, CacheFormat.PARQUET)
+    assert [fmt.value for fmt in status.cache_formats] == ["hdf5", "parquet"]

--- a/tests/project/test_feature_cache_status.py
+++ b/tests/project/test_feature_cache_status.py
@@ -407,3 +407,71 @@ def test_cache_formats_sorted_by_enum_value():
 
     assert status.cache_formats == (CacheFormat.HDF5, CacheFormat.PARQUET)
     assert [fmt.value for fmt in status.cache_formats] == ["hdf5", "parquet"]
+
+
+def test_stale_cache_is_not_coverage():
+    """A cache from another feature version will be recomputed, so it is not coverage.
+
+    This is the routine case after a JABS upgrade that bumps FEATURE_VERSION: the
+    window features are on disk, but the run rebuilds them.
+    """
+    status = _status(
+        _identity_cache(
+            identity=0, window_sizes=frozenset({5}), feature_version=_CURRENT_VERSION - 1
+        ),
+        expected_identity_count=1,
+    )
+
+    # still reported as present on disk, and flagged stale, for display purposes
+    assert status.window_sizes == (5,)
+    assert status.is_stale is True
+    # but not counted as cached for the train/classify warning
+    assert status.has_window_features(5) is False
+    assert status.has_window_features(5, [0]) is False
+
+
+def test_cache_without_per_frame_features_is_not_coverage():
+    """Window features are recomputed along with the per-frame features they need."""
+    status = _status(
+        _identity_cache(identity=0, window_sizes=frozenset({5}), per_frame_present=False),
+        expected_identity_count=1,
+    )
+
+    assert status.has_window_features(5) is False
+
+
+def test_coverage_is_not_stitched_together_from_different_pose_hashes():
+    """A window size only counts when one cache directory is loadable and has it.
+
+    Here the size exists only in a stale directory and the current directory lacks
+    it, so neither could serve the run even though merging the fields separately
+    would suggest otherwise.
+    """
+    status = _status(
+        _identity_cache(
+            identity=0,
+            window_sizes=frozenset({5}),
+            feature_version=_CURRENT_VERSION - 1,
+            directory=Path("/f/v/stale_hash/0"),
+        ),
+        _identity_cache(
+            identity=0,
+            window_sizes=frozenset({10}),
+            directory=Path("/f/v/current_hash/0"),
+        ),
+        expected_identity_count=1,
+    )
+
+    assert status.has_window_features(5) is False
+    # the current directory's own window size is still coverage
+    assert status.has_window_features(10) is True
+
+
+def test_current_cache_is_coverage():
+    """A current cache with per-frame features covers its window sizes."""
+    status = _status(
+        _identity_cache(identity=0, window_sizes=frozenset({5})),
+        expected_identity_count=1,
+    )
+
+    assert status.has_window_features(5) is True

--- a/tests/project/test_project_feature_cache_status.py
+++ b/tests/project/test_project_feature_cache_status.py
@@ -62,11 +62,13 @@ def _cache_window_features(
     identity: int,
     window_size: int,
     feature_version: int = FEATURE_VERSION,
+    distance_scale_factor: float | None = None,
 ) -> None:
     """Write a per-frame plus window feature cache for one identity.
 
     Defaults to the running feature version so the cache reads as current; pass an
-    older one to write a cache that JABS would discard and recompute.
+    older one to write a cache that JABS would discard and recompute. Pass a
+    distance scale factor to write a cache built in cm units.
     """
     identity_dir = project.feature_dir / Path(video).stem / str(identity)
     writer = HDF5FeatureCacheWriter()
@@ -75,6 +77,7 @@ def _cache_window_features(
         identity=identity,
         num_frames=_NUM_FRAMES,
         pose_hash="posehash",
+        distance_scale_factor=distance_scale_factor,
     )
     writer.write_per_frame(
         identity_dir,
@@ -221,3 +224,64 @@ def test_stale_cache_on_disk_counts_as_needing_computation(project):
     assert project.videos_missing_window_features(5, identities={"video1.avi": {0}}) == [
         "video1.avi"
     ]
+
+
+# ---------------------------------------------------------------------------
+# Distance units
+# ---------------------------------------------------------------------------
+
+_CM_POSE_FILE = "sample_pose_est_v5.h5"
+_CM_NUM_IDENTITIES = 3
+_CM_SCALE = 0.073341824
+
+
+@pytest.fixture
+def cm_project(tmp_path) -> Project:
+    """A project whose pose file provides a cm_per_pixel scale factor."""
+    (tmp_path / "cm_video.avi").touch()
+    shutil.copy(_DATA_DIR / _CM_POSE_FILE, tmp_path / "cm_video_pose_est_v5.h5")
+    return Project(tmp_path, enable_video_check=False, enable_session_tracker=False)
+
+
+def test_video_cm_availability_read_from_the_pose_file(project, cm_project):
+    """Whether a video can use cm units comes from its pose file."""
+    assert project.video_manager.video_has_cm_per_pixel("video1.avi") is False
+    assert cm_project.video_manager.video_has_cm_per_pixel("cm_video.avi") is True
+    # unknown videos report False rather than raising
+    assert project.video_manager.video_has_cm_per_pixel("nope.avi") is False
+
+
+def test_pixel_cache_is_not_coverage_for_a_cm_run(cm_project):
+    """Asking for cm units discards a cache built in pixels."""
+    for identity in range(_CM_NUM_IDENTITIES):
+        _cache_window_features(cm_project, "cm_video.avi", identity=identity, window_size=5)
+
+    assert cm_project.videos_missing_window_features(5, cm_units=False) == []
+    assert cm_project.videos_missing_window_features(5, cm_units=True) == ["cm_video.avi"]
+
+
+def test_cm_cache_is_coverage_only_for_a_cm_run(cm_project):
+    """A cache built in cm units covers a cm run, and not a pixel one."""
+    for identity in range(_CM_NUM_IDENTITIES):
+        _cache_window_features(
+            cm_project,
+            "cm_video.avi",
+            identity=identity,
+            window_size=5,
+            distance_scale_factor=_CM_SCALE,
+        )
+
+    assert cm_project.videos_missing_window_features(5, cm_units=True) == []
+    assert cm_project.videos_missing_window_features(5, cm_units=False) == ["cm_video.avi"]
+
+
+def test_cm_setting_ignored_for_a_video_that_cannot_use_cm(project):
+    """A video whose pose file has no scale factor is always computed in pixels.
+
+    Its pixel cache therefore still counts even when the project asks for cm units,
+    which is what keeps the warning from firing about work that will not happen.
+    """
+    for identity in range(_NUM_IDENTITIES):
+        _cache_window_features(project, "video1.avi", identity=identity, window_size=5)
+
+    assert project.videos_missing_window_features(5, videos=["video1.avi"], cm_units=True) == []

--- a/tests/project/test_project_feature_cache_status.py
+++ b/tests/project/test_project_feature_cache_status.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 
 from jabs.core.types import FeatureCacheMetadata, PerFrameCacheData
+from jabs.feature_extraction import FEATURE_VERSION
 from jabs.io.feature_cache.hdf5 import HDF5FeatureCacheWriter
 from jabs.project import Project, VideoLabels
 
@@ -55,12 +56,22 @@ def project(tmp_path) -> Project:
     return Project(tmp_path, enable_video_check=False, enable_session_tracker=False)
 
 
-def _cache_window_features(project: Project, video: str, identity: int, window_size: int) -> None:
-    """Write a per-frame plus window feature cache for one identity."""
+def _cache_window_features(
+    project: Project,
+    video: str,
+    identity: int,
+    window_size: int,
+    feature_version: int = FEATURE_VERSION,
+) -> None:
+    """Write a per-frame plus window feature cache for one identity.
+
+    Defaults to the running feature version so the cache reads as current; pass an
+    older one to write a cache that JABS would discard and recompute.
+    """
     identity_dir = project.feature_dir / Path(video).stem / str(identity)
     writer = HDF5FeatureCacheWriter()
     metadata = FeatureCacheMetadata(
-        feature_version=17,
+        feature_version=feature_version,
         identity=identity,
         num_frames=_NUM_FRAMES,
         pose_hash="posehash",
@@ -184,3 +195,29 @@ def test_labeled_identities_missing_when_its_cache_is_absent(project):
     identities = project.labeled_identities(["Walking"])
 
     assert project.videos_missing_window_features(5, identities=identities) == ["video1.avi"]
+
+
+def test_stale_cache_on_disk_counts_as_needing_computation(project):
+    """A cache from an older feature version is reported as missing.
+
+    JABS discards it and recomputes during the run, which is exactly what the
+    train/classify warning exists to announce.
+    """
+    for identity in range(_NUM_IDENTITIES):
+        _cache_window_features(
+            project,
+            "video1.avi",
+            identity=identity,
+            window_size=5,
+            feature_version=FEATURE_VERSION - 1,
+        )
+
+    status = project.refresh_feature_cache_status("video1.avi")
+    # the window features are on disk and reported for display
+    assert status.window_sizes == (5,)
+    assert status.is_stale is True
+    # but the run would rebuild them, so they are not coverage
+    assert "video1.avi" in project.videos_missing_window_features(5)
+    assert project.videos_missing_window_features(5, identities={"video1.avi": {0}}) == [
+        "video1.avi"
+    ]

--- a/tests/project/test_project_feature_cache_status.py
+++ b/tests/project/test_project_feature_cache_status.py
@@ -1,0 +1,186 @@
+"""Tests for the feature cache status a Project keeps in memory."""
+
+import json
+import shutil
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from jabs.core.types import FeatureCacheMetadata, PerFrameCacheData
+from jabs.io.feature_cache.hdf5 import HDF5FeatureCacheWriter
+from jabs.project import Project, VideoLabels
+
+_DATA_DIR = Path(__file__).parent.parent / "data"
+# sample_pose_est_v3.h5 tracks 5 identities over 1800 frames
+_POSE_FILE = "sample_pose_est_v3.h5"
+_NUM_FRAMES = 1800
+_NUM_IDENTITIES = 5
+_VIDEOS = ("video1.avi", "video2.avi")
+
+
+@pytest.fixture(autouse=True)
+def patch_session_tracker():
+    """Patch the SessionTracker to avoid side effects during tests."""
+    with patch("jabs.project.session_tracker.SessionTracker.__del__", return_value=None):
+        yield
+
+
+def _write_annotations(project_dir: Path, video: str, identities, behavior: str) -> None:
+    """Write an annotation file labeling ``behavior`` for the given identities."""
+    labels = VideoLabels(video, _NUM_FRAMES)
+    for identity in identities:
+        track = labels.get_track_labels(str(identity), behavior)
+        track.label_behavior(100, 200)
+        track.label_not_behavior(300, 400)
+
+    pose_est = MagicMock()
+    pose_est.identity_mask.return_value = np.full(_NUM_FRAMES, 1, dtype=bool)
+    path = project_dir / "jabs" / "annotations" / Path(video).with_suffix(".json")
+    with path.open("w", newline="\n") as f:
+        json.dump(labels.as_dict(pose_est), f)
+
+
+@pytest.fixture
+def project(tmp_path) -> Project:
+    """A two-video project; identity 0 of video1 is labeled for "Walking"."""
+    for video in _VIDEOS:
+        (tmp_path / video).touch()
+        shutil.copy(_DATA_DIR / _POSE_FILE, tmp_path / video.replace(".avi", "_pose_est_v3.h5"))
+
+    # first open creates the jabs directory so annotations can be placed in it
+    Project(tmp_path, enable_video_check=False, enable_session_tracker=False)
+    _write_annotations(tmp_path, _VIDEOS[0], identities=[0], behavior="Walking")
+    return Project(tmp_path, enable_video_check=False, enable_session_tracker=False)
+
+
+def _cache_window_features(project: Project, video: str, identity: int, window_size: int) -> None:
+    """Write a per-frame plus window feature cache for one identity."""
+    identity_dir = project.feature_dir / Path(video).stem / str(identity)
+    writer = HDF5FeatureCacheWriter()
+    metadata = FeatureCacheMetadata(
+        feature_version=17,
+        identity=identity,
+        num_frames=_NUM_FRAMES,
+        pose_hash="posehash",
+    )
+    writer.write_per_frame(
+        identity_dir,
+        metadata,
+        PerFrameCacheData(
+            frame_valid=np.ones(_NUM_FRAMES, dtype=np.uint8),
+            features={"mod feat": np.zeros(_NUM_FRAMES)},
+        ),
+    )
+    writer.write_window(
+        identity_dir, metadata, window_size, {"mod mean feat": np.zeros(_NUM_FRAMES)}
+    )
+
+
+def test_status_starts_empty(project):
+    """A freshly opened project has not scanned its feature cache."""
+    assert project.feature_cache_status == {}
+
+
+def test_refresh_stores_status_for_one_video(project):
+    """Refreshing a video scans it and records the result on the project."""
+    _cache_window_features(project, "video1.avi", identity=0, window_size=5)
+
+    status = project.refresh_feature_cache_status("video1.avi")
+
+    assert status.window_sizes == (5,)
+    assert project.feature_cache_status["video1.avi"] is status
+    assert "video2.avi" not in project.feature_cache_status
+
+
+def test_set_and_invalidate_status(project):
+    """Stored status can be replaced wholesale and dropped per video."""
+    status = project.refresh_feature_cache_status("video1.avi")
+    project.set_feature_cache_status({"video1.avi": status, "video2.avi": status})
+    assert set(project.feature_cache_status) == {"video1.avi", "video2.avi"}
+
+    project.invalidate_feature_cache_status(["video1.avi"])
+    assert set(project.feature_cache_status) == {"video2.avi"}
+
+    project.invalidate_feature_cache_status()
+    assert project.feature_cache_status == {}
+
+
+def test_clear_feature_cache_invalidates_status(project):
+    """Clearing the cache discards the status describing it."""
+    _cache_window_features(project, "video1.avi", identity=0, window_size=5)
+    project.refresh_feature_cache_status("video1.avi")
+
+    project.clear_feature_cache()
+
+    assert project.feature_cache_status == {}
+    assert project.refresh_feature_cache_status("video1.avi").has_cached_features is False
+
+
+def test_all_videos_missing_when_nothing_cached(project):
+    """With an empty cache every video needs feature computation."""
+    assert project.videos_missing_window_features(5) == list(_VIDEOS)
+
+
+def test_video_not_missing_once_every_identity_is_cached(project):
+    """A video is only covered when all of its identities have the window size."""
+    for identity in range(_NUM_IDENTITIES):
+        _cache_window_features(project, "video1.avi", identity=identity, window_size=5)
+
+    assert project.videos_missing_window_features(5) == ["video2.avi"]
+
+
+def test_partially_cached_video_still_missing(project):
+    """Caching some identities is not enough when every identity is required."""
+    _cache_window_features(project, "video1.avi", identity=0, window_size=5)
+
+    assert "video1.avi" in project.videos_missing_window_features(5)
+
+
+def test_other_window_size_does_not_count(project):
+    """A cache for a different window size does not cover the requested one."""
+    for identity in range(_NUM_IDENTITIES):
+        _cache_window_features(project, "video1.avi", identity=identity, window_size=10)
+
+    assert "video1.avi" in project.videos_missing_window_features(5)
+
+
+def test_missing_check_scans_unscanned_videos(project):
+    """Videos with no stored status are scanned rather than assumed missing."""
+    for identity in range(_NUM_IDENTITIES):
+        _cache_window_features(project, "video1.avi", identity=identity, window_size=5)
+    assert project.feature_cache_status == {}
+
+    missing = project.videos_missing_window_features(5, videos=["video1.avi"])
+
+    assert missing == []
+    assert "video1.avi" in project.feature_cache_status
+
+
+def test_missing_check_limited_to_requested_videos(project):
+    """Only the requested videos are checked."""
+    assert project.videos_missing_window_features(5, videos=["video2.avi"]) == ["video2.avi"]
+
+
+def test_labeled_identities_only_needs_labeled_identity_cached(project):
+    """Caching just the labeled identity covers a video for training."""
+    _cache_window_features(project, "video1.avi", identity=0, window_size=5)
+    identities = project.labeled_identities(["Walking"])
+
+    assert identities == {"video1.avi": {0}}
+    assert project.videos_missing_window_features(5, identities=identities) == []
+
+
+def test_labeled_identities_ignores_other_behaviors(project):
+    """A behavior with no labels anywhere selects no videos."""
+    assert project.labeled_identities(["Grooming"]) == {}
+    assert project.videos_missing_window_features(5, identities={}) == []
+
+
+def test_labeled_identities_missing_when_its_cache_is_absent(project):
+    """The labeled identity's own cache is what matters, not another identity's."""
+    _cache_window_features(project, "video1.avi", identity=1, window_size=5)
+    identities = project.labeled_identities(["Walking"])
+
+    assert project.videos_missing_window_features(5, identities=identities) == ["video1.avi"]

--- a/tests/ui/test_central_widget.py
+++ b/tests/ui/test_central_widget.py
@@ -5,6 +5,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from jabs.classifier import MultiClassClassifier
+from jabs.core.constants import MULTICLASS_NONE_BEHAVIOR
+
 try:
     from jabs.core.enums import ClassifierMode
     from jabs.ui.main_window.central_widget import CentralWidget
@@ -215,3 +218,163 @@ def test_classify_complete_autoswitches_to_other_video():
     assert stub._predictions == {"original": 1}
     stub._set_prediction_vis.assert_not_called()
     stub.request_video_selection.emit.assert_called_once_with("other.avi")
+
+
+def _feature_check_stub(
+    *,
+    mode=None,
+    window_size=5,
+    current_behavior="Walking",
+    behaviors=("Walking", "Grooming"),
+    classifier=None,
+    project_defaults=None,
+) -> SimpleNamespace:
+    """Build a stub self for the feature cache warning helpers."""
+    if mode is None:
+        mode = ClassifierMode.BINARY
+    return SimpleNamespace(
+        _window_size=window_size,
+        _classifier=classifier,
+        _controls=SimpleNamespace(current_behavior=current_behavior, behaviors=list(behaviors)),
+        _project=SimpleNamespace(
+            settings_manager=SimpleNamespace(classifier_mode=mode),
+            get_project_defaults=lambda: project_defaults or {"window_size": 11},
+            video_manager=SimpleNamespace(num_videos=4),
+        ),
+    )
+
+
+def test_training_behaviors_binary_uses_current_behavior():
+    """Binary training only reads labels for the behavior being trained."""
+    stub = _feature_check_stub(current_behavior="Walking")
+    assert CentralWidget._training_behaviors(stub) == ["Walking"]
+
+
+def test_training_behaviors_multiclass_includes_none_class():
+    """Multi-class training reads labels for every behavior plus the None class."""
+    stub = _feature_check_stub(mode=ClassifierMode.MULTICLASS)
+    assert CentralWidget._training_behaviors(stub) == [
+        MULTICLASS_NONE_BEHAVIOR,
+        "Walking",
+        "Grooming",
+    ]
+
+
+def test_feature_window_size_binary_uses_control_value():
+    """Binary mode uses the window size shown in the controls."""
+    stub = _feature_check_stub(window_size=7)
+    assert CentralWidget._feature_window_size(stub) == 7
+
+
+def test_feature_window_size_multiclass_uses_classifier_settings():
+    """Multi-class mode prefers the window size the classifier was configured with."""
+    classifier = MagicMock(spec=MultiClassClassifier)
+    classifier.project_settings = {"window_size": 30}
+    stub = _feature_check_stub(mode=ClassifierMode.MULTICLASS, classifier=classifier)
+
+    assert CentralWidget._feature_window_size(stub) == 30
+
+
+def test_feature_window_size_multiclass_falls_back_to_project_defaults():
+    """Without classifier settings, multi-class mode uses the project defaults."""
+    classifier = MagicMock(spec=MultiClassClassifier)
+    classifier.project_settings = None
+    stub = _feature_check_stub(
+        mode=ClassifierMode.MULTICLASS, classifier=classifier, project_defaults={"window_size": 11}
+    )
+
+    assert CentralWidget._feature_window_size(stub) == 11
+
+
+def test_confirm_on_demand_features_skips_dialog_when_all_cached(monkeypatch):
+    """Nothing is asked when every needed video already has cached features."""
+    confirm = MagicMock(return_value=False)
+    monkeypatch.setattr(
+        "jabs.ui.main_window.central_widget.MessageDialog.confirm", confirm, raising=True
+    )
+
+    assert CentralWidget._confirm_on_demand_features(_feature_check_stub(), [], 5, "training")
+    confirm.assert_not_called()
+
+
+@pytest.mark.parametrize("answer", [True, False], ids=["continue", "cancel"])
+def test_confirm_on_demand_features_returns_user_choice(monkeypatch, answer):
+    """The user's answer to the warning decides whether the run proceeds."""
+    confirm = MagicMock(return_value=answer)
+    monkeypatch.setattr(
+        "jabs.ui.main_window.central_widget.MessageDialog.confirm", confirm, raising=True
+    )
+
+    result = CentralWidget._confirm_on_demand_features(
+        _feature_check_stub(), ["a.avi", "b.avi"], 5, "classification"
+    )
+
+    assert result is answer
+    message = confirm.call_args.kwargs["message"]
+    assert "<b>5</b>" in message
+    assert "<b>2 videos</b>" in message
+    assert "classification" in message
+    assert "a.avi" in confirm.call_args.kwargs["details"]
+
+
+def test_confirm_on_demand_features_uses_singular_for_one_video(monkeypatch):
+    """A single uncached video reads as "1 video", not "1 videos"."""
+    confirm = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        "jabs.ui.main_window.central_widget.MessageDialog.confirm", confirm, raising=True
+    )
+
+    CentralWidget._confirm_on_demand_features(_feature_check_stub(), ["a.avi"], 5, "training")
+
+    assert "<b>1 video</b>" in confirm.call_args.kwargs["message"]
+
+
+def _gating_stub(confirmed: bool, missing=("a.avi",)) -> SimpleNamespace:
+    """Build a stub self for the train/classify feature cache gate."""
+    project = SimpleNamespace(
+        videos_missing_window_features=MagicMock(return_value=list(missing)),
+        labeled_identities=MagicMock(return_value={"a.avi": {0}}),
+        settings_manager=SimpleNamespace(classifier_mode=ClassifierMode.BINARY),
+    )
+    return SimpleNamespace(
+        _player_widget=MagicMock(),
+        _ensure_classifier_for_mode=MagicMock(),
+        _feature_window_size=MagicMock(return_value=5),
+        _training_behaviors=MagicMock(return_value=["Walking"]),
+        _confirm_on_demand_features=MagicMock(return_value=confirmed),
+        _project=project,
+        _classify_thread=None,
+        _training_report_markdown="stale report",
+        _classification_targets=None,
+    )
+
+
+def test_train_aborted_when_user_declines_feature_computation(monkeypatch):
+    """Declining the uncached-features warning stops training before it starts."""
+    training_thread = MagicMock()
+    monkeypatch.setattr(
+        "jabs.ui.main_window.central_widget.TrainingThread", training_thread, raising=True
+    )
+    stub = _gating_stub(confirmed=False)
+
+    CentralWidget._train_button_clicked(stub)
+
+    training_thread.assert_not_called()
+    stub._project.videos_missing_window_features.assert_called_once()
+    # the training report from a previous run is left alone since nothing ran
+    assert stub._training_report_markdown == "stale report"
+
+
+def test_classify_aborted_when_user_declines_feature_computation(monkeypatch):
+    """Declining the uncached-features warning stops classification before it starts."""
+    classify_thread = MagicMock()
+    monkeypatch.setattr(
+        "jabs.ui.main_window.central_widget.ClassifyThread", classify_thread, raising=True
+    )
+    stub = _gating_stub(confirmed=False)
+
+    CentralWidget._start_classification(stub, ["a.avi"])
+
+    classify_thread.assert_not_called()
+    stub._project.videos_missing_window_features.assert_called_once_with(5, videos=["a.avi"])
+    assert stub._classification_targets is None

--- a/tests/ui/test_central_widget.py
+++ b/tests/ui/test_central_widget.py
@@ -378,3 +378,107 @@ def test_classify_aborted_when_user_declines_feature_computation(monkeypatch):
     classify_thread.assert_not_called()
     stub._project.videos_missing_window_features.assert_called_once_with(5, videos=["a.avi"])
     assert stub._classification_targets is None
+
+
+def _cleanup_stub(*, classification_targets=None, training_cache_targets=None):
+    """Build a stub self for the thread cleanup handlers."""
+    return SimpleNamespace(
+        _training_thread=None,
+        _classify_thread=None,
+        _classification_targets=classification_targets,
+        _training_cache_targets=training_cache_targets,
+        _project=MagicMock(),
+        feature_cache_changed=SimpleNamespace(emit=MagicMock()),
+    )
+
+
+def test_training_cleanup_invalidates_only_the_videos_it_read():
+    """Training reads features only for labeled videos, so only those go stale."""
+    stub = _cleanup_stub(training_cache_targets=["a.avi", "b.avi"])
+
+    CentralWidget._cleanup_training_thread(stub)
+
+    stub._project.invalidate_feature_cache_status.assert_called_once_with(["a.avi", "b.avi"])
+    stub.feature_cache_changed.emit.assert_called_once()
+    # the targets are consumed so a later cleanup cannot act on a stale list
+    assert stub._training_cache_targets is None
+
+
+def test_training_cleanup_without_known_targets_invalidates_everything():
+    """With no recorded targets (no run started), nothing is assumed to be current."""
+    stub = _cleanup_stub()
+
+    CentralWidget._cleanup_training_thread(stub)
+
+    stub._project.invalidate_feature_cache_status.assert_called_once_with(None)
+
+
+def test_classify_cleanup_invalidates_only_classified_videos():
+    """A single-video classification only invalidates that video."""
+    stub = _cleanup_stub(classification_targets=["a.avi"])
+
+    CentralWidget._cleanup_classify_thread(stub)
+
+    stub._project.invalidate_feature_cache_status.assert_called_once_with(["a.avi"])
+    stub.feature_cache_changed.emit.assert_called_once()
+
+
+def test_classify_all_cleanup_invalidates_everything():
+    """Classifying every video (targets None) invalidates every status."""
+    stub = _cleanup_stub(classification_targets=None)
+
+    CentralWidget._cleanup_classify_thread(stub)
+
+    stub._project.invalidate_feature_cache_status.assert_called_once_with(None)
+
+
+class _StopBeforeThreadStart(Exception):
+    """Raised by the patched TrainingThread to end the handler under test early."""
+
+
+def _train_stub(confirmed: bool) -> SimpleNamespace:
+    """Build a gating stub that can reach the TrainingThread construction.
+
+    Carries the attributes _train_button_clicked reads while building the thread's
+    arguments, so the patched TrainingThread is what stops the handler.
+    """
+    stub = _gating_stub(confirmed=confirmed)
+    stub._project.labeled_identities.return_value = {"a.avi": {0}, "b.avi": {1}}
+    stub._training_cache_targets = None
+    stub._classifier = MagicMock()
+    stub._controls = SimpleNamespace(
+        current_behavior="Walking", behaviors=["Walking"], all_kfold=False, kfold_value=1
+    )
+    stub._included_project_bout_totals = MagicMock(return_value=(5, 5))
+    return stub
+
+
+def test_train_records_the_videos_whose_features_may_be_computed(monkeypatch):
+    """Starting training records the labeled videos for the later invalidation."""
+    monkeypatch.setattr(
+        "jabs.ui.main_window.central_widget.TrainingThread",
+        MagicMock(side_effect=_StopBeforeThreadStart),
+        raising=True,
+    )
+    stub = _train_stub(confirmed=True)
+
+    # the patched thread stops the handler right after the targets are recorded,
+    # before the progress dialog setup this stub does not provide
+    with pytest.raises(_StopBeforeThreadStart):
+        CentralWidget._train_button_clicked(stub)
+
+    assert stub._training_cache_targets == ["a.avi", "b.avi"]
+
+
+def test_declined_training_records_no_videos(monkeypatch):
+    """Declining the warning starts no run, so nothing is recorded to invalidate."""
+    monkeypatch.setattr(
+        "jabs.ui.main_window.central_widget.TrainingThread",
+        MagicMock(side_effect=_StopBeforeThreadStart),
+        raising=True,
+    )
+    stub = _train_stub(confirmed=False)
+
+    CentralWidget._train_button_clicked(stub)
+
+    assert stub._training_cache_targets is None

--- a/tests/ui/test_central_widget.py
+++ b/tests/ui/test_central_widget.py
@@ -317,6 +317,21 @@ def test_confirm_on_demand_features_returns_user_choice(monkeypatch, answer):
     assert "a.avi" in confirm.call_args.kwargs["details"]
 
 
+def test_confirm_on_demand_features_suggests_jabs_init(monkeypatch):
+    """The warning points at jabs-init, with the window size that is missing."""
+    confirm = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        "jabs.ui.main_window.central_widget.MessageDialog.confirm", confirm, raising=True
+    )
+
+    CentralWidget._confirm_on_demand_features(_feature_check_stub(), ["a.avi"], 30, "training")
+
+    message = confirm.call_args.kwargs["message"]
+    assert "jabs-init" in message
+    assert "jabs-init -w 30" in message
+    assert "jabs-features" not in message
+
+
 def test_confirm_on_demand_features_uses_singular_for_one_video(monkeypatch):
     """A single uncached video reads as "1 video", not "1 videos"."""
     confirm = MagicMock(return_value=True)

--- a/tests/ui/test_central_widget.py
+++ b/tests/ui/test_central_widget.py
@@ -342,14 +342,16 @@ def _gating_stub(confirmed: bool, missing=("a.avi",)) -> SimpleNamespace:
         _feature_window_size=MagicMock(return_value=5),
         _training_behaviors=MagicMock(return_value=["Walking"]),
         _confirm_on_demand_features=MagicMock(return_value=confirmed),
+        _confirm_training_features=MagicMock(return_value=confirmed),
         _project=project,
         _classify_thread=None,
         _training_report_markdown="stale report",
         _classification_targets=None,
+        _training_cache_targets=None,
     )
 
 
-def test_train_aborted_when_user_declines_feature_computation(monkeypatch):
+def test_train_aborted_when_the_feature_check_is_declined(monkeypatch):
     """Declining the uncached-features warning stops training before it starts."""
     training_thread = MagicMock()
     monkeypatch.setattr(
@@ -360,9 +362,49 @@ def test_train_aborted_when_user_declines_feature_computation(monkeypatch):
     CentralWidget._train_button_clicked(stub)
 
     training_thread.assert_not_called()
-    stub._project.videos_missing_window_features.assert_called_once()
+    stub._confirm_training_features.assert_called_once_with(5)
     # the training report from a previous run is left alone since nothing ran
     assert stub._training_report_markdown == "stale report"
+
+
+def test_training_feature_check_skips_annotation_reads_when_all_cached():
+    """A fully cached project costs no annotation I/O to check.
+
+    Working out the labeled identities means reading every annotation file, which
+    is pointless when no video is missing features for the window size: a subset of
+    those identities cannot be missing either.
+    """
+    stub = _gating_stub(confirmed=True, missing=())
+
+    assert CentralWidget._confirm_training_features(stub, 5) is True
+
+    stub._project.videos_missing_window_features.assert_called_once_with(5)
+    stub._project.labeled_identities.assert_not_called()
+    stub._confirm_on_demand_features.assert_not_called()
+    assert stub._training_cache_targets == []
+
+
+def test_training_feature_check_narrows_to_labeled_identities():
+    """When something is missing, the check narrows to the labeled identities."""
+    stub = _gating_stub(confirmed=True)
+
+    assert CentralWidget._confirm_training_features(stub, 5) is True
+
+    stub._project.labeled_identities.assert_called_once_with(["Walking"])
+    assert stub._project.videos_missing_window_features.call_args_list[-1].kwargs == {
+        "identities": {"a.avi": {0}}
+    }
+    stub._confirm_on_demand_features.assert_called_once_with(["a.avi"], 5, "training")
+    assert stub._training_cache_targets == ["a.avi"]
+
+
+def test_training_feature_check_records_nothing_when_declined():
+    """Declining the warning leaves no videos recorded, since no run starts."""
+    stub = _gating_stub(confirmed=False)
+
+    assert CentralWidget._confirm_training_features(stub, 5) is False
+
+    assert stub._training_cache_targets is None
 
 
 def test_classify_aborted_when_user_declines_feature_computation(monkeypatch):
@@ -436,15 +478,13 @@ class _StopBeforeThreadStart(Exception):
     """Raised by the patched TrainingThread to end the handler under test early."""
 
 
-def _train_stub(confirmed: bool) -> SimpleNamespace:
+def _train_stub() -> SimpleNamespace:
     """Build a gating stub that can reach the TrainingThread construction.
 
     Carries the attributes _train_button_clicked reads while building the thread's
     arguments, so the patched TrainingThread is what stops the handler.
     """
-    stub = _gating_stub(confirmed=confirmed)
-    stub._project.labeled_identities.return_value = {"a.avi": {0}, "b.avi": {1}}
-    stub._training_cache_targets = None
+    stub = _gating_stub(confirmed=True)
     stub._classifier = MagicMock()
     stub._controls = SimpleNamespace(
         current_behavior="Walking", behaviors=["Walking"], all_kfold=False, kfold_value=1
@@ -453,32 +493,19 @@ def _train_stub(confirmed: bool) -> SimpleNamespace:
     return stub
 
 
-def test_train_records_the_videos_whose_features_may_be_computed(monkeypatch):
-    """Starting training records the labeled videos for the later invalidation."""
+def test_train_proceeds_once_the_feature_check_passes(monkeypatch):
+    """An accepted feature check lets training start."""
     monkeypatch.setattr(
         "jabs.ui.main_window.central_widget.TrainingThread",
         MagicMock(side_effect=_StopBeforeThreadStart),
         raising=True,
     )
-    stub = _train_stub(confirmed=True)
+    stub = _train_stub()
 
-    # the patched thread stops the handler right after the targets are recorded,
-    # before the progress dialog setup this stub does not provide
+    # the patched thread stops the handler at the progress dialog setup this stub
+    # does not provide, which is past the point of interest
     with pytest.raises(_StopBeforeThreadStart):
         CentralWidget._train_button_clicked(stub)
 
-    assert stub._training_cache_targets == ["a.avi", "b.avi"]
-
-
-def test_declined_training_records_no_videos(monkeypatch):
-    """Declining the warning starts no run, so nothing is recorded to invalidate."""
-    monkeypatch.setattr(
-        "jabs.ui.main_window.central_widget.TrainingThread",
-        MagicMock(side_effect=_StopBeforeThreadStart),
-        raising=True,
-    )
-    stub = _train_stub(confirmed=False)
-
-    CentralWidget._train_button_clicked(stub)
-
-    assert stub._training_cache_targets is None
+    stub._confirm_training_features.assert_called_once_with(5)
+    assert stub._training_report_markdown is None

--- a/tests/ui/test_central_widget.py
+++ b/tests/ui/test_central_widget.py
@@ -478,6 +478,8 @@ def test_classify_cleanup_invalidates_only_classified_videos():
 
     stub._project.invalidate_feature_cache_status.assert_called_once_with(["a.avi"])
     stub.feature_cache_changed.emit.assert_called_once()
+    # consumed, so a canceled or failed run cannot leave stale targets behind
+    assert stub._classification_targets is None
 
 
 def test_classify_all_cleanup_invalidates_everything():

--- a/tests/ui/test_central_widget.py
+++ b/tests/ui/test_central_widget.py
@@ -7,6 +7,7 @@ import pytest
 
 from jabs.classifier import MultiClassClassifier
 from jabs.core.constants import MULTICLASS_NONE_BEHAVIOR
+from jabs.core.enums import ProjectDistanceUnit
 
 try:
     from jabs.core.enums import ClassifierMode
@@ -228,20 +229,31 @@ def _feature_check_stub(
     behaviors=("Walking", "Grooming"),
     classifier=None,
     project_defaults=None,
+    behavior_settings=None,
 ) -> SimpleNamespace:
-    """Build a stub self for the feature cache warning helpers."""
+    """Build a stub self for the feature cache warning helpers.
+
+    The settings resolvers are wired to their real implementations so the tests
+    exercise the actual resolution chain rather than a mocked shortcut.
+    """
     if mode is None:
         mode = ClassifierMode.BINARY
-    return SimpleNamespace(
+    stub = SimpleNamespace(
         _window_size=window_size,
         _classifier=classifier,
         _controls=SimpleNamespace(current_behavior=current_behavior, behaviors=list(behaviors)),
         _project=SimpleNamespace(
-            settings_manager=SimpleNamespace(classifier_mode=mode),
+            settings_manager=SimpleNamespace(
+                classifier_mode=mode,
+                get_behavior=lambda _behavior: behavior_settings or {"window_size": window_size},
+            ),
             get_project_defaults=lambda: project_defaults or {"window_size": 11},
             video_manager=SimpleNamespace(num_videos=4),
         ),
     )
+    stub._feature_op_settings = lambda: CentralWidget._feature_op_settings(stub)
+    stub._feature_cm_units = lambda: CentralWidget._feature_cm_units(stub)
+    return stub
 
 
 def test_training_behaviors_binary_uses_current_behavior():
@@ -344,7 +356,7 @@ def test_confirm_on_demand_features_uses_singular_for_one_video(monkeypatch):
     assert "<b>1 video</b>" in confirm.call_args.kwargs["message"]
 
 
-def _gating_stub(confirmed: bool, missing=("a.avi",)) -> SimpleNamespace:
+def _gating_stub(confirmed: bool, missing=("a.avi",), cm_units=False) -> SimpleNamespace:
     """Build a stub self for the train/classify feature cache gate."""
     project = SimpleNamespace(
         videos_missing_window_features=MagicMock(return_value=list(missing)),
@@ -355,6 +367,7 @@ def _gating_stub(confirmed: bool, missing=("a.avi",)) -> SimpleNamespace:
         _player_widget=MagicMock(),
         _ensure_classifier_for_mode=MagicMock(),
         _feature_window_size=MagicMock(return_value=5),
+        _feature_cm_units=MagicMock(return_value=cm_units),
         _training_behaviors=MagicMock(return_value=["Walking"]),
         _confirm_on_demand_features=MagicMock(return_value=confirmed),
         _confirm_training_features=MagicMock(return_value=confirmed),
@@ -393,7 +406,7 @@ def test_training_feature_check_skips_annotation_reads_when_all_cached():
 
     assert CentralWidget._confirm_training_features(stub, 5) is True
 
-    stub._project.videos_missing_window_features.assert_called_once_with(5)
+    stub._project.videos_missing_window_features.assert_called_once_with(5, cm_units=False)
     stub._project.labeled_identities.assert_not_called()
     stub._confirm_on_demand_features.assert_not_called()
     assert stub._training_cache_targets == []
@@ -407,7 +420,8 @@ def test_training_feature_check_narrows_to_labeled_identities():
 
     stub._project.labeled_identities.assert_called_once_with(["Walking"])
     assert stub._project.videos_missing_window_features.call_args_list[-1].kwargs == {
-        "identities": {"a.avi": {0}}
+        "identities": {"a.avi": {0}},
+        "cm_units": False,
     }
     stub._confirm_on_demand_features.assert_called_once_with(["a.avi"], 5, "training")
     assert stub._training_cache_targets == ["a.avi"]
@@ -433,7 +447,9 @@ def test_classify_aborted_when_user_declines_feature_computation(monkeypatch):
     CentralWidget._start_classification(stub, ["a.avi"])
 
     classify_thread.assert_not_called()
-    stub._project.videos_missing_window_features.assert_called_once_with(5, videos=["a.avi"])
+    stub._project.videos_missing_window_features.assert_called_once_with(
+        5, videos=["a.avi"], cm_units=False
+    )
     assert stub._classification_targets is None
 
 
@@ -526,3 +542,67 @@ def test_train_proceeds_once_the_feature_check_passes(monkeypatch):
 
     stub._confirm_training_features.assert_called_once_with(5)
     assert stub._training_report_markdown is None
+
+
+def test_feature_op_settings_binary_uses_behavior_settings():
+    """Binary mode reads the settings of the behavior being trained."""
+    stub = _feature_check_stub(behavior_settings={"window_size": 7, "cm_units": True})
+
+    assert CentralWidget._feature_op_settings(stub) == {"window_size": 7, "cm_units": True}
+
+
+def test_feature_op_settings_multiclass_prefers_classifier_settings():
+    """Multi-class mode uses the bundle the classifier was configured with."""
+    classifier = MagicMock(spec=MultiClassClassifier)
+    classifier.project_settings = {"window_size": 30, "cm_units": True}
+    stub = _feature_check_stub(mode=ClassifierMode.MULTICLASS, classifier=classifier)
+
+    assert CentralWidget._feature_op_settings(stub) == {"window_size": 30, "cm_units": True}
+
+
+def test_feature_op_settings_multiclass_falls_back_to_defaults():
+    """Without classifier settings, multi-class mode uses the project defaults."""
+    classifier = MagicMock(spec=MultiClassClassifier)
+    classifier.project_settings = None
+    stub = _feature_check_stub(
+        mode=ClassifierMode.MULTICLASS,
+        classifier=classifier,
+        project_defaults={"window_size": 11, "cm_units": False},
+    )
+
+    assert CentralWidget._feature_op_settings(stub) == {"window_size": 11, "cm_units": False}
+
+
+@pytest.mark.parametrize(
+    ("setting", "expected"),
+    [
+        (ProjectDistanceUnit.CM, True),
+        (ProjectDistanceUnit.PIXEL, False),
+        (True, True),
+        (False, False),
+        (None, False),
+    ],
+    ids=["enum-cm", "enum-pixel", "bool-true", "bool-false", "missing"],
+)
+def test_feature_cm_units_matches_the_extractor_truthiness(setting, expected):
+    """The unit flag is read the way IdentityFeatures reads it.
+
+    The stored value is a ProjectDistanceUnit (PIXEL is 0), and the extractor tests
+    it for truthiness, so this must agree for both enum and bool values.
+    """
+    behavior_settings = {"window_size": 5}
+    if setting is not None:
+        behavior_settings["cm_units"] = setting
+    stub = _feature_check_stub(behavior_settings=behavior_settings)
+
+    assert CentralWidget._feature_cm_units(stub) is expected
+
+
+def test_training_feature_check_passes_the_unit_setting(monkeypatch):
+    """The gate tells the project which units the run will use."""
+    stub = _gating_stub(confirmed=True, cm_units=True)
+
+    CentralWidget._confirm_training_features(stub, 5)
+
+    for call in stub._project.videos_missing_window_features.call_args_list:
+        assert call.kwargs["cm_units"] is True

--- a/tests/ui/test_feature_cache_scan_thread.py
+++ b/tests/ui/test_feature_cache_scan_thread.py
@@ -1,0 +1,93 @@
+"""Tests for the background feature cache scan thread."""
+
+from unittest import mock
+
+import pytest
+
+try:
+    from PySide6.QtWidgets import QApplication
+
+    from jabs.ui.feature_cache_scan_thread import FeatureCacheScanThread
+
+    SKIP_UI_TESTS = False
+    SKIP_REASON = None
+except ImportError as e:
+    SKIP_UI_TESTS = True
+    SKIP_REASON = f"Qt/UI dependencies not available: {e}"
+
+pytestmark = pytest.mark.skipif(
+    SKIP_UI_TESTS,
+    reason=SKIP_REASON if SKIP_UI_TESTS else "",
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def qapp():
+    """Ensure a QApplication exists, matching the other UI tests in this suite.
+
+    A QCoreApplication would be enough for QThread, but creating one here would
+    prevent widget tests later in the session from creating a QApplication.
+    """
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    yield app
+
+
+def test_scan_emits_project_and_statuses(monkeypatch):
+    """A successful scan emits the scanned project alongside its results."""
+    project = mock.MagicMock()
+    statuses = {"a.avi": mock.MagicMock()}
+    monkeypatch.setattr(
+        "jabs.ui.feature_cache_scan_thread.scan_project_feature_cache",
+        lambda p, should_continue=None: statuses if p is project else None,
+    )
+    thread = FeatureCacheScanThread(project)
+    received = []
+    thread.scan_complete.connect(lambda p, s: received.append((p, s)))
+
+    # run() directly rather than start(): the work is synchronous and this keeps
+    # the test free of thread scheduling and event loop timing
+    thread.run()
+
+    assert received == [(project, statuses)]
+
+
+def test_failed_scan_emits_nothing(monkeypatch):
+    """A scan that raises is logged and emits no results."""
+
+    def _raise(_project, should_continue=None):
+        raise OSError("feature dir unreadable")
+
+    monkeypatch.setattr("jabs.ui.feature_cache_scan_thread.scan_project_feature_cache", _raise)
+    thread = FeatureCacheScanThread(mock.MagicMock())
+    received = []
+    thread.scan_complete.connect(lambda p, s: received.append((p, s)))
+
+    thread.run()
+
+    assert received == []
+
+
+def test_termination_request_stops_scan_and_discards_results(monkeypatch):
+    """Requesting termination stops the scan and suppresses partial results."""
+    scanned = []
+
+    def _scan(_project, should_continue=None):
+        # mimic scan_project_feature_cache: check the predicate per video
+        for video in ("a.avi", "b.avi", "c.avi"):
+            if should_continue is not None and not should_continue():
+                break
+            scanned.append(video)
+        return dict.fromkeys(scanned, mock.MagicMock())
+
+    monkeypatch.setattr("jabs.ui.feature_cache_scan_thread.scan_project_feature_cache", _scan)
+    thread = FeatureCacheScanThread(mock.MagicMock())
+    received = []
+    thread.scan_complete.connect(lambda p, s: received.append((p, s)))
+
+    thread.request_termination()
+    thread.run()
+
+    assert scanned == []
+    assert received == []

--- a/tests/ui/test_feature_cache_text.py
+++ b/tests/ui/test_feature_cache_text.py
@@ -1,0 +1,53 @@
+"""Tests for feature cache status text formatting."""
+
+import pytest
+
+from jabs.core.enums import CacheFormat
+from jabs.ui.feature_cache_text import (
+    format_byte_size,
+    format_cache_formats,
+    format_window_sizes,
+)
+
+
+@pytest.mark.parametrize(
+    ("num_bytes", "expected"),
+    [
+        (0, "0 bytes"),
+        (512, "512 bytes"),
+        (2048, "2.0 KiB"),
+        (1024 * 1024 + 512 * 1024, "1.5 MiB"),
+        (3 * 1024**3, "3.0 GiB"),
+        (2 * 1024**4, "2.0 TiB"),
+        (1024**5, "1024.0 TiB"),
+    ],
+    ids=["zero", "bytes", "kib", "mib", "gib", "tib", "beyond-tib"],
+)
+def test_format_byte_size(num_bytes, expected):
+    """Byte counts are scaled to the largest unit that leaves a value >= 1."""
+    assert format_byte_size(num_bytes) == expected
+
+
+def test_format_window_sizes_lists_sizes():
+    """Window sizes are joined with commas in the order given."""
+    assert format_window_sizes((5, 10, 30)) == "5, 10, 30"
+
+
+def test_format_window_sizes_empty():
+    """An empty window size collection reads as 'none'."""
+    assert format_window_sizes(()) == "none"
+
+
+def test_format_cache_formats_single():
+    """A single format is named directly."""
+    assert format_cache_formats((CacheFormat.PARQUET,)) == "Parquet"
+
+
+def test_format_cache_formats_mixed():
+    """Multiple formats are reported as mixed."""
+    assert format_cache_formats((CacheFormat.HDF5, CacheFormat.PARQUET)) == "Mixed (HDF5, Parquet)"
+
+
+def test_format_cache_formats_empty():
+    """No formats reads as unknown."""
+    assert format_cache_formats(()) == "unknown"

--- a/tests/ui/test_feature_cache_text.py
+++ b/tests/ui/test_feature_cache_text.py
@@ -3,10 +3,25 @@
 import pytest
 
 from jabs.core.enums import CacheFormat
-from jabs.ui.feature_cache_text import (
-    format_byte_size,
-    format_cache_formats,
-    format_window_sizes,
+
+try:
+    # These helpers are Qt-free, but importing anything under jabs.ui executes
+    # jabs/ui/__init__.py, which imports MainWindow and therefore PySide6.
+    from jabs.ui.feature_cache_text import (
+        format_byte_size,
+        format_cache_formats,
+        format_window_sizes,
+    )
+
+    SKIP_UI_TESTS = False
+    SKIP_REASON = None
+except ImportError as e:
+    SKIP_UI_TESTS = True
+    SKIP_REASON = f"Qt/UI dependencies not available: {e}"
+
+pytestmark = pytest.mark.skipif(
+    SKIP_UI_TESTS,
+    reason=SKIP_REASON if SKIP_UI_TESTS else "",
 )
 
 

--- a/tests/ui/test_main_window.py
+++ b/tests/ui/test_main_window.py
@@ -1,0 +1,83 @@
+"""Tests for MainWindow feature cache scan handling.
+
+The methods under test are called unbound with lightweight stand-ins for ``self``,
+so a full MainWindow (and its child widgets) never has to be constructed.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+try:
+    import jabs.ui.main_window.main_window as main_window_module
+    from jabs.ui.main_window.main_window import MainWindow
+
+    SKIP_UI_TESTS = False
+    SKIP_REASON = None
+except ImportError as e:
+    SKIP_UI_TESTS = True
+    SKIP_REASON = f"Qt/UI dependencies not available: {e}"
+
+pytestmark = pytest.mark.skipif(
+    SKIP_UI_TESTS,
+    reason=SKIP_REASON if SKIP_UI_TESTS else "",
+)
+
+
+def test_feature_cache_scan_results_stored_on_project():
+    """Scan results are handed to the project that was scanned."""
+    project = MagicMock()
+    stub = SimpleNamespace(_project=project)
+    statuses = {"a.avi": MagicMock()}
+
+    MainWindow._feature_cache_scan_complete(stub, project, statuses)
+
+    project.set_feature_cache_status.assert_called_once_with(statuses)
+
+
+def test_feature_cache_scan_results_discarded_for_closed_project():
+    """Results arriving after another project was opened are dropped."""
+    scanned_project = MagicMock()
+    current_project = MagicMock()
+    stub = SimpleNamespace(_project=current_project)
+
+    MainWindow._feature_cache_scan_complete(stub, scanned_project, {"a.avi": MagicMock()})
+
+    scanned_project.set_feature_cache_status.assert_not_called()
+    current_project.set_feature_cache_status.assert_not_called()
+
+
+def test_feature_cache_scan_thread_released_when_finished():
+    """A finished scan thread is dropped and scheduled for deletion."""
+    thread = MagicMock()
+    stub = SimpleNamespace(_feature_cache_scan_thread=thread)
+
+    MainWindow._feature_cache_scan_finished(stub, thread)
+
+    assert stub._feature_cache_scan_thread is None
+    thread.deleteLater.assert_called_once()
+
+
+def test_finished_scan_thread_does_not_clear_a_newer_one():
+    """An older thread finishing must not drop the reference to a running scan."""
+    older = MagicMock()
+    newer = MagicMock()
+    stub = SimpleNamespace(_feature_cache_scan_thread=newer)
+
+    MainWindow._feature_cache_scan_finished(stub, older)
+
+    assert stub._feature_cache_scan_thread is newer
+    older.deleteLater.assert_called_once()
+    newer.deleteLater.assert_not_called()
+
+
+def test_refresh_feature_cache_status_without_project_does_nothing(monkeypatch):
+    """With no project open there is nothing to scan."""
+    scan_thread = MagicMock()
+    monkeypatch.setattr(main_window_module, "FeatureCacheScanThread", scan_thread)
+    stub = SimpleNamespace(_project=None, _feature_cache_scan_thread=None)
+
+    MainWindow.refresh_feature_cache_status(stub)
+
+    scan_thread.assert_not_called()

--- a/tests/ui/test_main_window.py
+++ b/tests/ui/test_main_window.py
@@ -80,10 +80,26 @@ def test_feature_cache_scan_results_discarded_when_superseded():
     project.set_feature_cache_status.assert_not_called()
 
 
+def _refresh_stub(scan_thread=None, pending=False, has_project=True) -> SimpleNamespace:
+    """Build a stub self for the scan start/finish bookkeeping.
+
+    Args:
+        scan_thread: The scan thread the window is tracking, if any.
+        pending: Whether a rescan is already queued.
+        has_project: Whether a project is open.
+    """
+    return SimpleNamespace(
+        _project=MagicMock() if has_project else None,
+        _feature_cache_scan_thread=scan_thread,
+        _feature_cache_scan_pending=pending,
+        _start_feature_cache_scan=MagicMock(),
+    )
+
+
 def test_feature_cache_scan_thread_released_when_finished():
     """A finished scan thread is dropped and scheduled for deletion."""
     thread = MagicMock()
-    stub = SimpleNamespace(_feature_cache_scan_thread=thread)
+    stub = _refresh_stub(scan_thread=thread)
 
     MainWindow._feature_cache_scan_finished(stub, thread)
 
@@ -95,7 +111,7 @@ def test_finished_scan_thread_does_not_clear_a_newer_one():
     """An older thread finishing must not drop the reference to a running scan."""
     older = MagicMock()
     newer = MagicMock()
-    stub = SimpleNamespace(_feature_cache_scan_thread=newer)
+    stub = _refresh_stub(scan_thread=newer)
 
     MainWindow._feature_cache_scan_finished(stub, older)
 
@@ -104,12 +120,89 @@ def test_finished_scan_thread_does_not_clear_a_newer_one():
     newer.deleteLater.assert_not_called()
 
 
-def test_refresh_feature_cache_status_without_project_does_nothing(monkeypatch):
+def test_refresh_feature_cache_status_without_project_does_nothing():
     """With no project open there is nothing to scan."""
-    scan_thread = MagicMock()
-    monkeypatch.setattr(main_window_module, "FeatureCacheScanThread", scan_thread)
-    stub = SimpleNamespace(_project=None, _feature_cache_scan_thread=None)
+    stub = _refresh_stub(has_project=False)
 
     MainWindow.refresh_feature_cache_status(stub)
 
-    scan_thread.assert_not_called()
+    stub._start_feature_cache_scan.assert_not_called()
+
+
+def test_start_feature_cache_scan_tracks_and_starts_the_thread(monkeypatch):
+    """The scan thread is built for the open project, tracked, and started."""
+    scan_thread_class = MagicMock()
+    monkeypatch.setattr(main_window_module, "FeatureCacheScanThread", scan_thread_class)
+    project = MagicMock()
+    stub = SimpleNamespace(
+        _project=project,
+        _feature_cache_scan_thread=None,
+        _feature_cache_scan_complete=MagicMock(),
+        _feature_cache_scan_finished=MagicMock(),
+    )
+
+    MainWindow._start_feature_cache_scan(stub)
+
+    scan_thread_class.assert_called_once_with(project, parent=stub)
+    thread = scan_thread_class.return_value
+    thread.start.assert_called_once()
+    assert stub._feature_cache_scan_thread is thread
+
+
+def test_refresh_starts_a_scan_when_none_is_running():
+    """With no scan in flight, a refresh starts one immediately."""
+    stub = _refresh_stub()
+
+    MainWindow.refresh_feature_cache_status(stub)
+
+    stub._start_feature_cache_scan.assert_called_once()
+    assert stub._feature_cache_scan_pending is False
+
+
+def test_refresh_during_a_scan_queues_instead_of_starting_a_second():
+    """A refresh while scanning stops that scan and queues a replacement.
+
+    Keeps a single scan in flight, so repeated refreshes cannot pile up concurrent
+    passes over the feature directory or leave untracked threads at shutdown.
+    """
+    running = MagicMock()
+    stub = _refresh_stub(scan_thread=running)
+
+    MainWindow.refresh_feature_cache_status(stub)
+
+    stub._start_feature_cache_scan.assert_not_called()
+    running.request_termination.assert_called_once()
+    assert stub._feature_cache_scan_pending is True
+
+
+def test_queued_rescan_starts_when_the_running_scan_finishes():
+    """The queued refresh runs once the scan it superseded has finished."""
+    thread = MagicMock()
+    stub = _refresh_stub(scan_thread=thread, pending=True)
+
+    MainWindow._feature_cache_scan_finished(stub, thread)
+
+    assert stub._feature_cache_scan_thread is None
+    thread.deleteLater.assert_called_once()
+    stub._start_feature_cache_scan.assert_called_once()
+    assert stub._feature_cache_scan_pending is False
+
+
+def test_no_rescan_started_when_none_was_queued():
+    """A scan finishing with nothing queued does not start another."""
+    thread = MagicMock()
+    stub = _refresh_stub(scan_thread=thread, pending=False)
+
+    MainWindow._feature_cache_scan_finished(stub, thread)
+
+    stub._start_feature_cache_scan.assert_not_called()
+
+
+def test_queued_rescan_dropped_when_no_project_is_open():
+    """A queued refresh is abandoned if the project was closed meanwhile."""
+    thread = MagicMock()
+    stub = _refresh_stub(scan_thread=thread, pending=True, has_project=False)
+
+    MainWindow._feature_cache_scan_finished(stub, thread)
+
+    stub._start_feature_cache_scan.assert_not_called()

--- a/tests/ui/test_main_window.py
+++ b/tests/ui/test_main_window.py
@@ -4,6 +4,7 @@ The methods under test are called unbound with lightweight stand-ins for ``self`
 so a full MainWindow (and its child widgets) never has to be constructed.
 """
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -206,3 +207,55 @@ def test_queued_rescan_dropped_when_no_project_is_open():
     MainWindow._feature_cache_scan_finished(stub, thread)
 
     stub._start_feature_cache_scan.assert_not_called()
+
+
+def test_stop_feature_cache_scan_without_a_scan_is_a_noop():
+    """Nothing to stop when no scan is running."""
+    stub = _refresh_stub()
+
+    MainWindow._stop_feature_cache_scan(stub)  # must not raise
+
+
+def test_stop_feature_cache_scan_asks_the_thread_to_stop():
+    """A responsive scan is asked to stop and is not forced."""
+    thread = MagicMock()
+    thread.wait.return_value = True
+    stub = _refresh_stub(scan_thread=thread)
+
+    MainWindow._stop_feature_cache_scan(stub)
+
+    thread.request_termination.assert_called_once()
+    thread.wait.assert_called_once()
+    thread.terminate.assert_not_called()
+
+
+def test_stop_feature_cache_scan_forces_an_unresponsive_thread():
+    """A scan stuck in a filesystem call is terminated rather than waited on forever.
+
+    Leaving it running would let the window be destroyed with a live child thread,
+    which aborts the process; blocking indefinitely would make JABS unquittable on
+    a wedged mount.
+    """
+    thread = MagicMock()
+    # the cooperative stop times out, the forced stop works
+    thread.wait.side_effect = [False, True]
+    stub = _refresh_stub(scan_thread=thread)
+
+    MainWindow._stop_feature_cache_scan(stub)
+
+    thread.request_termination.assert_called_once()
+    thread.terminate.assert_called_once()
+    assert thread.wait.call_count == 2
+
+
+def test_stop_feature_cache_scan_logs_when_it_cannot_stop_the_thread(caplog):
+    """A thread that survives even termination is reported rather than hidden."""
+    thread = MagicMock()
+    thread.wait.return_value = False
+    stub = _refresh_stub(scan_thread=thread)
+
+    with caplog.at_level(logging.ERROR, logger=main_window_module.__name__):
+        MainWindow._stop_feature_cache_scan(stub)
+
+    thread.terminate.assert_called_once()
+    assert "could not be stopped" in caplog.text

--- a/tests/ui/test_main_window.py
+++ b/tests/ui/test_main_window.py
@@ -25,10 +25,26 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+def _scan_complete_stub(project, scan_thread, sender=None) -> SimpleNamespace:
+    """Build a stub self for _feature_cache_scan_complete.
+
+    Args:
+        project: The project the window currently has open.
+        scan_thread: The scan thread the window is tracking.
+        sender: The thread whose signal is being delivered; defaults to
+            ``scan_thread`` (the current scan).
+    """
+    return SimpleNamespace(
+        _project=project,
+        _feature_cache_scan_thread=scan_thread,
+        sender=lambda: scan_thread if sender is None else sender,
+    )
+
+
 def test_feature_cache_scan_results_stored_on_project():
     """Scan results are handed to the project that was scanned."""
     project = MagicMock()
-    stub = SimpleNamespace(_project=project)
+    stub = _scan_complete_stub(project, MagicMock())
     statuses = {"a.avi": MagicMock()}
 
     MainWindow._feature_cache_scan_complete(stub, project, statuses)
@@ -40,12 +56,28 @@ def test_feature_cache_scan_results_discarded_for_closed_project():
     """Results arriving after another project was opened are dropped."""
     scanned_project = MagicMock()
     current_project = MagicMock()
-    stub = SimpleNamespace(_project=current_project)
+    stub = _scan_complete_stub(current_project, MagicMock())
 
     MainWindow._feature_cache_scan_complete(stub, scanned_project, {"a.avi": MagicMock()})
 
     scanned_project.set_feature_cache_status.assert_not_called()
     current_project.set_feature_cache_status.assert_not_called()
+
+
+def test_feature_cache_scan_results_discarded_when_superseded():
+    """An older scan finishing after a newer one started must not write back.
+
+    Its results describe the cache before the newer scan's starting point (for
+    example before a training run computed features).
+    """
+    project = MagicMock()
+    current_scan = MagicMock()
+    older_scan = MagicMock()
+    stub = _scan_complete_stub(project, current_scan, sender=older_scan)
+
+    MainWindow._feature_cache_scan_complete(stub, project, {"a.avi": MagicMock()})
+
+    project.set_feature_cache_status.assert_not_called()
 
 
 def test_feature_cache_scan_thread_released_when_finished():

--- a/tests/ui/test_video_info_dialog.py
+++ b/tests/ui/test_video_info_dialog.py
@@ -167,10 +167,19 @@ def test_dialog_reports_incomplete_identity_coverage():
 
 
 def test_dialog_warns_about_missing_per_frame_features():
-    """A cache without per-frame features shows a warning row."""
+    """A cache without per-frame features names the affected identities."""
     dialog = _dialog(_status(per_frame_present=False))
 
-    assert "Per-frame features are missing" in _value_for(dialog, "Warning:")
+    warning = _value_for(dialog, "Warning:")
+    assert "Per-frame features are missing" in warning
+    assert warning.endswith("0, 1")
+
+
+def test_dialog_omits_warning_when_per_frame_features_are_present():
+    """No warning row appears for a healthy cache."""
+    dialog = _dialog(_status())
+
+    assert "Warning:" not in _label_texts(dialog)
 
 
 @pytest.mark.parametrize(

--- a/tests/ui/test_video_info_dialog.py
+++ b/tests/ui/test_video_info_dialog.py
@@ -1,0 +1,183 @@
+"""Tests for the feature cache section of the video info dialog."""
+
+from pathlib import Path
+
+import pytest
+
+from jabs.core.enums import CacheFormat
+from jabs.io.feature_cache import IdentityCacheInfo
+from jabs.project import VideoFeatureCacheStatus
+
+try:
+    from PySide6.QtWidgets import QApplication, QLabel
+
+    from jabs.ui.dialogs.video_info_dialog import VideoInfoDialog
+
+    SKIP_UI_TESTS = False
+    SKIP_REASON = None
+except ImportError as e:
+    SKIP_UI_TESTS = True
+    SKIP_REASON = f"Qt/UI dependencies not available: {e}"
+
+pytestmark = pytest.mark.skipif(
+    SKIP_UI_TESTS,
+    reason=SKIP_REASON if SKIP_UI_TESTS else "",
+)
+
+_CURRENT_VERSION = 17
+
+# The dialog reads the video and pose files directly; pointing it at paths that
+# do not exist exercises its existing error handling and leaves only the feature
+# cache section (built from the status object) under test.
+_VIDEO_PATH = Path("/does/not/exist/video1.mp4")
+_POSE_PATH = Path("/does/not/exist/video1_pose_est_v6.h5")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def qapp():
+    """Ensure a QApplication exists for widget tests."""
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    yield app
+
+
+def _status(
+    *,
+    identities: int = 2,
+    window_sizes: tuple[frozenset[int], ...] | None = None,
+    feature_version: int = _CURRENT_VERSION,
+    cache_format: CacheFormat = CacheFormat.PARQUET,
+    per_frame_present: bool = True,
+    distance_scale_factor: float | None = None,
+    expected_identity_count: int | None = 2,
+) -> VideoFeatureCacheStatus:
+    """Build a status with one cache per identity.
+
+    Args:
+        identities: Number of cached identities.
+        window_sizes: Per-identity window size sets; defaults to ``{5, 10}`` for
+            every identity.
+        feature_version: Feature version recorded in each cache.
+        cache_format: Storage format recorded in each cache.
+        per_frame_present: Whether per-frame features are present.
+        distance_scale_factor: Distance scale recorded in each cache.
+        expected_identity_count: Identity count of the video, or ``None``.
+    """
+    sizes = window_sizes or tuple(frozenset({5, 10}) for _ in range(identities))
+    caches = tuple(
+        IdentityCacheInfo(
+            directory=Path("/features/video1") / str(i),
+            identity=i,
+            cache_format=cache_format,
+            feature_version=feature_version,
+            pose_hash="hash",
+            num_frames=100,
+            distance_scale_factor=distance_scale_factor,
+            window_sizes=sizes[i],
+            per_frame_present=per_frame_present,
+            size_bytes=2048,
+        )
+        for i in range(identities)
+    )
+    return VideoFeatureCacheStatus(
+        video="video1.mp4",
+        cache_dir=Path("/features/video1"),
+        identity_caches=caches,
+        current_feature_version=_CURRENT_VERSION,
+        expected_identity_count=expected_identity_count,
+    )
+
+
+def _label_texts(dialog) -> list[str]:
+    """Return the text of every label in the dialog."""
+    return [label.text() for label in dialog.findChildren(QLabel)]
+
+
+def _value_for(dialog, label_text: str) -> str:
+    """Return the text of the field value following a form label.
+
+    Args:
+        dialog: Dialog to search.
+        label_text: The form row label, including its trailing colon.
+
+    Returns:
+        The value label's text.
+    """
+    texts = _label_texts(dialog)
+    assert label_text in texts, f"{label_text!r} not in {texts!r}"
+    return texts[texts.index(label_text) + 1]
+
+
+def _dialog(status):
+    """Build a VideoInfoDialog for the given feature cache status."""
+    return VideoInfoDialog(_VIDEO_PATH, _POSE_PATH, identity_count=2, feature_cache_status=status)
+
+
+def test_dialog_shows_feature_cache_section():
+    """The dialog reports the cache directory, coverage, window sizes and size."""
+    dialog = _dialog(_status())
+
+    assert "<b>Feature Cache</b>" in _label_texts(dialog)
+    assert _value_for(dialog, "Directory:") == "/features/video1"
+    assert _value_for(dialog, "Identities cached:") == "2 of 2"
+    assert _value_for(dialog, "Window sizes:") == "5, 10"
+    assert _value_for(dialog, "Format:") == "Parquet"
+    assert _value_for(dialog, "Feature version:") == str(_CURRENT_VERSION)
+    assert _value_for(dialog, "Size on disk:") == "4.0 KiB"
+
+
+def test_dialog_reports_no_cached_features():
+    """A video with no cached features shows the directory and 'None'."""
+    dialog = _dialog(_status(identities=0))
+
+    assert _value_for(dialog, "Cached features:") == "None"
+    assert "Window sizes:" not in _label_texts(dialog)
+
+
+def test_dialog_reports_unknown_status():
+    """Without a status the section says the cache could not be determined."""
+    dialog = _dialog(None)
+
+    assert _value_for(dialog, "Status:") == "Unable to determine"
+
+
+def test_dialog_flags_stale_feature_version():
+    """A cache from an older feature version is flagged with the current one."""
+    dialog = _dialog(_status(feature_version=_CURRENT_VERSION - 1))
+
+    version_text = _value_for(dialog, "Feature version:")
+    assert version_text.startswith(str(_CURRENT_VERSION - 1))
+    assert f"current is {_CURRENT_VERSION}" in version_text
+
+
+def test_dialog_reports_partial_window_sizes():
+    """Window sizes cached for only some identities are listed separately."""
+    dialog = _dialog(_status(window_sizes=(frozenset({5, 10}), frozenset({5}))))
+
+    assert _value_for(dialog, "Window sizes:") == "5"
+    assert _value_for(dialog, "Partial window sizes:").startswith("10")
+
+
+def test_dialog_reports_incomplete_identity_coverage():
+    """A cache missing an identity is marked incomplete."""
+    dialog = _dialog(_status(identities=1, expected_identity_count=3))
+
+    assert _value_for(dialog, "Identities cached:") == "1 of 3 (incomplete)"
+
+
+def test_dialog_warns_about_missing_per_frame_features():
+    """A cache without per-frame features shows a warning row."""
+    dialog = _dialog(_status(per_frame_present=False))
+
+    assert "Per-frame features are missing" in _value_for(dialog, "Warning:")
+
+
+@pytest.mark.parametrize(
+    ("scale", "expected"), [(0.05, "cm"), (None, "pixels")], ids=["cm", "pixels"]
+)
+def test_dialog_reports_distance_units(scale, expected):
+    """The units the cache was computed with are reported."""
+    dialog = _dialog(_status(distance_scale_factor=scale))
+
+    assert _value_for(dialog, "Distance units:") == expected

--- a/tests/ui/test_video_list_widget.py
+++ b/tests/ui/test_video_list_widget.py
@@ -1,6 +1,11 @@
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+
+from jabs.core.enums import CacheFormat
+from jabs.io.feature_cache import IdentityCacheInfo
+from jabs.project import VideoFeatureCacheStatus
 
 try:
     from PySide6 import QtWidgets
@@ -154,3 +159,56 @@ def test_choosing_classify_action_emits_request(monkeypatch):
     widget._show_context_menu(QPoint(0, 0))
 
     assert requested == ["a.avi"]
+
+
+def _cache_status(video, window_sizes=frozenset({5})) -> VideoFeatureCacheStatus:
+    """Build a feature cache status with one cached identity."""
+    return VideoFeatureCacheStatus(
+        video=video,
+        cache_dir=Path("/features") / Path(video).stem,
+        identity_caches=(
+            IdentityCacheInfo(
+                directory=Path("/features") / Path(video).stem / "0",
+                identity=0,
+                cache_format=CacheFormat.PARQUET,
+                feature_version=17,
+                pose_hash="hash",
+                num_frames=100,
+                distance_scale_factor=None,
+                window_sizes=window_sizes,
+                per_frame_present=True,
+                size_bytes=10,
+            ),
+        ),
+        current_feature_version=17,
+        expected_identity_count=1,
+    )
+
+
+def test_feature_cache_status_rescans_the_video():
+    """Get Info re-scans the video so the status it shows is current."""
+    project = _mock_project(["a.avi"], excluded=set())
+    refreshed = _cache_status("a.avi")
+    project.refresh_feature_cache_status.return_value = refreshed
+    widget = VideoListDockWidget()
+    widget.set_project(project)
+
+    assert widget._feature_cache_status("a.avi") is refreshed
+    project.refresh_feature_cache_status.assert_called_once_with("a.avi")
+
+
+def test_feature_cache_status_falls_back_to_stored_status_on_error():
+    """A failed re-scan falls back to the status already stored on the project."""
+    project = _mock_project(["a.avi"], excluded=set())
+    stored = _cache_status("a.avi")
+    project.refresh_feature_cache_status.side_effect = OSError("unreadable")
+    project.feature_cache_status = {"a.avi": stored}
+    widget = VideoListDockWidget()
+    widget.set_project(project)
+
+    assert widget._feature_cache_status("a.avi") is stored
+
+
+def test_feature_cache_status_without_project():
+    """With no project loaded there is no status to report."""
+    assert VideoListDockWidget()._feature_cache_status("a.avi") is None

--- a/uv.lock
+++ b/uv.lock
@@ -1957,15 +1957,13 @@ name = "jabs-io"
 version = "0.46.2"
 source = { editable = "packages/jabs-io" }
 dependencies = [
+    { name = "h5py" },
     { name = "jabs-core" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
 [package.optional-dependencies]
-h5py = [
-    { name = "h5py" },
-]
 nwb = [
     { name = "ndx-multisubjects" },
     { name = "ndx-pose" },
@@ -1997,7 +1995,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "h5py", marker = "extra == 'h5py'", specifier = ">=3.15.1" },
+    { name = "h5py", specifier = ">=3.10.0,<4.0.0" },
     { name = "jabs-core", editable = "packages/jabs-core" },
     { name = "ndx-multisubjects", marker = "extra == 'nwb'", specifier = ">=0.1.1" },
     { name = "ndx-pose", marker = "extra == 'nwb'", specifier = ">=0.2.2" },
@@ -2005,7 +2003,7 @@ requires-dist = [
     { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=18.0.0" },
     { name = "pynwb", marker = "extra == 'nwb'", specifier = ">=3.1.3" },
 ]
-provides-extras = ["nwb", "h5py", "parquet"]
+provides-extras = ["nwb", "parquet"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Adds an in-memory picture of a project's on-disk feature cache and uses it in two places: the video **Get Info** dialog, and a warning before **Train** / **Classify** when features are not cached for the selected window size (they would otherwise be computed mid-run, which can take minutes per video with no explanation to the user).

## What's new

**Cache inspection (`jabs-io`)** — `inspect_identity_cache()` reports what one per-identity cache directory holds: format, feature version, pose hash, cached window sizes, whether per-frame features are present, size on disk. It reads only metadata (HDF5 attributes or `metadata.json`), never feature data, and never validates: an unreadable cache is reported the same as an absent one. Parquet window sizes are only reported when the `window_{size}.parquet` file actually exists, so the result reflects what could really be loaded.

**Per-video status (`jabs.project.feature_cache_status`)** — `VideoFeatureCacheStatus` aggregates the per-identity summaries: `window_sizes` (cached for every cached identity), `partial_window_sizes`, `cached_identity_count` / `is_complete`, `cache_formats`, `is_stale`, `cm_units`, `size_bytes`, and `has_window_features(window_size, identities=None)`. Both on-disk layouts are handled: flat `features/<video>/<id>/` and the CLI's `features/<video>/<hash>/<id>/`.

Nothing here validates a cache against its pose file: that would mean hashing every pose file, which is far too slow for a status scan. A cache whose pose file changed still reports as present and is detected when the features are actually loaded.

**Background scan at project open** — `FeatureCacheScanThread` scans the project off the main thread when it opens (the scan touches every per-identity cache directory, slow enough on network storage to matter) and the results are stored on the `Project`. The thread supports cooperative termination and is stopped in `MainWindow.closeEvent`.

**Project API** — `feature_cache_status`, `set_feature_cache_status()`, `refresh_feature_cache_status(video)`, `invalidate_feature_cache_status()`, `videos_missing_window_features(...)`, and `labeled_identities(behaviors)`. Videos with no stored status are scanned on demand, so the queries never depend on the background scan having finished. Training and classification invalidate the status when they finish, since a run caches whatever it computed.

**Get Info** — new **Feature Cache** section: cache directory, identities cached, window sizes (and partial ones), format, feature version with an out-of-date flag, distance units, size on disk, and a warning row when per-frame features are missing. The dialog re-scans the single video so what it shows is current.

**Train / Classify warning** — a Yes/No dialog naming the number of videos whose features are missing, with the video list in the details section. The scope differs per action so the warning is accurate rather than noisy: training checks only *labeled* identities (it never reads features for unlabeled ones), while classification checks every identity of every target video.

## Verification

- 960 tests pass (878 before, 82 added), plus 237 in `jabs-io`. Ruff clean.
- Checked against real `IdentityFeatures` output for both cache formats: the scanner agrees with what the production write path produces (3 identities, window sizes 5 and 10, correct version, not stale).
- Checked the warning scope end to end on a real project: with nothing cached, Train flags the labeled video and Classify flags both; after a training run caches the labeled identity, Train no longer warns while Classify still does (it needs the other four identities); a different window size warns again.
- Drove a real offscreen `MainWindow` through the background scan to confirm results cross the thread boundary and land on the project.

## Docs

`gui.md` (both the online copy and the in-app copy) gets a **Feature Computation** section and an expanded **Get Info** description.
