### PR TITLE
Only stitch not-behavior gaps that separate two behavior bouts

### DIFF
--- a/packages/jabs-behavior/src/jabs/behavior/postprocessing/stages/stitching_stage.py
+++ b/packages/jabs-behavior/src/jabs/behavior/postprocessing/stages/stitching_stage.py
@@ -27,6 +27,12 @@ class BoutStitchingStage(PostprocessingStage):
     def apply(self, classes: np.ndarray, probabilities: np.ndarray) -> np.ndarray:
         """Apply stitching to the predictions.
 
+        Only a NOT_BEHAVIOR run that actually separates two BEHAVIOR bouts is
+        stitched across. A short NOT_BEHAVIOR run at the very start or end of
+        the vector, or one bordering frames with no prediction, has a BEHAVIOR
+        bout on at most one side, so removing it would relabel not-behavior
+        frames instead of joining two bouts.
+
         Args:
             classes (np.ndarray): The predicted classes.
             probabilities (np.ndarray): The predicted probabilities. (Not used in this stage.)
@@ -35,12 +41,22 @@ class BoutStitchingStage(PostprocessingStage):
             np.ndarray: Classes after applying the stitching.
         """
         rle_data = BehaviorEvents.from_vector(classes)
+        states = rle_data.states
+
+        # a bout is a stitchable gap only if the bouts on both sides are BEHAVIOR;
+        # the first and last bouts have no neighbor on one side, so they never are
+        flanked_by_behavior = np.zeros(len(states), dtype=bool)
+        if len(states) > 2:
+            flanked_by_behavior[1:-1] = np.logical_and(
+                states[:-2] == ClassLabels.BEHAVIOR, states[2:] == ClassLabels.BEHAVIOR
+            )
 
         # find short bouts of NOT_BEHAVIOR -- we can stitch across these gaps
-        bouts_to_remove = np.logical_and(
+        short_not_behavior = np.logical_and(
             rle_data.durations <= self._config["max_stitch_gap"],
-            rle_data.states == ClassLabels.NOT_BEHAVIOR,
+            states == ClassLabels.NOT_BEHAVIOR,
         )
+        bouts_to_remove = np.logical_and(short_not_behavior, flanked_by_behavior)
 
         if np.any(bouts_to_remove):
             rle_data.delete_bouts(np.where(bouts_to_remove)[0])
@@ -58,6 +74,8 @@ class BoutStitchingStage(PostprocessingStage):
             description="Combines predictions that are separated by short gaps.",
             description_long=textwrap.dedent("""
             The Stitching Stage connects behavior bouts that are separated by short gaps of not-behavior prediction.
+            A short run of not-behavior prediction that does not separate two behavior bouts -- one at the start or
+            end of the video, or one bordering frames with no prediction -- is left unchanged.
             """),
             kwargs={
                 "max_stitch_gap": KwargHelp(

--- a/packages/jabs-behavior/tests/test_pipeline.py
+++ b/packages/jabs-behavior/tests/test_pipeline.py
@@ -183,14 +183,16 @@ class TestPostprocessingPipeline:
         # After removal, NOT_BEHAVIOR sections merge
         expected1 = np.array([ClassLabels.NOT_BEHAVIOR] * 9)
 
-        # Pipeline 2: Stitching removes ALL NOT_BEHAVIOR bouts <= 2 (including boundaries!)
-        # Removes indices [0, 2, 4]:
-        #   - Index 4 (last): merges with previous BEHAVIOR
-        #   - Index 2 (middle): merges surrounding BEHAVIORs
-        #   - Index 0 (first): merges with next BEHAVIOR (takes BEHAVIOR state)
-        # Result after stitching: BEHAVIOR(9)
-        # Duration filter: BEHAVIOR(9) >= 4, so nothing removed
-        expected2 = np.array([ClassLabels.BEHAVIOR] * 9)
+        # Pipeline 2: Stitching only removes NOT_BEHAVIOR bouts <= 2 that separate two
+        # BEHAVIOR bouts, so only index 2 is removed. The leading (index 0) and trailing
+        # (index 4) NOT_BEHAVIOR bouts are not gaps between bouts and are left alone.
+        # Result after stitching: NOT_BEHAVIOR(2), BEHAVIOR(5), NOT_BEHAVIOR(2)
+        # Duration filter: BEHAVIOR(5) >= 4, so nothing removed
+        expected2 = np.array(
+            [ClassLabels.NOT_BEHAVIOR] * 2
+            + [ClassLabels.BEHAVIOR] * 5
+            + [ClassLabels.NOT_BEHAVIOR] * 2
+        )
 
         np.testing.assert_array_equal(result1, expected1)
         np.testing.assert_array_equal(result2, expected2)
@@ -260,36 +262,20 @@ class TestPostprocessingPipeline:
         probabilities = np.full_like(classes, 0.5, dtype=float)
         result = pipeline.run(classes, probabilities)
 
-        # After stitching (removes ALL NOT_BEHAVIOR bouts <= 2, including boundaries):
-        # Removes indices [0, 2, 6, 8]:
-        #   - Index 8 (last, NOT_BEHAVIOR(2)): merges with previous BEHAVIOR(2) → BEHAVIOR(4)
-        #   - Index 6 (NOT_BEHAVIOR(1)): merges surrounding BEHAVIORs → BEHAVIOR(9)
+        # After stitching (removes NOT_BEHAVIOR bouts <= 2 that separate two BEHAVIOR bouts):
+        # Removes indices [2, 6]:
+        #   - Index 6 (NOT_BEHAVIOR(1)): merges surrounding BEHAVIORs → BEHAVIOR(6)
         #   - Index 2 (NOT_BEHAVIOR(1)): merges surrounding BEHAVIORs → BEHAVIOR(6)
-        #   - Index 0 (first, NOT_BEHAVIOR(2)): merges with next BEHAVIOR → BEHAVIOR(8)
-        # Result: BEHAVIOR(8), NOT_BEHAVIOR(3), BEHAVIOR(9)
-        # After duration filter (min 4): All bouts >= 4, so nothing removed
+        # Index 0 (first) and index 8 (last) are not gaps between two BEHAVIOR bouts and
+        # index 4 (NOT_BEHAVIOR(3)) is longer than max_stitch_gap, so all three are kept.
+        # Result: NOT_BEHAVIOR(2), BEHAVIOR(6), NOT_BEHAVIOR(3), BEHAVIOR(6), NOT_BEHAVIOR(2)
+        # After duration filter (min 4): All BEHAVIOR bouts >= 4, so nothing removed
         expected = np.array(
-            [
-                ClassLabels.BEHAVIOR,
-                ClassLabels.BEHAVIOR,
-                ClassLabels.BEHAVIOR,
-                ClassLabels.BEHAVIOR,
-                ClassLabels.BEHAVIOR,
-                ClassLabels.BEHAVIOR,
-                ClassLabels.BEHAVIOR,
-                ClassLabels.BEHAVIOR,
-                ClassLabels.NOT_BEHAVIOR,
-                ClassLabels.NOT_BEHAVIOR,
-                ClassLabels.NOT_BEHAVIOR,
-                ClassLabels.BEHAVIOR,
-                ClassLabels.BEHAVIOR,
-                ClassLabels.BEHAVIOR,
-                ClassLabels.BEHAVIOR,
-                ClassLabels.BEHAVIOR,
-                ClassLabels.BEHAVIOR,
-                ClassLabels.BEHAVIOR,
-                ClassLabels.BEHAVIOR,
-            ]
+            [ClassLabels.NOT_BEHAVIOR] * 2
+            + [ClassLabels.BEHAVIOR] * 6
+            + [ClassLabels.NOT_BEHAVIOR] * 3
+            + [ClassLabels.BEHAVIOR] * 6
+            + [ClassLabels.NOT_BEHAVIOR] * 2
         )
         np.testing.assert_array_equal(result, expected)
 

--- a/packages/jabs-behavior/tests/test_stitching_stage.py
+++ b/packages/jabs-behavior/tests/test_stitching_stage.py
@@ -174,6 +174,83 @@ class TestStitchingStage:
         # NONE labels should not be treated as NOT_BEHAVIOR for stitching
         np.testing.assert_array_equal(result, classes)
 
+    def test_apply_keeps_leading_not_behavior_run(self):
+        """Test that a short NOT_BEHAVIOR run at the start of the vector is kept.
+
+        It has no BEHAVIOR bout before it, so it is not a gap between two bouts.
+        """
+        classes = np.array(
+            [
+                ClassLabels.NOT_BEHAVIOR,
+                ClassLabels.NOT_BEHAVIOR,
+                ClassLabels.BEHAVIOR,
+                ClassLabels.BEHAVIOR,
+                ClassLabels.BEHAVIOR,
+            ]
+        )
+
+        filter_obj = BoutStitchingStage(max_stitch_gap=3)
+        probabilities = np.full_like(classes, 0.5, dtype=float)
+        result = filter_obj.apply(classes, probabilities)
+
+        np.testing.assert_array_equal(result, classes)
+
+    def test_apply_keeps_trailing_not_behavior_run(self):
+        """Test that a short NOT_BEHAVIOR run at the end of the vector is kept.
+
+        It has no BEHAVIOR bout after it, so it is not a gap between two bouts.
+        """
+        classes = np.array(
+            [
+                ClassLabels.BEHAVIOR,
+                ClassLabels.BEHAVIOR,
+                ClassLabels.BEHAVIOR,
+                ClassLabels.NOT_BEHAVIOR,
+                ClassLabels.NOT_BEHAVIOR,
+            ]
+        )
+
+        filter_obj = BoutStitchingStage(max_stitch_gap=3)
+        probabilities = np.full_like(classes, 0.5, dtype=float)
+        result = filter_obj.apply(classes, probabilities)
+
+        np.testing.assert_array_equal(result, classes)
+
+    def test_apply_keeps_not_behavior_run_bordering_none(self):
+        """Test that a NOT_BEHAVIOR run bordering NONE frames is kept.
+
+        Only one side is a BEHAVIOR bout, so there is nothing to stitch to on the
+        other side.
+        """
+        classes = np.array(
+            [
+                ClassLabels.NONE,
+                ClassLabels.NONE,
+                ClassLabels.NOT_BEHAVIOR,
+                ClassLabels.BEHAVIOR,
+                ClassLabels.BEHAVIOR,
+                ClassLabels.NOT_BEHAVIOR,
+                ClassLabels.NONE,
+                ClassLabels.NONE,
+            ]
+        )
+
+        filter_obj = BoutStitchingStage(max_stitch_gap=3)
+        probabilities = np.full_like(classes, 0.5, dtype=float)
+        result = filter_obj.apply(classes, probabilities)
+
+        np.testing.assert_array_equal(result, classes)
+
+    def test_apply_keeps_all_not_behavior(self):
+        """Test that a vector that is entirely a short NOT_BEHAVIOR bout is kept."""
+        classes = np.array([ClassLabels.NOT_BEHAVIOR] * 2)
+
+        filter_obj = BoutStitchingStage(max_stitch_gap=3)
+        probabilities = np.full_like(classes, 0.5, dtype=float)
+        result = filter_obj.apply(classes, probabilities)
+
+        np.testing.assert_array_equal(result, classes)
+
     def test_apply_empty_array(self):
         """Test apply with empty array."""
         classes = np.array([])


### PR DESCRIPTION
## Reasoning

`BoutStitchingStage` documents itself as connecting "behavior bouts that are separated by short gaps of not-behavior prediction," but it removed **every** `NOT_BEHAVIOR` bout shorter than or equal to `max_stitch_gap`, regardless of what surrounded it. `BehaviorEvents.delete_bouts` then absorbed the removed bout's frames into its neighbors, which produced two wrong outcomes:

- **A run at the start or end of the vector** has only one neighbor, so all of its frames were absorbed by that neighbor. `[NB, NB, B, B, B]` with `max_stitch_gap=3` came out as all `BEHAVIOR` — leading not-behavior frames were relabeled as behavior, with nothing stitched to.
- **A run bordering a `NONE` (no prediction) run** has mismatched borders, so `delete_bouts` split it in half: some not-behavior frames became `BEHAVIOR` and the rest became `NONE`. This case is common, since missing pose at the start/end of a video is common.

Neither case joins two behavior bouts, so neither is stitching — the frames were simply relabeled. I picked this over the other candidates I looked at (a wrong `Raises:` docstring on `VideoLabels.rename_behavior`, a stale `FilterHelp` type name in three stage docstrings, dead `legacy_names` attribute, `print()`-instead-of-logging in `prediction_manager`/`behavior_search_util`) because it is the only one that changes classifier output: predictions are written to disk and used for analysis, so silently relabeled frames at video boundaries matter more than a docstring or a log call.

Why the fix is safe: a `NOT_BEHAVIOR` bout's neighbors can only be `BEHAVIOR` or `NONE` (RLE states never repeat), so requiring both neighbors to be `BEHAVIOR` is exactly "this gap separates two behavior bouts." Every gap that still qualifies takes `delete_bouts`' matching-borders path, which merges the three bouts into one `BEHAVIOR` bout — the intended stitch. Frame counts are preserved as before, and the duration filter and interpolation stages are untouched.

This is a deliberate behavior change (it is the bug fix), so it is not net-zero: a leading/trailing/`NONE`-bordered short not-behavior run is now left alone instead of being converted. Two existing pipeline tests asserted the old outcome, with comments that read as observations of the surprising behavior rather than statements of intent ("removes ALL NOT_BEHAVIOR bouts <= 2 (including boundaries!)"), so I updated them. No `FEATURE_VERSION` bump: this is postprocessing of predictions, not feature computation.

## Change

### Logic changes

- **`packages/jabs-behavior/src/jabs/behavior/postprocessing/stages/stitching_stage.py`** — `apply()` now builds a `flanked_by_behavior` mask (a bout qualifies only when the bouts on both sides are `BEHAVIOR`; the first and last bouts never qualify) and ANDs it into `bouts_to_remove` alongside the existing duration and `NOT_BEHAVIOR` checks. Also documented the rule in the `apply()` docstring and in the user-facing `description_long` shown by the GUI settings dialog and the CLI config generator.

### Test changes

- **`packages/jabs-behavior/tests/test_stitching_stage.py`** — four new cases: a leading short not-behavior run, a trailing one, one bordering `NONE` frames on both sides, and a vector that is entirely one short not-behavior bout. All assert the vector is returned unchanged.
- **`packages/jabs-behavior/tests/test_pipeline.py`** — updated the expected arrays and explanatory comments in `test_run_order_matters` and `test_run_complex_sequence`, which encoded the old boundary behavior. Both now expect the boundary runs to survive stitching; the interior gaps they exercise still stitch exactly as before.

No mechanical/import-only churn in this PR.

### Verification

- `uv run ruff check .` and `uv run ruff format .` — clean
- `uv run pytest packages/jabs-behavior/tests` — 113 passed
- `uv run pytest` (root) — 847 passed, 200 skipped
- `uv run pytest packages/jabs-core/tests` — 88 passed

(`packages/jabs-io/tests` fails to collect in this environment on a pre-existing, unrelated missing optional dependency: `ModuleNotFoundError: No module named 'ndx_multisubjects'` in `internal/pose/test_nwb.py`.)

This PR was produced by an automated analysis from Claude Code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WMMkjLjBxUaiNX6wHpMpMx)_