### PR TITLE
Fix inconsistent behavior key lookup in Project.archive_behavior

### DIFF
--- a/src/jabs/project/project.py
+++ b/src/jabs/project/project.py
@@ -1043,13 +1043,13 @@ class Project:
             path.unlink()
 
         # archive labels and unfragmented_labels
-        archived_labels = {}
+        archived_labels: dict[str, dict] = {}
         for video in self._video_manager.videos:
-            if (labels := self._video_manager.load_video_labels(video)) is None:
+            if (video_labels := self._video_manager.load_video_labels(video)) is None:
                 continue
 
             pose = self.load_pose_est(self._video_manager.video_path(video))
-            annotations = labels.as_dict(pose)
+            annotations = video_labels.as_dict(pose)
 
             # ensure archive structure exists for this video:
             # {
@@ -1057,36 +1057,28 @@ class Project:
             #   "labels": {"<behavior>": {}},
             #   "unfragmented_labels": {"<behavior>": {}}
             # }
-            if video not in archived_labels:
-                archived_labels[video] = {
+            # the behavior is keyed by its name as provided (not to_safe_name()) in the
+            # archive per requested schema
+            video_archive = archived_labels.setdefault(
+                video,
+                {
                     "num_frames": annotations["num_frames"],
                     "labels": {},
                     "unfragmented_labels": {},
-                }
-            if to_safe_name(behavior) not in archived_labels[video]["labels"]:
-                # keep the behavior key as provided (not safe_name) in the archive per requested schema
-                archived_labels[video]["labels"][behavior] = {}
-            if to_safe_name(behavior) not in archived_labels[video]["unfragmented_labels"]:
-                archived_labels[video]["unfragmented_labels"][behavior] = {}
+                },
+            )
 
-            # Move per-identity blocks for the behavior from live annotations into archive
-            # Identities are stored as string keys in annotations
-            # 1) Fragmented labels
-            if "labels" in annotations:
-                for ident in list(annotations["labels"].keys()):
-                    labels = annotations["labels"].get(ident, {})
-                    if behavior in labels:
-                        # copy to archive
-                        archived_labels[video]["labels"][behavior][ident] = labels.pop(behavior)
-
-            # 2) Unfragmented labels
-            if "unfragmented_labels" in annotations:
-                for ident in list(annotations["unfragmented_labels"].keys()):
-                    labels = annotations["unfragmented_labels"].get(ident, {})
-                    if behavior in labels:
-                        archived_labels[video]["unfragmented_labels"][behavior][ident] = (
-                            labels.pop(behavior)
-                        )
+            # Move per-identity blocks for the behavior from the live annotations into the
+            # archive. Identities are stored as string keys in annotations. Both label
+            # sections are archived: "labels" holds the blocks masked to frames where the
+            # identity has pose data, "unfragmented_labels" holds them unmasked.
+            for section in ("labels", "unfragmented_labels"):
+                archived_section = video_archive[section].setdefault(behavior, {})
+                # values are per-identity dicts of {behavior: blocks}; popping from them
+                # removes the behavior from the annotations saved back to disk below
+                for identity, identity_behaviors in annotations.get(section, {}).items():
+                    if behavior in identity_behaviors:
+                        archived_section[identity] = identity_behaviors.pop(behavior)
 
             # persist the modified annotations back to disk (with the behavior removed)
             self.save_annotations(VideoLabels.load(annotations, pose), pose)

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -997,7 +997,9 @@ def _pose_mock_with_mask(num_frames: int, untracked: slice | None = None) -> Mag
     return pose
 
 
-def _project_for_archive(tmp_path: Path, video: str, labels: VideoLabels, pose: MagicMock):
+def _project_for_archive(
+    tmp_path: Path, video: str, labels: VideoLabels, pose: MagicMock
+) -> Project:
     """Return a project whose single video resolves to ``labels`` and ``pose``."""
     project = _bare_project(tmp_path)
     mock_vm = MagicMock()

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -1,4 +1,5 @@
 import contextlib
+import gzip
 import json
 import shutil
 from pathlib import Path
@@ -974,3 +975,117 @@ def test_load_counts_identity_missing_from_one_section(tmp_path: Path) -> None:
     assert counts[1]["fragmented_bout_counts"] == (0, 0)
     assert counts[1]["unfragmented_frame_counts"] == (5, 0)
     assert counts[1]["unfragmented_bout_counts"] == (1, 0)
+
+
+# ---------------------------------------------------------------------------
+# archive_behavior
+# ---------------------------------------------------------------------------
+
+
+def _pose_mock_with_mask(num_frames: int, untracked: slice | None = None) -> MagicMock:
+    """Return a pose stub whose identity mask hides ``untracked`` frames.
+
+    Hiding frames makes the ``labels`` and ``unfragmented_labels`` sections of a
+    serialized VideoLabels differ, so tests can tell them apart.
+    """
+    mask = np.ones(num_frames, dtype=np.uint8)
+    if untracked is not None:
+        mask[untracked] = 0
+    pose = MagicMock()
+    pose.identity_mask.return_value = mask
+    pose.external_identities = None
+    return pose
+
+
+def _project_for_archive(tmp_path: Path, video: str, labels: VideoLabels, pose: MagicMock):
+    """Return a project whose single video resolves to ``labels`` and ``pose``."""
+    project = _bare_project(tmp_path)
+    mock_vm = MagicMock()
+    mock_vm.videos = [video]
+    mock_vm.video_path.side_effect = lambda v: tmp_path / v
+    mock_vm.load_video_labels.side_effect = lambda v, pose=None: labels
+    project._video_manager = mock_vm
+    project.load_pose_est = MagicMock(return_value=pose)
+    project.save_annotations = MagicMock()
+    return project
+
+
+def _read_archive(project: Project, safe_behavior: str) -> dict:
+    """Return the contents of the single archive file written for a behavior."""
+    archives = list(project.project_paths.archive_dir.glob(f"{safe_behavior}_*.json.gz"))
+    assert len(archives) == 1
+    with gzip.open(archives[0], "rt") as f:
+        return json.load(f)
+
+
+def test_archive_behavior_keys_archive_by_behavior_name(tmp_path: Path) -> None:
+    """The archive is keyed by the behavior name as given, not by its safe name.
+
+    A behavior whose safe name differs from its name (spaces become underscores)
+    is the case where a mismatch between the key written and the key looked up
+    would go unnoticed.
+    """
+    behavior = "Walking Fast"
+    labels = VideoLabels("video1.avi", 100)
+    labels.get_track_labels("0", behavior).label_behavior(10, 20)
+    pose = _pose_mock_with_mask(100)
+    project = _project_for_archive(tmp_path, "video1.avi", labels, pose)
+
+    project.archive_behavior(behavior)
+
+    archive = _read_archive(project, "Walking_Fast")
+    assert list(archive) == ["video1.avi"]
+    assert archive["video1.avi"]["num_frames"] == 100
+    for section in ("labels", "unfragmented_labels"):
+        assert list(archive["video1.avi"][section]) == [behavior]
+        assert archive["video1.avi"][section][behavior] == {
+            "0": [{"start": 10, "end": 20, "present": True}]
+        }
+
+
+def test_archive_behavior_archives_both_label_sections(tmp_path: Path) -> None:
+    """Masked (``labels``) and unmasked (``unfragmented_labels``) blocks are both archived."""
+    labels = VideoLabels("video1.avi", 100)
+    labels.get_track_labels("0", "Walk").label_behavior(10, 20)
+    # frames 15-20 have no pose data for this identity, so the masked section
+    # only keeps frames 10-14
+    pose = _pose_mock_with_mask(100, untracked=slice(15, 21))
+    project = _project_for_archive(tmp_path, "video1.avi", labels, pose)
+
+    project.archive_behavior("Walk")
+
+    archive = _read_archive(project, "Walk")["video1.avi"]
+    assert archive["labels"]["Walk"] == {"0": [{"start": 10, "end": 14, "present": True}]}
+    assert archive["unfragmented_labels"]["Walk"] == {
+        "0": [{"start": 10, "end": 20, "present": True}]
+    }
+
+
+def test_archive_behavior_records_video_with_no_labels_for_behavior(tmp_path: Path) -> None:
+    """A video with labels for other behaviors gets an empty entry for the archived one."""
+    labels = VideoLabels("video1.avi", 100)
+    labels.get_track_labels("0", "Grooming").label_behavior(30, 40)
+    pose = _pose_mock_with_mask(100)
+    project = _project_for_archive(tmp_path, "video1.avi", labels, pose)
+
+    project.archive_behavior("Walk")
+
+    archive = _read_archive(project, "Walk")["video1.avi"]
+    assert archive["labels"] == {"Walk": {}}
+    assert archive["unfragmented_labels"] == {"Walk": {}}
+
+
+def test_archive_behavior_removes_only_archived_behavior_from_annotations(tmp_path: Path) -> None:
+    """The re-saved annotations drop the archived behavior and keep the others."""
+    labels = VideoLabels("video1.avi", 100)
+    labels.get_track_labels("0", "Walk").label_behavior(10, 20)
+    labels.get_track_labels("0", "Grooming").label_behavior(30, 40)
+    pose = _pose_mock_with_mask(100)
+    project = _project_for_archive(tmp_path, "video1.avi", labels, pose)
+
+    project.archive_behavior("Walk")
+
+    project.save_annotations.assert_called_once()
+    saved_labels = project.save_annotations.call_args.args[0]
+    remaining = dict(saved_labels.iter_behavior_labels("0"))
+    assert list(remaining) == ["Grooming"]


### PR DESCRIPTION
## Reasoning

I looked for a defect where the code says one thing and does another. `Project.archive_behavior()` ([project.py:1023](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/main/src/jabs/project/project.py#L1023)) had two:

**1. A guard that can never be false.** The archive-structure setup tested `to_safe_name(behavior)` for membership in dicts that are only ever keyed by the raw `behavior` name:

```python
if to_safe_name(behavior) not in archived_labels[video]["labels"]:
    # keep the behavior key as provided (not safe_name) in the archive per requested schema
    archived_labels[video]["labels"][behavior] = {}
```

The comment on the very next line states the dict is keyed by the raw name, so for any behavior whose safe name differs from its name (`"Walking Fast"` → `"Walking_Fast"`) the condition is always true. This is harmless *today* only because the enclosing loop is `for video in self._video_manager.videos`, so each video is visited exactly once and the reset never happens twice. It is a trap for the next edit, though: the guard exists precisely to prevent clobbering already-collected blocks, and it cannot do that job. Fixed by keying the lookup on `behavior` (via `setdefault`), matching what is written.

**2. A shadowed variable.** `labels` was bound by the walrus to a `VideoLabels` object, then rebound partway through the same loop body to a per-identity `dict` of `{behavior: blocks}`. Two different types under one name in one scope.

Why this over other candidates I considered: the `print()`-instead-of-logging calls scattered through `behavior_search_util.py` and `project_merge.py` are a real convention violation, but converting them changes where output goes, which isn't a net-zero change. Extracting a shared helper for the repeated `unfragmented_labels`-else-`labels` idiom (3 sites) was a cleaner de-dup but lower value. This one is an actual latent bug in a destructive operation (`archive_behavior` deletes predictions and classifiers and rewrites annotation files) that had **zero test coverage**.

**Why it's safe:** net-zero behavior change, and demonstrably so — the four new tests pass unchanged against both the old and the new implementation of `archive_behavior` (I verified by stashing the source change and re-running). The full suite passes: `835 passed, 200 skipped`. `ruff check` and `ruff format` are clean. No `FEATURE_VERSION` bump: nothing here touches feature computation.

## Change

### Logic changes

**`src/jabs/project/project.py`** — `archive_behavior()` only:
- Archive-structure setup now uses `archived_labels.setdefault(...)` and `video_archive[section].setdefault(behavior, {})`, so the key looked up is the key written. Also means a repeat visit to a video would merge rather than reset, which is what the original guards were reaching for.
- The two near-identical blocks that moved blocks out of `"labels"` and `"unfragmented_labels"` are now one loop over `("labels", "unfragmented_labels")`.
- Renamed the outer `labels` → `video_labels` and the inner shadowing `labels` → `identity_behaviors`.
- Added a type annotation on `archived_labels` and a comment explaining that the `.pop()` on the per-identity dicts is what removes the behavior from the annotations saved back to disk.

**`tests/project/test_project.py`** — new `archive_behavior` section (the method previously had no tests):
- `test_archive_behavior_keys_archive_by_behavior_name` — uses `"Walking Fast"`, the case where a raw-vs-safe key mismatch is observable, and asserts the archive is keyed by the raw name in both sections.
- `test_archive_behavior_archives_both_label_sections` — a pose mask hiding frames 15-20 makes the masked and unmasked sections differ, so the test can prove both are archived rather than one twice.
- `test_archive_behavior_records_video_with_no_labels_for_behavior` — a video labeled only for another behavior still gets an empty entry.
- `test_archive_behavior_removes_only_archived_behavior_from_annotations` — the re-saved `VideoLabels` drops the archived behavior and keeps the rest.

### Mechanical updates

- `import gzip` added to `tests/project/test_project.py` (test helper reads the `.json.gz` archive). No logic change.

---

This PR was produced by an automated analysis from Claude Code.

---
_Generated by [Claude Code](https://claude.ai/code/session_019dd7WR8YJr75X1XSn1Bsyp)_