### PR TITLE
Correct label-count return types/docs and remove broken VideoLabels.counts

### DIFF
--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -1099,18 +1099,15 @@ class Project:
         # save project file
         self._settings_manager.remove_behavior(behavior)
 
-    def counts(self, behavior):
+    def counts(self, behavior: str) -> dict[str, dict[int, dict[str, tuple[int, int]]]]:
         """get the labeled frame counts and bout counts for each video in the project
 
+        Args:
+            behavior: behavior to get label counts for
+
         Returns:
-            dict where keys are video names and values are lists of
-                (
-                    identity,
-                    (behavior frame count - fragmented, not behavior frame count - fragmented),
-                    (behavior bout count - fragmented, not behavior bout count - fragmented),
-                    (behavior frame count - unfragmented, not behavior frame count - unfragmented),
-                    (behavior bout count - unfragmented, not behavior bout count - unfragmented)
-                )
+            dict keyed by video name, where each value is the per-identity count
+            mapping returned by :meth:`load_counts` for that video.
         """
         counts = {}
         for video in self._video_manager.videos:
@@ -1606,8 +1603,12 @@ class Project:
             return False
         return True
 
-    def load_counts(self, video, behavior) -> dict[str, tuple[int, int]]:
+    def load_counts(self, video: str, behavior: str) -> dict[int, dict[str, tuple[int, int]]]:
         """load labeled frame and bout counts from json file
+
+        Args:
+            video: name of the video to load counts for
+            behavior: behavior to get label counts for
 
         Returns:
             dict of labeled frame and bout counts for each identity for
@@ -1669,12 +1670,13 @@ class Project:
                 labels = data.get("labels", {})
 
                 for identity in set(unfragmented_labels.keys()).union(labels.keys()):
-                    fragmented_counts = (
-                        count_labels(labels.get(identity, [])) if labels else ((0, 0), (0, 0))
-                    )
+                    # an identity may be present in one of the two label sections but not
+                    # the other, so default to an empty behavior mapping (which counts as
+                    # zero frames and zero bouts) rather than assuming it is present
+                    fragmented_counts = count_labels(labels.get(identity, {}))
 
                     if "unfragmented_labels" in data:
-                        unfragmented_counts = count_labels(unfragmented_labels.get(identity, []))
+                        unfragmented_counts = count_labels(unfragmented_labels.get(identity, {}))
                     else:
                         # if the file doesn't have unfragmented labels, use the fragmented counts -- they're the same
                         # unless the user creates some new labels over frames without identity

--- a/src/jabs/project/project_pruning.py
+++ b/src/jabs/project/project_pruning.py
@@ -21,7 +21,7 @@ def get_videos_to_prune(project: Project, behavior: str | None = None) -> list[V
         behavior (str | None): The behavior to check for labels. If None, checks all behaviors.
     """
 
-    def check_label_counts(label_counts: dict[str, dict[str, tuple[int, int]]]) -> bool:
+    def check_label_counts(label_counts: dict[int, dict[str, tuple[int, int]]]) -> bool:
         """Return True if any count in label_counts is greater than zero."""
         for identity_counts in label_counts.values():
             for counts in identity_counts.values():

--- a/src/jabs/project/video_labels.py
+++ b/src/jabs/project/video_labels.py
@@ -154,27 +154,6 @@ class VideoLabels:
         """
         yield from self._identity_labels.get(identity, {}).items()
 
-    def counts(self, behavior):
-        """get the count of labeled frames and bouts for each identity in this video for a specified behavior
-
-        Args:
-            behavior: behavior to get label counts for
-
-        Returns:
-            list of tuples with the following form
-            (
-                identity,
-                (behavior frame count, not behavior frame count),
-                (behavior bout count, not behavior bout count)
-            )
-        """
-        counts = []
-        for identity in self._identity_labels:
-            if behavior in self._identity_labels[identity]:
-                c = self._identity_labels[identity][behavior].counts
-                counts.append((identity, c[0], c[1]))
-        return counts
-
     def as_dict(
         self,
         pose: PoseEstimation,

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -912,3 +912,65 @@ def test_get_multiclass_labeled_features_fills_missing_behavior_keys(
         features["labels_by_behavior"]["Run"],
         np.full(2, TrackLabels.Label.NONE, dtype=np.int8),
     )
+
+
+# ---------------------------------------------------------------------------
+# load_counts
+# ---------------------------------------------------------------------------
+
+
+def _write_annotations(project: Project, video: str, data: dict) -> None:
+    """Write a raw annotation dict to the project's annotation directory."""
+    path = project.project_paths.annotations_dir / Path(video).with_suffix(".json")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        json.dump(data, f)
+
+
+def test_load_counts_keys_identities_by_int(tmp_path: Path) -> None:
+    """Identities are returned as ints, with fragmented and unfragmented counts."""
+    project = _bare_project(tmp_path)
+    _write_annotations(
+        project,
+        "video_a.avi",
+        {
+            "file": "video_a.avi",
+            "num_frames": 100,
+            "labels": {"0": {"Walk": [{"start": 0, "end": 4, "present": True}]}},
+            "unfragmented_labels": {"0": {"Walk": [{"start": 0, "end": 9, "present": True}]}},
+        },
+    )
+
+    counts = project.load_counts("video_a.avi", "Walk")
+
+    assert counts[0]["fragmented_frame_counts"] == (5, 0)
+    assert counts[0]["fragmented_bout_counts"] == (1, 0)
+    assert counts[0]["unfragmented_frame_counts"] == (10, 0)
+    assert counts[0]["unfragmented_bout_counts"] == (1, 0)
+
+
+def test_load_counts_identity_missing_from_one_section(tmp_path: Path) -> None:
+    """An identity present in only one label section counts as zero in the other."""
+    project = _bare_project(tmp_path)
+    _write_annotations(
+        project,
+        "video_a.avi",
+        {
+            "file": "video_a.avi",
+            "num_frames": 100,
+            # identity "1" has unfragmented labels only (all of its labeled frames
+            # fall on frames where the identity is not tracked)
+            "labels": {"0": {"Walk": [{"start": 0, "end": 4, "present": True}]}},
+            "unfragmented_labels": {
+                "0": {"Walk": [{"start": 0, "end": 4, "present": True}]},
+                "1": {"Walk": [{"start": 20, "end": 24, "present": True}]},
+            },
+        },
+    )
+
+    counts = project.load_counts("video_a.avi", "Walk")
+
+    assert counts[1]["fragmented_frame_counts"] == (0, 0)
+    assert counts[1]["fragmented_bout_counts"] == (0, 0)
+    assert counts[1]["unfragmented_frame_counts"] == (5, 0)
+    assert counts[1]["unfragmented_bout_counts"] == (1, 0)


### PR DESCRIPTION
## Reasoning

The label-count API (`Project.load_counts` → `Project.counts`) is consumed in six
places (`central_widget`, `training_strategy`, `session_tracker`,
`project_pruning`, `cross_validation` CLI, `MultiClassClassifier`), and every one
of them treats the result as `dict[identity_int, dict[str, tuple[int, int]]]`.
The declarations disagreed with that in three ways, all of which actively mislead
a reader:

1. [`Project.load_counts`](src/jabs/project/project.py#L1606) was annotated
   `-> dict[str, tuple[int, int]]`. Both the key type and the value type are
   wrong — keys are `int` (the code does `counts[int(identity)] = {...}`) and
   values are dicts of four named count tuples. The docstring body below it
   already described the correct shape, so the annotation contradicted the
   docstring immediately above the code.
2. [`Project.counts`](src/jabs/project/project.py#L1102) documented its values as
   *"lists of (identity, 4 tuples)"* — a shape that no longer exists anywhere.
3. [`VideoLabels.counts`](src/jabs/project/video_labels.py#L157) is where that
   obsolete shape came from, and it is broken: it reads
   `TrackLabels.counts`, an attribute `TrackLabels` does not define. Any call
   with a labeled identity raises `AttributeError: 'TrackLabels' object has no
   attribute 'counts'` (verified against `main`). It has no callers in `src/`,
   `tests/`, or `packages/`.

While confirming the real shape I also found a latent crash in `load_counts`.
The loop iterates the *union* of identity keys from the `labels` and
`unfragmented_labels` sections, but defaults a missing identity to `[]` — and
`count_labels` immediately calls `.get()` on its argument. An identity present in
one section but not the other therefore raises
`AttributeError: 'list' object has no attribute 'get'`. Files written by
`VideoLabels.as_dict` currently keep both sections in sync (it seeds `{}` for
every identity in both), so this is unreachable today, but it is one asymmetric
annotation file away from a hard failure at project load. A wrong-typed default
constant is exactly the kind of thing that stops being latent when the writer
changes.

I picked this over the other candidates I looked at (a copy-paste "ignored"
docstring on `psd_mean_band`'s `freqs` parameter, which *is* used; the
`TrackLabels.downsample` docstring's imprecise PAD bin description) because this
one is a genuine bug plus documentation that would send a reader down the wrong
path about a widely-consumed return type — not just cosmetics.

**Why it's safe:** net-zero behavior change on every reachable path.
`count_labels({})` returns `((0, 0), (0, 0))`, which is exactly what the removed
`if labels else ((0, 0), (0, 0))` guard produced, so the guard is redundant, not
dropped semantics. Annotations and docstrings do not affect runtime. The removed
`VideoLabels.counts` could only ever raise. No `FEATURE_VERSION` bump — no
computed feature values are touched.

## Change

### Logic changes

- **`src/jabs/project/project.py`**
  - `load_counts`: corrected return annotation to
    `dict[int, dict[str, tuple[int, int]]]`; added the missing `Args` section;
    changed the two missing-identity defaults from `[]` to `{}` and removed the
    now-redundant `if labels` guard (the AttributeError fix).
  - `counts`: added `behavior: str` and the return annotation; replaced the
    obsolete list-of-tuples `Returns` description with a pointer to
    `load_counts`.
- **`src/jabs/project/video_labels.py`** — removed the unused, always-raising
  `counts()` method.
- **`src/jabs/project/project_pruning.py`** — corrected the identity key type on
  the local `check_label_counts` helper (`dict[str, ...]` → `dict[int, ...]`) to
  match what `load_counts` returns.
- **`tests/project/test_project.py`** — two regression tests for `load_counts`:
  one asserting identities come back as `int` with both fragmented and
  unfragmented counts, one covering an identity present only in
  `unfragmented_labels`. The second fails on `main` with the `AttributeError`
  above.

### Mechanical updates

None — no import paths, exports, or re-export shims were touched.

### Verification

`ruff check .` and `ruff format .` clean; full root suite `827 passed,
200 skipped`. Nothing under `packages/` was modified.

---

This PR was produced by an automated analysis from Claude Code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1cGDmJzKJq3NabpGcEDwq)_