### PR TITLE
Build timeline annotations through the Annotation dataclass on load

### DIFF
--- a/src/jabs/project/timeline_annotations.py
+++ b/src/jabs/project/timeline_annotations.py
@@ -1,9 +1,11 @@
-import sys
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
 from intervaltree import Interval, IntervalTree
+
+logger = logging.getLogger(__name__)
 
 MAX_TAG_LEN = 32
 
@@ -40,7 +42,8 @@ class TimelineAnnotations:
         """Add a new timeline annotation to the interval tree.
 
         Args:
-            annotation (Annotation): The annotation to add.
+            annotation (Annotation): The annotation to add. Its ``start`` and ``end``
+                frames are inclusive, so the stored interval ends at ``end + 1``.
         """
         self._tree[annotation.start : annotation.end + 1] = {
             "tag": annotation.tag,
@@ -54,52 +57,53 @@ class TimelineAnnotations:
     def load(
         cls, data: list[dict[str, Any]], id_index_to_display: Callable[[int], str] | None = None
     ) -> "TimelineAnnotations":
-        """Load a TimelineAnnotations instance from a JSON-compatible dictionary.
+        """Load a TimelineAnnotations instance from a list of serialized annotations.
 
         Args:
-            data (dict): The dictionary containing serialized timeline annotations.
+            data (list[dict[str, Any]]): Serialized timeline annotations, as produced by
+                :meth:`serialize`. The ``start`` and ``end`` frames are inclusive.
             id_index_to_display (Callable[[int], str] | None): Optional function to map identity index to a display string.
 
         Returns:
             TimelineAnnotations: An instance loaded with the provided data.
 
-        Note: loading currently skips invalid entries with a warning printed to stderr. Consider
+        Note: loading currently skips invalid entries with a logged warning. Consider
         raising an exception for stricter handling in the future.
         """
         annotations = cls()
 
-        for annotation in data:
+        for entry in data:
             try:
-                start = annotation["start"]
-                end = annotation["end"]
-                tag = annotation["tag"]
-                color = annotation["color"]
+                start = entry["start"]
+                end = entry["end"]
+                tag = entry["tag"]
+                color = entry["color"]
             except KeyError:
-                print(
-                    "Missing required annotation fields, loading skipped for annotation:",
-                    annotation,
-                    file=sys.stderr,
+                logger.warning(
+                    "Missing required annotation fields, loading skipped for annotation: %s", entry
                 )
                 continue
 
             # validate the tag format:
             if len(tag) < 1 or len(tag) > MAX_TAG_LEN:
-                print(
-                    f"Annotation tag must be 1 to {MAX_TAG_LEN} characters in length, skipping annotation: \n\t{annotation}",
-                    file=sys.stderr,
+                logger.warning(
+                    "Annotation tag must be 1 to %d characters in length, "
+                    "skipping annotation: \n\t%s",
+                    MAX_TAG_LEN,
+                    entry,
                 )
                 continue
             # only allow alphanumeric characters, underscores, and hyphens
             if not all(c.isalnum() or c in "_-" for c in tag):
-                print(
-                    f"Annotation tag can only contain alphanumeric characters, underscores, and hyphens. Skipping annotation: \n\t{annotation}",
-                    file=sys.stderr,
+                logger.warning(
+                    "Annotation tag can only contain alphanumeric characters, underscores, "
+                    "and hyphens. Skipping annotation: \n\t%s",
+                    entry,
                 )
                 continue
 
-            # Create a data dict for the interval.
             # Note: description and identity are optional fields
-            identity_index = annotation.get("identity")
+            identity_index = entry.get("identity")
             if identity_index is not None:
                 if id_index_to_display:
                     display_identity = id_index_to_display(identity_index)
@@ -107,17 +111,18 @@ class TimelineAnnotations:
                     display_identity = str(identity_index)
             else:
                 display_identity = None
-            data = {
-                "tag": tag,
-                "color": color,
-                "description": annotation.get("description"),
-                "identity": identity_index,
-                "display_identity": display_identity,
-            }
 
-            # Add the annotation to the IntervalTree.
-            # The start and end contained in the JSON file are inclusive, so we add 1 to end.
-            annotations._tree[start : end + 1] = data
+            annotations.add_annotation(
+                cls.Annotation(
+                    start=start,
+                    end=end,
+                    tag=tag,
+                    color=color,
+                    description=entry.get("description"),
+                    identity_index=identity_index,
+                    display_identity=display_identity,
+                )
+            )
         return annotations
 
     def serialize(self) -> list[dict]:
@@ -137,7 +142,7 @@ class TimelineAnnotations:
                     "color": element.data["color"],
                 }
             except KeyError as e:
-                print(f"Missing required annotation data: {e}")
+                logger.warning("Missing required annotation data: %s", e)
                 continue
 
             # optional fields

--- a/tests/project/test_timeline_annotations.py
+++ b/tests/project/test_timeline_annotations.py
@@ -137,6 +137,70 @@ def test_load_skips_invalid_entries():
     assert rebuilt2.annotation_exists(start=0, end=1, tag="good_tag-1", identity_index=None)
 
 
+def test_load_stores_same_payload_as_add_annotation():
+    """load() and add_annotation() must produce identical interval payloads."""
+    loaded = TimelineAnnotations.load(
+        [
+            {
+                "start": 5,
+                "end": 9,
+                "tag": "tag1",
+                "color": "#abcdef",
+                "description": "desc",
+                "identity": 3,
+            }
+        ],
+        id_index_to_display=identity_index_to_display,
+    )
+    added = TimelineAnnotations()
+    added.add_annotation(
+        TimelineAnnotations.Annotation(
+            start=5,
+            end=9,
+            tag="tag1",
+            color="#abcdef",
+            description="desc",
+            identity_index=3,
+            display_identity="ID-3",
+        )
+    )
+
+    assert sorted(loaded._tree) == sorted(added._tree)
+
+
+def test_load_continues_after_skipping_invalid_entry():
+    """A skipped entry must not stop the remaining entries from loading."""
+    data = [
+        {"start": 0, "end": 1, "color": "#fff"},  # missing tag, skipped
+        {"start": 2, "end": 3, "tag": "ok_one", "color": "#fff"},
+        {"start": 4, "end": 5, "tag": "bad tag!", "color": "#fff"},  # invalid tag, skipped
+        {"start": 6, "end": 7, "tag": "ok_two", "color": "#fff"},
+    ]
+    rebuilt = TimelineAnnotations.load(data)
+
+    assert len(rebuilt) == 2
+    assert rebuilt.annotation_exists(start=2, end=3, tag="ok_one", identity_index=None)
+    assert rebuilt.annotation_exists(start=6, end=7, tag="ok_two", identity_index=None)
+
+
+def test_load_without_display_mapping_stringifies_identity():
+    """Without a mapping function the identity index is stored as a string."""
+    rebuilt = TimelineAnnotations.load(
+        [{"start": 0, "end": 1, "tag": "tag1", "color": "#fff", "identity": 7}]
+    )
+    (interval,) = list(rebuilt._tree)
+    assert interval.data["identity"] == 7
+    assert interval.data["display_identity"] == "7"
+
+
+def test_load_warns_on_skipped_entry(caplog):
+    """Skipped entries are reported through the module logger, not stdout/stderr."""
+    with caplog.at_level("WARNING", logger="jabs.project.timeline_annotations"):
+        TimelineAnnotations.load([{"start": 0, "end": 1, "tag": "bad tag!", "color": "#fff"}])
+
+    assert any("Skipping annotation" in record.getMessage() for record in caplog.records)
+
+
 @pytest.mark.parametrize(
     "tag, ok",
     [


### PR DESCRIPTION
## Reasoning

I looked for a real bug first, and didn't find one I could confirm with high confidence, so I moved down the list to duplication and clarity. The strongest candidate was `TimelineAnnotations.load()` in [`src/jabs/project/timeline_annotations.py`](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/main/src/jabs/project/timeline_annotations.py#L53-L121), which had three related problems in one ~50-line method:

1. **Duplicated payload construction.** `load()` hand-built the interval data dict (`tag`, `color`, `description`, `identity`, `display_identity`) and wrote `annotations._tree[start : end + 1] = data` directly — exactly what `add_annotation()` already does from an `Annotation`. Two copies of the same payload shape, in the same class, that can drift: adding a field to `Annotation`/`add_annotation` would silently not appear on annotations that came in through `load()`. The `Annotation` dataclass exists precisely to carry this.

2. **The `data` parameter was rebound inside the loop that iterates it.** [Line 110](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/main/src/jabs/project/timeline_annotations.py#L110) did `data = {...}` for the per-entry payload while the enclosing loop was `for annotation in data:`. This is not a live bug — `for` captures the iterator before the first rebind, so iteration completes correctly — but it is a trap: adding any second use of `data` after the loop (a length check, a retry pass, a log line) would read the last entry's payload instead of the input list.

3. **Wrong docstring type.** The parameter was documented as `data (dict): The dictionary containing serialized timeline annotations` while the signature is `list[dict[str, Any]]`.

**Why this is safe:** `add_annotation()` writes `self._tree[annotation.start : annotation.end + 1] = {...}` with the same five keys and the same values that `load()` was writing inline, so the resulting interval tree is byte-for-byte identical. Validation, skip behavior, and the `id_index_to_display` fallback to `str(identity_index)` are all unchanged. Added `test_load_stores_same_payload_as_add_annotation` to pin the equivalence directly.

The one intentional behavioral difference is the warning destination: the module's `print(..., file=sys.stderr)` calls are now `logger.warning(...)` with lazy formatting, per CLAUDE.md's "Never use `print()` for operational output". Visibility is preserved in both entry points — the GUI configures `logging.basicConfig(level=logging.WARNING)` in `gui_entrypoint.py`, and the CLI has no handler configured, so Python's last-resort handler still emits WARNING and above to stderr.

Other candidates I considered and dropped: the unused `frame_mask` parameter on `Feature._compute_window_feature`/`_compute_signal_features` (removing it cascades into the `identity` arguments of `_window_standard`/`_window_signal`, which are protected methods a downstream feature subclass could plausibly override — more risk than a cleanup warrants); and `signal_stats.psd_mean_band` documenting `freqs` as "ignored" when it selects the band (real, but a one-line docstring fix, too thin to stand alone and unrelated to this module).

## Change

### Logic changes

- **`src/jabs/project/timeline_annotations.py`**
  - `load()` now constructs a `cls.Annotation` and calls `annotations.add_annotation(...)` instead of assembling the interval payload and writing to `_tree` directly.
  - Renamed the loop variable from `annotation` to `entry` so the `data` parameter is no longer shadowed; the per-entry dict is gone entirely.
  - Corrected the `data` param docstring to `list[dict[str, Any]]` and noted that `start`/`end` are inclusive.
  - Moved the "start and end are inclusive, so the interval ends at `end + 1`" note onto `add_annotation()`, which is where the `+ 1` now lives.
  - Replaced the four `print()` calls in `load()` and `serialize()` with a module-level `logger` and lazy `%s` formatting; dropped the now-unused `import sys`.

- **`tests/project/test_timeline_annotations.py`** — four new tests:
  - `test_load_stores_same_payload_as_add_annotation` — the two construction paths produce identical trees (this is the guard for the refactor).
  - `test_load_continues_after_skipping_invalid_entry` — a skipped entry doesn't stop later entries loading.
  - `test_load_without_display_mapping_stringifies_identity` — the `str(identity_index)` fallback when no mapping function is given.
  - `test_load_warns_on_skipped_entry` — skips are reported through the module logger.

### Mechanical updates

None.

## Verification

`ruff check .` and `ruff format .` clean. Full root suite: **831 passed, 200 skipped**. No files under `packages/` were touched.

---

This PR was produced by an automated analysis from Claude Code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ua3Fkt11kvBCZ6iuVbsbVc)_