### PR TITLE
Decode JSON-encoded list settings when reading a training file

### DIFF
--- a/src/jabs/project/export_training.py
+++ b/src/jabs/project/export_training.py
@@ -20,6 +20,12 @@ if TYPE_CHECKING:
     from jabs.project import Project
 
 
+# HDF5 attribute set on a settings dataset whose value was JSON-encoded because
+# it has no direct HDF5 equivalent. jabs.project.read_training reads this
+# attribute to decode the value back into the original Python object.
+JSON_ENCODED_SETTING_ATTR = "json_encoded"
+
+
 def _write_group_mapping(
     out_h5: h5py.File, group_mapping: dict[int, dict], string_type: np.dtype
 ) -> None:
@@ -189,6 +195,11 @@ def write_project_settings(
 ):
     """write project settings to a training h5 file recursively
 
+    Lists (e.g. postprocessing stage configs) have no direct HDF5 equivalent, so they
+    are stored as a JSON string tagged with the ``JSON_ENCODED_SETTING_ATTR`` attribute.
+    :func:`jabs.project.read_training.read_project_settings` uses that tag to decode the
+    value back into a list.
+
     Args:
         h5_file: open h5 file to write to
         settings: dict of project settings
@@ -199,8 +210,7 @@ def write_project_settings(
         if type(val) is dict:
             write_project_settings(current_group, val, key)
         elif isinstance(val, list):
-            # Lists (e.g. postprocessing stage configs) have no direct HDF5 equivalent;
-            # store as a JSON string so the data round-trips without loss.
-            current_group.create_dataset(key, data=json.dumps(val))
+            dataset = current_group.create_dataset(key, data=json.dumps(val))
+            dataset.attrs[JSON_ENCODED_SETTING_ATTR] = True
         else:
             current_group.create_dataset(key, data=val)

--- a/src/jabs/project/read_training.py
+++ b/src/jabs/project/read_training.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from typing import Any
 
@@ -6,6 +7,28 @@ import numpy as np
 import pandas as pd
 
 from jabs.core.enums import ClassifierType, ProjectDistanceUnit
+
+from .export_training import JSON_ENCODED_SETTING_ATTR
+
+
+def _read_setting_value(node: h5py.Dataset) -> Any:
+    """Read the value of a single project settings dataset.
+
+    Values that have no direct HDF5 equivalent (currently lists, such as the
+    postprocessing stage configs) are written as JSON strings tagged with the
+    ``JSON_ENCODED_SETTING_ATTR`` attribute, so decode those back into the original
+    object. Settings written before that attribute existed are returned as stored.
+
+    Args:
+        node: settings dataset to read.
+
+    Returns:
+        The setting value, JSON-decoded when the dataset is tagged as JSON-encoded.
+    """
+    value = node[...].item()
+    if node.attrs.get(JSON_ENCODED_SETTING_ATTR, False):
+        return json.loads(value)
+    return value
 
 
 def read_project_settings(h5_file: h5py.Group) -> dict:
@@ -39,10 +62,10 @@ def read_project_settings(h5_file: h5py.Group) -> dict:
             if "/" in fullname:
                 level_name, key = fullname.split("/")
                 level_settings = all_settings.get(level_name, {})
-                level_settings.update({key: node[...].item()})
+                level_settings.update({key: _read_setting_value(node)})
                 all_settings.update({level_name: level_settings})
             else:
-                all_settings.update({fullname: node[...].item()})
+                all_settings.update({fullname: _read_setting_value(node)})
 
     h5_file.visititems(_walk_project_settings)
     return all_settings

--- a/src/jabs/project/read_training.py
+++ b/src/jabs/project/read_training.py
@@ -24,10 +24,18 @@ def _read_setting_value(node: h5py.Dataset) -> Any:
 
     Returns:
         The setting value, JSON-decoded when the dataset is tagged as JSON-encoded.
+
+    Raises:
+        ValueError: If a dataset tagged as JSON-encoded does not hold valid JSON.
     """
     value = node[...].item()
     if node.attrs.get(JSON_ENCODED_SETTING_ATTR, False):
-        return json.loads(value)
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError as e:
+            raise ValueError(
+                f"setting '{node.name}' is tagged as JSON-encoded but could not be decoded: {e}"
+            ) from e
     return value
 
 

--- a/tests/project/test_training_settings.py
+++ b/tests/project/test_training_settings.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+from typing import Any
 
 import h5py
 import pytest
@@ -10,7 +11,7 @@ from jabs.project.export_training import JSON_ENCODED_SETTING_ATTR, write_projec
 from jabs.project.read_training import read_project_settings
 
 
-def _round_trip(tmp_path: Path, settings: dict) -> dict:
+def _round_trip(tmp_path: Path, settings: dict[str, Any]) -> dict[str, Any]:
     """Write settings to a training file and read them back."""
     path = tmp_path / "training.h5"
     with h5py.File(path, "w") as out_h5:
@@ -83,11 +84,23 @@ def test_untagged_string_setting_is_not_decoded(tmp_path: Path) -> None:
     assert settings["postprocessing"] == b'[{"name": "duration"}]'
 
 
+def test_tagged_setting_with_invalid_json_names_the_dataset(tmp_path: Path) -> None:
+    """A tagged dataset holding invalid JSON raises an error naming the setting."""
+    path = tmp_path / "training.h5"
+    with h5py.File(path, "w") as out_h5:
+        group = out_h5.require_group("settings")
+        dataset = group.create_dataset("postprocessing", data="not json")
+        dataset.attrs[JSON_ENCODED_SETTING_ATTR] = True
+
+    with h5py.File(path, "r") as in_h5, pytest.raises(ValueError, match="settings/postprocessing"):
+        read_project_settings(in_h5["settings"])
+
+
 @pytest.mark.parametrize(
     "value",
     [["a", "b"], [1, 2, 3], [[1, 2], [3, 4]], [{"a": 1}]],
     ids=["strings", "ints", "nested_lists", "dicts"],
 )
-def test_list_element_types_round_trip(tmp_path: Path, value: list) -> None:
+def test_list_element_types_round_trip(tmp_path: Path, value: list[Any]) -> None:
     """Lists of assorted JSON-compatible element types round-trip."""
     assert _round_trip(tmp_path, {"setting": value})["setting"] == value

--- a/tests/project/test_training_settings.py
+++ b/tests/project/test_training_settings.py
@@ -1,0 +1,93 @@
+"""Tests for project settings serialization in exported training files."""
+
+import json
+from pathlib import Path
+
+import h5py
+import pytest
+
+from jabs.project.export_training import JSON_ENCODED_SETTING_ATTR, write_project_settings
+from jabs.project.read_training import read_project_settings
+
+
+def _round_trip(tmp_path: Path, settings: dict) -> dict:
+    """Write settings to a training file and read them back."""
+    path = tmp_path / "training.h5"
+    with h5py.File(path, "w") as out_h5:
+        write_project_settings(out_h5, settings, "settings")
+    with h5py.File(path, "r") as in_h5:
+        return read_project_settings(in_h5["settings"])
+
+
+def test_scalar_settings_round_trip(tmp_path: Path) -> None:
+    """Scalar settings survive the write/read cycle unchanged."""
+    settings = {"window_size": 5, "social": True, "cm_units": False}
+    assert _round_trip(tmp_path, settings) == settings
+
+
+def test_nested_dict_settings_round_trip(tmp_path: Path) -> None:
+    """A one-level-deep settings sub-group survives the write/read cycle."""
+    settings = {"window_size": 5, "static_objects": {"lixit": True, "food_hopper": False}}
+    assert _round_trip(tmp_path, settings) == settings
+
+
+def test_list_setting_round_trips_as_list(tmp_path: Path) -> None:
+    """A list setting (e.g. postprocessing stages) reads back as a list, not a JSON string."""
+    stages = [
+        {"name": "duration", "enabled": True, "params": {"min_frames": 3}},
+        {"name": "stitching", "enabled": False, "params": {"max_gap": 5}},
+    ]
+    result = _round_trip(tmp_path, {"window_size": 5, "postprocessing": stages})
+
+    assert result["postprocessing"] == stages
+    assert result["window_size"] == 5
+
+
+def test_empty_list_setting_round_trips(tmp_path: Path) -> None:
+    """An empty list reads back as an empty list."""
+    assert _round_trip(tmp_path, {"postprocessing": []})["postprocessing"] == []
+
+
+def test_nested_list_setting_round_trips(tmp_path: Path) -> None:
+    """A list nested inside a settings sub-group is decoded too."""
+    stages = [{"name": "duration", "params": {"min_frames": 3}}]
+    result = _round_trip(tmp_path, {"behavior": {"postprocessing": stages}})
+
+    assert result["behavior"]["postprocessing"] == stages
+
+
+def test_list_setting_dataset_is_tagged(tmp_path: Path) -> None:
+    """The JSON-encoded dataset carries the attribute the reader looks for."""
+    stages = [{"name": "duration"}]
+    path = tmp_path / "training.h5"
+    with h5py.File(path, "w") as out_h5:
+        write_project_settings(out_h5, {"postprocessing": stages, "social": True}, "settings")
+
+    with h5py.File(path, "r") as in_h5:
+        postprocessing = in_h5["settings/postprocessing"]
+        assert postprocessing.attrs[JSON_ENCODED_SETTING_ATTR]
+        assert json.loads(postprocessing[...].item()) == stages
+        assert JSON_ENCODED_SETTING_ATTR not in in_h5["settings/social"].attrs
+
+
+def test_untagged_string_setting_is_not_decoded(tmp_path: Path) -> None:
+    """Settings written without the tag are returned as stored (older training files)."""
+    path = tmp_path / "training.h5"
+    with h5py.File(path, "w") as out_h5:
+        group = out_h5.require_group("settings")
+        group.create_dataset("postprocessing", data=json.dumps([{"name": "duration"}]))
+
+    with h5py.File(path, "r") as in_h5:
+        settings = read_project_settings(in_h5["settings"])
+
+    assert settings["postprocessing"] == b'[{"name": "duration"}]'
+
+
+@pytest.mark.parametrize(
+    "value",
+    [["a", "b"], [1, 2, 3], [[1, 2], [3, 4]], [{"a": 1}]],
+    ids=["strings", "ints", "nested_lists", "dicts"],
+)
+def test_list_element_types_round_trip(tmp_path: Path, value: list) -> None:
+    """Lists of assorted JSON-compatible element types round-trip."""
+    assert _round_trip(tmp_path, {"setting": value})["setting"] == value


### PR DESCRIPTION
## Reasoning

`write_project_settings()` stores list-valued settings (today: the `postprocessing`
stage configs) as a JSON string, because HDF5 has no direct list equivalent. That was
added in a8a8e06 to stop the export from crashing, and the comment there claimed the
value "round-trips without loss" — but the read side was never updated, so
`read_project_settings()` returns the raw stored bytes. Verified on `main`:

```python
settings = {"window_size": 5, "postprocessing": [{"name": "duration", "params": {"min_frames": 3}}]}
# write_project_settings(...) then read_project_settings(...) gives:
{'postprocessing': b'[{"name": "duration", "params": {"min_frames": 3}}]', 'window_size': 5}
```

A `bytes` blob where a `list` belongs breaks the contract documented on
[`set_dict_settings()`](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/main/src/jabs/classifier/base.py#L128-L135)
("same structure as `project.settings_manager.get_behavior`"), which is what
`Classifier.from_training_file()` /
`MultiClassClassifier.from_training_file()` feed it. Any consumer that does
`settings.get("postprocessing", [])` and iterates — the shape
`PostprocessingPipeline` expects — gets characters instead of stage dicts. Nothing on
the current CLI path iterates it yet, so this is latent rather than a live crash, but
it is a half-finished fix plus a comment that documents behavior the code does not have.

I picked this over the other candidates I looked at because it is an actual
writer/reader asymmetry with a stated-but-false invariant, and it is cheap to make
symmetric. Considered and passed over: `FeatureManager._static_objects` returning `[]`
(a `list`) for a project with no videos though the property is annotated `set[str]`
(latent type inconsistency, no crash — no caller does set algebra on it);
`SessionTracker` logging the video under key `"video_path"` in `video_closed()` but
`"video"` in `video_opened()` (real, but it changes the session-log schema that external
analysis scripts read, so it deserves the owner's call, not an automated PR);
`psd_mean_band()` documenting `freqs` as "ignored" when it uses it; and several
`print()` calls in non-CLI modules that `CLAUDE.md` forbids (too many files to be one
targeted change).

Why this is safe:

- The decode is opt-in per dataset. Only datasets the writer tags are decoded, and the
  writer only tags values it JSON-encoded.
- Backward compatible: training files exported before this change carry no tag, so
  `_read_setting_value()` returns them exactly as it does today — no silent
  reinterpretation of existing files, and no heuristic sniffing of string values.
- Forward compatible: an older JABS reading a newly exported file ignores the unknown
  HDF5 attribute and behaves as it does now.
- No feature values change, so no `FEATURE_VERSION` bump.

## Change

### Logic changes

- **`src/jabs/project/export_training.py`** — added the `JSON_ENCODED_SETTING_ATTR`
  (`"json_encoded"`) module constant and set it as an attribute on the dataset when
  `write_project_settings()` JSON-encodes a list. Moved the explanation of the encoding
  from an inline comment into the function docstring and corrected it to point at the
  tag rather than claim an unaided round trip.
- **`src/jabs/project/read_training.py`** — added the `_read_setting_value()` helper,
  which JSON-decodes a settings dataset tagged with `JSON_ENCODED_SETTING_ATTR` and
  otherwise returns the stored value unchanged. A decode failure is re-raised as a
  `ValueError` naming the dataset (chained from the original `JSONDecodeError`), so a
  corrupt or hand-edited training file points at the setting that failed.
  `read_project_settings()` now reads both its top-level and its nested branch through
  that helper instead of calling `node[...].item()` directly.
- **`tests/project/test_training_settings.py`** (new) — round-trip tests through
  `write_project_settings()` / `read_project_settings()`: scalars, a nested settings
  sub-group, a `postprocessing`-shaped list (the case that regressed), an empty list, a
  list nested inside a sub-group, assorted list element types, that the tag lands on the
  JSON dataset and not on scalar datasets, that an untagged JSON string is still
  returned as stored (the older-file path), and that a tagged dataset holding invalid
  JSON raises an error naming the setting.

### Mechanical updates

None.

Second commit (e24dde5) is review feedback only: the `ValueError`-with-dataset-name
described above plus its test, and parameterized `dict[str, Any]` / `list[Any]` hints on
the two new test helpers.

Checks run locally: `ruff check .`, `ruff format .`, and `pytest` (842 passed,
200 skipped). CI green on both commits.

Note on authorship: the commits are authored as `Claude` / `noreply@anthropic.com`,
matching previous automated quality PRs — pushing as `glen.beane@jax.org` is rejected by
the account's GitHub email-privacy setting.

This PR was produced by an automated analysis from Claude Code.