### PR TITLE
Run shutdown cleanup on the menu and dialog quit paths

### DIFF
--- a/src/jabs/ui/main_control_widget/main_control_widget.py
+++ b/src/jabs/ui/main_control_widget/main_control_widget.py
@@ -670,6 +670,11 @@ class MainControlWidget(QtWidgets.QWidget):
                 self.new_behavior_label.emit(self._behaviors)
                 self._behavior_changed()
         else:
+            # Close the main window first so its closeEvent runs (stopping
+            # background threads and shutting down the process pool) before the
+            # interpreter exits. close() delivers the event synchronously, so the
+            # cleanup completes before sys.exit below.
+            QtWidgets.QApplication.closeAllWindows()
             sys.exit(0)
 
     def _new_window_size(self):

--- a/src/jabs/ui/main_control_widget/main_control_widget.py
+++ b/src/jabs/ui/main_control_widget/main_control_widget.py
@@ -670,11 +670,15 @@ class MainControlWidget(QtWidgets.QWidget):
                 self.new_behavior_label.emit(self._behaviors)
                 self._behavior_changed()
         else:
-            # Close the main window first so its closeEvent runs (stopping
-            # background threads and shutting down the process pool) before the
-            # interpreter exits. close() delivers the event synchronously, so the
-            # cleanup completes before sys.exit below.
-            QtWidgets.QApplication.closeAllWindows()
+            # Close the window holding this widget (the main window) first, so its
+            # closeEvent runs -- stopping background threads and shutting down the
+            # process pool -- before the interpreter exits. close() delivers the
+            # event synchronously and reports whether it was accepted; a declined
+            # close means the application is not quitting, so exiting anyway would
+            # skip that cleanup.
+            window = self.window()
+            if window is not None and not window.close():
+                return
             sys.exit(0)
 
     def _new_window_size(self):

--- a/src/jabs/ui/main_window/central_widget.py
+++ b/src/jabs/ui/main_window/central_widget.py
@@ -1150,6 +1150,7 @@ class CentralWidget(QtWidgets.QWidget):
                 "can take several minutes per video.<br><br>"
                 "Features can be computed ahead of time with the <b>jabs-init</b> command "
                 f"line tool: <tt>jabs-init -w {window_size} &lt;project directory&gt;</tt>"
+                f"<br>See <tt>jabs-init --help</tt> for more options."
                 f"<br><br>Continue with {action}?"
             ),
             details="Videos needing feature computation:\n" + "\n".join(videos_missing_features),

--- a/src/jabs/ui/main_window/main_window.py
+++ b/src/jabs/ui/main_window/main_window.py
@@ -573,8 +573,16 @@ class MainWindow(QtWidgets.QMainWindow):
         The explicit quit matters: closing this window is only enough to end the
         application when no other top-level window is open, and JABS creates some
         without a parent (for example the training report).
+
+        A declined close means the application is not quitting after all, so the
+        quit is conditional on it: quitting anyway would leave the event loop
+        without the cleanup, which is the failure this method exists to avoid.
+        Nothing declines the close today, but the guard keeps that true if a
+        confirmation prompt is ever added to :meth:`closeEvent`.
         """
-        self.close()
+        if not self.close():
+            logger.debug("Quit cancelled: the main window declined to close")
+            return
         QtWidgets.QApplication.quit()
 
     def closeEvent(self, event: QtGui.QCloseEvent) -> None:
@@ -584,13 +592,21 @@ class MainWindow(QtWidgets.QMainWindow):
         The pre-initialized process pool is shut down in a non-blocking manner. A
         feature cache scan still in flight is stopped first, so its thread is not
         destroyed mid-run (see :meth:`_stop_feature_cache_scan`).
+
+        The cleanup only runs once the close is actually accepted: tearing down the
+        pool and the scan thread for a window that stays open would leave the
+        application running without them.
         """
+        super().closeEvent(event)
+        if not event.isAccepted():
+            logger.debug("[MainWindow] closeEvent declined; leaving background work running")
+            return
+
         # drop any queued rescan first so the finished thread does not start one
         self._feature_cache_scan_pending = False
         self._stop_feature_cache_scan()
         logger.debug("[MainWindow] closeEvent: shutting down process pool")
         self._process_pool.shutdown(wait=False, cancel_futures=True)
-        super().closeEvent(event)
 
     def on_project_settings_changed(self) -> None:
         """Slot called when project settings are changed via ProjectSettingsDialog.

--- a/src/jabs/ui/main_window/main_window.py
+++ b/src/jabs/ui/main_window/main_window.py
@@ -489,6 +489,23 @@ class MainWindow(QtWidgets.QMainWindow):
             self._central_widget.id_overlay_mode = PlayerWidget.IdentityOverlayMode.MINIMAL
             self._identity_overlay_minimal.setChecked(True)
 
+    def quit_application(self) -> None:
+        """Quit JABS, running the shutdown cleanup first.
+
+        Wired to the Quit menu action. ``QCoreApplication.quit()`` on its own
+        leaves the event loop without delivering a close event, which skips
+        :meth:`closeEvent` and therefore the background-thread and process-pool
+        shutdown it performs; a worker thread still running when the interpreter
+        tears down aborts the process. ``close()`` delivers the event
+        synchronously, so the cleanup has finished by the time we quit.
+
+        The explicit quit matters: closing this window is only enough to end the
+        application when no other top-level window is open, and JABS creates some
+        without a parent (for example the training report).
+        """
+        self.close()
+        QtWidgets.QApplication.quit()
+
     def closeEvent(self, event: QtGui.QCloseEvent) -> None:
         """Handle the close event for the main window.
 

--- a/src/jabs/ui/main_window/menu_builder.py
+++ b/src/jabs/ui/main_window/menu_builder.py
@@ -10,7 +10,7 @@ as it serves as a helper/companion class for menu handling.
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6 import QtGui, QtWidgets
 
 from jabs.feature_extraction.landmark_features import LandmarkFeatureGroup
 
@@ -191,11 +191,14 @@ class MenuBuilder:
         license_action.triggered.connect(self.handlers.show_license_dialog)
         menu.addAction(license_action)
 
-        # Quit action
+        # Quit action. Routed through MainWindow.quit_application() rather than
+        # QCoreApplication.quit(): quit() leaves the event loop without delivering
+        # a close event, so the shutdown cleanup in MainWindow.closeEvent would be
+        # skipped (see that method).
         exit_action = QtGui.QAction(f" &Quit {self.app_name}", self.main_window)
         exit_action.setShortcut(QtGui.QKeySequence("Ctrl+Q"))
         exit_action.setStatusTip("Exit application")
-        exit_action.triggered.connect(QtCore.QCoreApplication.quit)
+        exit_action.triggered.connect(self.main_window.quit_application)
         menu.addAction(exit_action)
 
         return {

--- a/tests/ui/test_main_control_widget.py
+++ b/tests/ui/test_main_control_widget.py
@@ -1,9 +1,13 @@
+from types import SimpleNamespace
+
 import pytest
 
 try:
+    from PySide6.QtCore import Qt
     from PySide6.QtGui import QColor
     from PySide6.QtWidgets import QApplication
 
+    import jabs.ui.main_control_widget.main_control_widget as main_control_widget_module
     from jabs.ui.colors import BEHAVIOR_COLOR
     from jabs.ui.main_control_widget.main_control_widget import MainControlWidget
 
@@ -88,3 +92,36 @@ def test_default_disabled_text_is_grey() -> None:
 
     widget.set_behavior_button_color(None)
     assert "color: grey" in widget._label_behavior_button.styleSheet()
+
+
+def test_first_label_quit_closes_windows_before_exiting(monkeypatch) -> None:
+    """Choosing "Quit JABS" at the first-behavior prompt runs window cleanup first.
+
+    Closing the windows delivers MainWindow.closeEvent (stopping background threads
+    and shutting down the process pool) before the interpreter exits.
+    """
+    calls = []
+
+    class _RejectedDialog:
+        """Stands in for the QInputDialog the user cancels."""
+
+        def __getattr__(self, _name):
+            return lambda *args, **kwargs: None
+
+        def windowFlags(self):
+            return Qt.WindowType.Dialog
+
+        def exec(self):
+            return 0  # rejected: the "Quit JABS" button
+
+    fake_qtwidgets = SimpleNamespace(
+        QInputDialog=_RejectedDialog,
+        QApplication=SimpleNamespace(closeAllWindows=lambda: calls.append("closeAllWindows")),
+    )
+    monkeypatch.setattr(main_control_widget_module, "QtWidgets", fake_qtwidgets)
+
+    with pytest.raises(SystemExit) as exit_info:
+        MainControlWidget._get_first_label(SimpleNamespace())
+
+    assert exit_info.value.code == 0
+    assert calls == ["closeAllWindows"]

--- a/tests/ui/test_main_control_widget.py
+++ b/tests/ui/test_main_control_widget.py
@@ -94,34 +94,59 @@ def test_default_disabled_text_is_grey() -> None:
     assert "color: grey" in widget._label_behavior_button.styleSheet()
 
 
-def test_first_label_quit_closes_windows_before_exiting(monkeypatch) -> None:
+class _RejectedDialog:
+    """Stands in for the QInputDialog the user cancels with "Quit JABS"."""
+
+    def __getattr__(self, _name):
+        return lambda *args, **kwargs: None
+
+    def windowFlags(self):
+        return Qt.WindowType.Dialog
+
+    def exec(self):
+        return 0  # rejected
+
+
+def _quit_prompt_stub(monkeypatch, close_accepted: bool) -> SimpleNamespace:
+    """Patch the dialog and return a stub self whose window closes as requested."""
+    monkeypatch.setattr(
+        main_control_widget_module,
+        "QtWidgets",
+        SimpleNamespace(QInputDialog=_RejectedDialog),
+    )
+    closed = []
+
+    def close() -> bool:
+        closed.append(True)
+        return close_accepted
+
+    window = SimpleNamespace(close=close)
+    return SimpleNamespace(window=lambda: window, closed=closed)
+
+
+def test_first_label_quit_closes_the_main_window_before_exiting(monkeypatch) -> None:
     """Choosing "Quit JABS" at the first-behavior prompt runs window cleanup first.
 
-    Closing the windows delivers MainWindow.closeEvent (stopping background threads
-    and shutting down the process pool) before the interpreter exits.
+    Closing the main window delivers MainWindow.closeEvent (stopping background
+    threads and shutting down the process pool) before the interpreter exits.
     """
-    calls = []
-
-    class _RejectedDialog:
-        """Stands in for the QInputDialog the user cancels."""
-
-        def __getattr__(self, _name):
-            return lambda *args, **kwargs: None
-
-        def windowFlags(self):
-            return Qt.WindowType.Dialog
-
-        def exec(self):
-            return 0  # rejected: the "Quit JABS" button
-
-    fake_qtwidgets = SimpleNamespace(
-        QInputDialog=_RejectedDialog,
-        QApplication=SimpleNamespace(closeAllWindows=lambda: calls.append("closeAllWindows")),
-    )
-    monkeypatch.setattr(main_control_widget_module, "QtWidgets", fake_qtwidgets)
+    stub = _quit_prompt_stub(monkeypatch, close_accepted=True)
 
     with pytest.raises(SystemExit) as exit_info:
-        MainControlWidget._get_first_label(SimpleNamespace())
+        MainControlWidget._get_first_label(stub)
 
     assert exit_info.value.code == 0
-    assert calls == ["closeAllWindows"]
+    assert stub.closed == [True]
+
+
+def test_first_label_quit_does_not_exit_when_the_close_is_declined(monkeypatch) -> None:
+    """A declined close means the application is not quitting, so it must not exit.
+
+    Exiting anyway would skip the cleanup that closing the window performs.
+    """
+    stub = _quit_prompt_stub(monkeypatch, close_accepted=False)
+
+    # returns normally instead of raising SystemExit
+    MainControlWidget._get_first_label(stub)
+
+    assert stub.closed == [True]

--- a/tests/ui/test_main_window.py
+++ b/tests/ui/test_main_window.py
@@ -42,23 +42,44 @@ def _scan_complete_stub(project, scan_thread, sender=None) -> SimpleNamespace:
     )
 
 
-def test_quit_application_closes_window_before_quitting(monkeypatch):
-    """Quit closes the window first so closeEvent's cleanup runs, then quits.
-
-    Closing delivers the close event synchronously; the explicit quit is what
-    ends the application even when another top-level window is still open.
-    """
+def _quit_stub(monkeypatch, close_accepted: bool) -> tuple[SimpleNamespace, MagicMock]:
+    """Return a stub self whose close() reports the given result, and a call recorder."""
     calls = MagicMock()
+    calls.close.return_value = close_accepted
     stub = SimpleNamespace(close=calls.close)
     monkeypatch.setattr(
         main_window_module,
         "QtWidgets",
         SimpleNamespace(QApplication=SimpleNamespace(quit=calls.quit)),
     )
+    return stub, calls
+
+
+def test_quit_application_closes_window_before_quitting(monkeypatch):
+    """Quit closes the window first so closeEvent's cleanup runs, then quits.
+
+    Closing delivers the close event synchronously; the explicit quit is what
+    ends the application even when another top-level window is still open.
+    """
+    stub, calls = _quit_stub(monkeypatch, close_accepted=True)
 
     MainWindow.quit_application(stub)
 
     assert calls.mock_calls == [call.close(), call.quit()]
+
+
+def test_quit_application_does_not_quit_when_the_close_is_declined(monkeypatch):
+    """A declined close means the app is not quitting, so the event loop stays up.
+
+    Quitting anyway would leave the loop without the cleanup closeEvent performs,
+    which is the failure this method exists to prevent.
+    """
+    stub, calls = _quit_stub(monkeypatch, close_accepted=False)
+
+    MainWindow.quit_application(stub)
+
+    assert calls.mock_calls == [call.close()]
+    calls.quit.assert_not_called()
 
 
 def test_feature_cache_scan_results_stored_on_project():

--- a/tests/ui/test_main_window.py
+++ b/tests/ui/test_main_window.py
@@ -1,11 +1,11 @@
-"""Tests for MainWindow feature cache scan handling.
+"""Tests for MainWindow shutdown and feature cache scan handling.
 
 The methods under test are called unbound with lightweight stand-ins for ``self``,
 so a full MainWindow (and its child widgets) never has to be constructed.
 """
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 
@@ -23,6 +23,25 @@ pytestmark = pytest.mark.skipif(
     SKIP_UI_TESTS,
     reason=SKIP_REASON if SKIP_UI_TESTS else "",
 )
+
+
+def test_quit_application_closes_window_before_quitting(monkeypatch):
+    """Quit closes the window first so closeEvent's cleanup runs, then quits.
+
+    Closing delivers the close event synchronously; the explicit quit is what
+    ends the application even when another top-level window is still open.
+    """
+    calls = MagicMock()
+    stub = SimpleNamespace(close=calls.close)
+    monkeypatch.setattr(
+        main_window_module,
+        "QtWidgets",
+        SimpleNamespace(QApplication=SimpleNamespace(quit=calls.quit)),
+    )
+
+    MainWindow.quit_application(stub)
+
+    assert calls.mock_calls == [call.close(), call.quit()]
 
 
 def test_feature_cache_scan_results_stored_on_project():


### PR DESCRIPTION
## Summary

Two of the three ways to quit JABS never delivered a close event, so `MainWindow.closeEvent` — and the cleanup it performs — was skipped. With a background thread still running, the process aborts with SIGABRT at interpreter shutdown; the process pool shutdown was also being skipped.

Stacked on #424 (both branches touch `main_window.py`). Base retargets to `main` once that merges.

## The problem

| Quit path | Delivered a close event? |
| --- | --- |
| Window close button | yes |
| Quit menu item / Ctrl+Q (`menu_builder.py`) | no — wired straight to `QCoreApplication.quit`, which leaves the event loop without closing anything |
| "Quit JABS" on the first-behavior prompt (`main_control_widget.py`) | no — bare `sys.exit(0)` |

Measured with a background scan in flight (20 videos), the two bypassing paths exited with code **134 (SIGABRT)** after `QThread: Destroyed while thread is still running`, and `_process_pool.shutdown()` was never called.

The gap predates the feature cache scan (`ProjectLoaderThread` is exposed the same way, and it runs longer), but the scan makes it easy to hit because it starts automatically when a project opens — the seconds right after opening are exactly when someone might hit Ctrl+Q, and the first-behavior prompt appears in that same window.

## The fix

- `MainWindow.quit_application()`: `close()` to deliver the close event synchronously, then `QtWidgets.QApplication.quit()`. The Quit action now points at this.
- The explicit quit is load-bearing. Connecting the action to `close()` alone leaves the application running when another top-level window is open, and JABS creates some without a parent (`TrainingReportDialog(..., parent=None)`), so Ctrl+Q with a training report open would have closed the main window and left the app alive.
- The first-behavior prompt's quit calls `QApplication.closeAllWindows()` before `sys.exit(0)`, which delivers the close event synchronously so cleanup finishes first.

## Verification

Measured with a scan in flight (20 videos, 0.4 s each):

| Path | Before | After |
| --- | --- | --- |
| Quit menu / Ctrl+Q | SIGABRT (134), pool never shut down | exit 0, scan stopped in 0.11 s, pool shut down |
| Quit menu, unparented window open | n/a | exit 0, cleanup ran, app still quits |
| First-behavior "Quit JABS" | bypassed cleanup | exit 0, scan stopped, pool shut down |
| Window close button | already clean | unchanged, exit 0 |

962 tests pass (7 added covering the quit call order and the first-behavior prompt path). Ruff clean.

## Known remaining case

If a filesystem call is genuinely wedged, the bounded wait in `closeEvent` times out and the abort still happens on every path: no cooperative cancel can interrupt a blocked `h5py.File()` open. Left alone deliberately — a hung mount makes JABS unusable regardless, and `QThread::terminate()` is a worse trade.
