### PR TITLE
Fix IndexError in delete_bouts and suppress a lone too-short bout in the duration filter

### DIFF
--- a/packages/jabs-behavior/src/jabs/behavior/events/behavior_events.py
+++ b/packages/jabs-behavior/src/jabs/behavior/events/behavior_events.py
@@ -57,14 +57,19 @@ class BehaviorEvents:
     def delete_bouts(self, indices_to_remove) -> None:
         """Helper function to delete events from bout data.
 
+        The deleted bout's frames are absorbed by its neighboring bouts, so the
+        total number of encoded frames is preserved. This object is modified in
+        place.
+
         Args:
             indices_to_remove: event indices to delete
 
-        Returns:
-            Bouts object that has been modified to interpolate within deleted events
-
         Notes:
-            Interpolation on an odd number will result with the "previous" state getting 1 more frame compared to "next" state
+            Interpolation on an odd number of frames will result with the "next" state getting 1
+            more frame compared to the "previous" state.
+
+            A bout with no neighbor to absorb its frames (i.e. the only remaining bout) is left
+            in place, since removing it would shorten the encoded vector.
         """
         new_durations = np.copy(self.durations)
         new_starts = np.copy(self.starts)
@@ -72,7 +77,11 @@ class BehaviorEvents:
         if len(indices_to_remove) > 0:
             # Delete backwards so that we don't need to shift indices
             for cur_gap in np.sort(indices_to_remove)[::-1]:
-                if cur_gap == 0:
+                if len(new_durations) < 2:
+                    # Nothing left to merge this bout into. Deleting it anyway would drop its
+                    # frames from the encoded vector, so leave it as-is.
+                    continue
+                elif cur_gap == 0:
                     # Remove the first bout, merge with the next (use next bout's class)
                     new_durations[1] += new_durations[0]
                     new_starts[1] = new_starts[0]

--- a/packages/jabs-behavior/src/jabs/behavior/postprocessing/stages/duration_stage.py
+++ b/packages/jabs-behavior/src/jabs/behavior/postprocessing/stages/duration_stage.py
@@ -25,6 +25,14 @@ class BoutDurationFilterStage(PostprocessingStage):
     def apply(self, classes: np.ndarray, probabilities: np.ndarray) -> np.ndarray:
         """Apply the duration filter to the predictions.
 
+        A too-short bout is normally removed by absorbing its frames into the
+        neighboring bouts, which for a lone short BEHAVIOR bout means the
+        surrounding NOT_BEHAVIOR state takes them over. When the whole vector is
+        one too-short BEHAVIOR bout there is no neighbor to absorb it, so the
+        frames are set to NOT_BEHAVIOR directly: leaving them as BEHAVIOR would
+        keep a bout this filter rejected, and would make the result depend on
+        whether other frames happened to be present.
+
         Args:
             classes (np.ndarray): The predicted classes.
             probabilities (np.ndarray): The predicted probabilities. (Not used in this stage.)
@@ -39,9 +47,13 @@ class BoutDurationFilterStage(PostprocessingStage):
             rle_data.states == ClassLabels.BEHAVIOR,
         )
 
-        if np.any(bouts_to_remove):
-            rle_data.delete_bouts(np.where(bouts_to_remove)[0])
+        if not np.any(bouts_to_remove):
+            return rle_data.to_vector()
 
+        if len(rle_data.states) == 1:
+            return np.full_like(classes, ClassLabels.NOT_BEHAVIOR)
+
+        rle_data.delete_bouts(np.where(bouts_to_remove)[0])
         return rle_data.to_vector()
 
     @classmethod

--- a/packages/jabs-behavior/tests/test_behavior_events.py
+++ b/packages/jabs-behavior/tests/test_behavior_events.py
@@ -232,6 +232,35 @@ class TestBehaviorEvents:
         np.testing.assert_array_equal(events.durations, [2, 2, 2])
         np.testing.assert_array_equal(events.states, [0, 1, 0])
 
+    def test_delete_bouts_only_bout_is_kept(self):
+        """Test delete_bouts on a single-bout encoding leaves the bout in place.
+
+        There is no neighboring bout to absorb the frames, so removing it would shorten the
+        encoded vector.
+        """
+        events = BehaviorEvents.from_vector(np.array([1, 1, 1]))
+        events.delete_bouts([0])
+
+        np.testing.assert_array_equal(events.starts, [0])
+        np.testing.assert_array_equal(events.durations, [3])
+        np.testing.assert_array_equal(events.states, [1])
+        np.testing.assert_array_equal(events.to_vector(), [1, 1, 1])
+
+    def test_delete_bouts_all_bouts_keeps_last_remaining(self):
+        """Test delete_bouts when every bout is marked for removal.
+
+        The bouts merge until a single bout is left, which is then kept so the encoded vector
+        keeps its original length.
+        """
+        events = BehaviorEvents.from_vector(np.array([0, 0, 1, 1]))
+        events.delete_bouts([0, 1])
+
+        # index 1 (the last bout) merges into index 0, leaving a single bout that is kept
+        np.testing.assert_array_equal(events.starts, [0])
+        np.testing.assert_array_equal(events.durations, [4])
+        np.testing.assert_array_equal(events.states, [0])
+        assert len(events.to_vector()) == 4
+
     def test_rle_simple(self):
         """Test _rle with simple input."""
         vector = np.array([1, 1, 2, 2, 2, 1])

--- a/packages/jabs-behavior/tests/test_behavior_events.py
+++ b/packages/jabs-behavior/tests/test_behavior_events.py
@@ -250,7 +250,9 @@ class TestBehaviorEvents:
         """Test delete_bouts when every bout is marked for removal.
 
         The bouts merge until a single bout is left, which is then kept so the encoded vector
-        keeps its original length.
+        keeps its original length. Which state survives follows from the merge order rather
+        than from any rule, so callers that care (such as the postprocessing stages) decide
+        the outcome themselves instead of relying on this.
         """
         events = BehaviorEvents.from_vector(np.array([0, 0, 1, 1]))
         events.delete_bouts([0, 1])

--- a/packages/jabs-behavior/tests/test_duration_filter.py
+++ b/packages/jabs-behavior/tests/test_duration_filter.py
@@ -215,6 +215,19 @@ class TestDurationFilter:
         expected = np.array([ClassLabels.NOT_BEHAVIOR] * len(classes))
         np.testing.assert_array_equal(result, expected)
 
+    def test_apply_uniform_short_behavior_vector(self):
+        """Test apply on a vector that is a single short BEHAVIOR bout.
+
+        There is no neighboring bout to absorb the removed frames, so the predictions are
+        returned unchanged rather than raising.
+        """
+        filter_obj = BoutDurationFilterStage(min_duration=5)
+        classes = np.full(3, ClassLabels.BEHAVIOR, dtype=np.int8)
+
+        result = filter_obj.apply(classes, np.zeros(3, dtype=np.float32))
+
+        np.testing.assert_array_equal(result, classes)
+
     def test_help_method(self):
         """Test that help method returns valid FilterHelp."""
         filter_obj = BoutDurationFilterStage(min_duration=5)

--- a/packages/jabs-behavior/tests/test_duration_filter.py
+++ b/packages/jabs-behavior/tests/test_duration_filter.py
@@ -218,11 +218,49 @@ class TestDurationFilter:
     def test_apply_uniform_short_behavior_vector(self):
         """Test apply on a vector that is a single short BEHAVIOR bout.
 
-        There is no neighboring bout to absorb the removed frames, so the predictions are
-        returned unchanged rather than raising.
+        There is no neighboring bout to absorb the removed frames, so the frames become
+        NOT_BEHAVIOR directly: the same outcome a neighboring NOT_BEHAVIOR bout would have
+        produced, rather than keeping a bout the filter rejected.
         """
         filter_obj = BoutDurationFilterStage(min_duration=5)
         classes = np.full(3, ClassLabels.BEHAVIOR, dtype=np.int8)
+
+        result = filter_obj.apply(classes, np.zeros(3, dtype=np.float32))
+
+        np.testing.assert_array_equal(result, np.full(3, ClassLabels.NOT_BEHAVIOR))
+        assert result.dtype == classes.dtype
+
+    def test_apply_short_behavior_bout_matches_with_and_without_a_neighbor(self):
+        """A short BEHAVIOR bout is suppressed whether or not other frames surround it.
+
+        Guards the inconsistency of the same bout being kept when it is alone in the vector
+        and dropped when a NOT_BEHAVIOR bout happens to follow it.
+        """
+        filter_obj = BoutDurationFilterStage(min_duration=5)
+        alone = np.full(3, ClassLabels.BEHAVIOR, dtype=np.int8)
+        with_neighbor = np.array(
+            [ClassLabels.BEHAVIOR] * 3 + [ClassLabels.NOT_BEHAVIOR] * 3, dtype=np.int8
+        )
+
+        result_alone = filter_obj.apply(alone, np.zeros(3, dtype=np.float32))
+        result_with_neighbor = filter_obj.apply(with_neighbor, np.zeros(6, dtype=np.float32))
+
+        assert set(np.unique(result_alone)) == {ClassLabels.NOT_BEHAVIOR}
+        assert set(np.unique(result_with_neighbor)) == {ClassLabels.NOT_BEHAVIOR}
+
+    def test_apply_uniform_behavior_vector_at_min_duration_is_kept(self):
+        """A lone bout that meets the minimum duration is not filtered."""
+        filter_obj = BoutDurationFilterStage(min_duration=5)
+        classes = np.full(5, ClassLabels.BEHAVIOR, dtype=np.int8)
+
+        result = filter_obj.apply(classes, np.zeros(5, dtype=np.float32))
+
+        np.testing.assert_array_equal(result, classes)
+
+    def test_apply_uniform_short_none_vector_is_untouched(self):
+        """A lone short bout of NONE is not a BEHAVIOR bout, so the filter ignores it."""
+        filter_obj = BoutDurationFilterStage(min_duration=5)
+        classes = np.full(3, ClassLabels.NONE, dtype=np.int8)
 
         result = filter_obj.apply(classes, np.zeros(3, dtype=np.float32))
 

--- a/packages/jabs-behavior/tests/test_interpolation_stage.py
+++ b/packages/jabs-behavior/tests/test_interpolation_stage.py
@@ -313,3 +313,16 @@ class TestInterpolationFilter:
         filter_obj = GapInterpolationStage(max_interpolation_gap=7)
         assert "max_interpolation_gap" in filter_obj.config
         assert filter_obj.config["max_interpolation_gap"] == 7
+
+    def test_apply_uniform_short_none_vector_is_unchanged(self):
+        """A vector that is entirely NONE has no neighboring state to interpolate from.
+
+        Unlike the duration filter, which suppresses a lone rejected bout, there is no
+        prediction here to spread into the gap, so the frames stay NONE.
+        """
+        filter_obj = GapInterpolationStage(max_interpolation_gap=5)
+        classes = np.full(3, ClassLabels.NONE, dtype=np.int8)
+
+        result = filter_obj.apply(classes, np.zeros(3, dtype=np.float32))
+
+        np.testing.assert_array_equal(result, classes)

--- a/packages/jabs-behavior/tests/test_stitching_stage.py
+++ b/packages/jabs-behavior/tests/test_stitching_stage.py
@@ -277,3 +277,16 @@ class TestStitchingStage:
         filter_obj = BoutStitchingStage(max_stitch_gap=5)
         assert "max_stitch_gap" in filter_obj.config
         assert filter_obj.config["max_stitch_gap"] == 5
+
+    def test_apply_uniform_short_not_behavior_vector_is_unchanged(self):
+        """A vector with no BEHAVIOR bouts has no bouts to stitch together.
+
+        Unlike the duration filter, which suppresses a lone rejected bout, stitching only
+        joins behavior across a gap, so with nothing to join the frames stay NOT_BEHAVIOR.
+        """
+        filter_obj = BoutStitchingStage(max_stitch_gap=3)
+        classes = np.full(2, ClassLabels.NOT_BEHAVIOR, dtype=np.int8)
+
+        result = filter_obj.apply(classes, np.zeros(2, dtype=np.float32))
+
+        np.testing.assert_array_equal(result, classes)


### PR DESCRIPTION
## Reasoning

I looked for candidates across all six categories and picked this one because it is a category-1 bug (unhandled edge case) with a reproducible crash, it sits in non-GUI core logic (`jabs-behavior`), and the fix is small and testable. Other candidates I considered and passed over, all lower priority:

- `docs/development/development.md` omits `jabs-behavior` from the "Project Structure" tree and the "Monorepo Transition" list (category 2, docs-only).
- The three postprocessing stages' `help()` docstrings say `Returns: FilterHelp` but the actual type is `StageHelp` (category 2, cosmetic).
- `GapInterpolationStage.__init__` reassigns `self._config = {...}` where the sibling stages assign a key into the dict inherited from `super().__init__` (category 3, currently equivalent).

### What was wrong

[`BehaviorEvents.delete_bouts`](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/main/packages/jabs-behavior/src/jabs/behavior/events/behavior_events.py#L57-L120) assumed every bout marked for removal had a neighbor to merge into. When the run-length encoding held a single bout, the `cur_gap == 0` branch did `new_durations[1] += new_durations[0]` on a length-1 array and raised `IndexError`.

All three postprocessing stages reach this when an identity's prediction vector is a **single run that is also below the stage's threshold**. Both conditions are required — a uniform vector alone is not enough, since a whole-video run of thousands of frames never satisfies `durations < min_duration`:

```python
# crashes on main
BoutDurationFilterStage(min_duration=5).apply(np.array([1, 1, 1]), None)
GapInterpolationStage(max_interpolation_gap=5).apply(np.array([-1, -1, -1]), None)
BoutStitchingStage(max_stitch_gap=3).apply(np.array([0, 0]), None)
# IndexError: index 1 is out of bounds for axis 0 with size 1

# does NOT crash — uniform, but the run exceeds the threshold
BoutDurationFilterStage(min_duration=5).apply(np.full(1800, 1), None)
```

So the real triggers are a very short clip, or a threshold configured larger than the video — a latent edge case rather than something users are likely hitting today. The same path is also reached when *every* bout is marked for removal, though that is unreachable from the stages (RLE runs alternate by construction, so a stage filtering on one class can never mark them all).

Neither call site guards against it: `BinaryClassifyStrategy.postprocess_identity` (`src/jabs/ui/classify_strategy.py:132`) and the per-identity loop in `src/jabs/scripts/cli/postprocessing.py:388` both let the `IndexError` propagate uncaught.

### Why the fix is safe

The `delete_bouts` guard only fires when fewer than two bouts remain — exactly the states that previously raised. Every input that worked before takes an identical path.

Leaving the lone bout in place *inside the primitive* is the length-preserving choice: `delete_bouts` absorbs a removed bout's frames into its neighbors, so with no neighbor there is nothing to absorb them, and deleting anyway would return a vector shorter than the input. Callers index `postprocessed[i]` into a fixed `(n_identities, n_frames)` array and require the length to be preserved.

But the primitive is state-agnostic, so it cannot decide the *outcome*, and the three stages do not want the same one. `BoutDurationFilterStage` exists to eliminate brief predictions, so a rejected bout surviving is the filter failing at its job — and with only the guard, the same 3-frame bout got opposite treatment depending on whether anything else was in the vector:

```
[1,1,1,0,0,0] -> [0 0 0 0 0 0]   suppressed
[1,1,1]       -> [1 1 1]         kept
```

Interpolation and stitching *do* want the guard's behavior: an all-NONE vector has no prediction to spread into the gap, and a vector with no BEHAVIOR bouts has no gaps to join. So the outcome decision belongs in the stages, which is what the second commit does.

## Change

### Logic changes

- **`packages/jabs-behavior/src/jabs/behavior/events/behavior_events.py`** — added a `len(new_durations) < 2` guard at the top of the deletion loop in `delete_bouts`, which skips bouts that have no neighbor left to merge into. Also corrected two errors in the same docstring:
  - it documented a `Returns:` value, but the method mutates in place and returns `None`;
  - its note on odd-length interpolation said the *previous* state gets the extra frame. The code assigns `floor(n/2)` to the previous bout and `ceil(n/2)` to the next, so the *next* state gets it. The existing test `test_delete_bouts_non_matching_borders_odd_duration` already asserts the code's actual behavior, so only the prose was wrong.

- **`packages/jabs-behavior/src/jabs/behavior/postprocessing/stages/duration_stage.py`** — `apply()` returns `np.full_like(classes, NOT_BEHAVIOR)` when the whole vector is one bout it marked for removal, matching what a neighboring NOT_BEHAVIOR bout would have done. `full_like` preserves the caller's dtype and length.

- **Tests** (`test_behavior_events.py`, `test_duration_filter.py`, `test_interpolation_stage.py`, `test_stitching_stage.py`) — regression coverage for: deleting the only bout; marking every bout for removal; the with-neighbor/without-neighbor pair asserting they now agree; a bout exactly at `min_duration` (the comparison is strict `<`); a lone short NONE bout the duration filter ignores; and the lone bout being *kept* by interpolation and stitching, so the difference between the three stages reads as a decision rather than an oversight.

### Mechanical updates

None. No imports, exports, or public signatures changed, and no `FEATURE_VERSION` bump (no computed feature values are affected).

### Verification

`ruff check .`, `ruff format .`, `pytest packages/jabs-behavior/tests` (109 passed) and the root suite (806 passed, 200 skipped) all clean.

---

This PR was produced by an automated analysis from Claude Code.