### PR TITLE
add check for unmasked instance_embed_id values of 0 in v4 pose files

### DIFF
--- a/src/jabs/pose_estimation/pose_est_v4.py
+++ b/src/jabs/pose_estimation/pose_est_v4.py
@@ -92,6 +92,11 @@ class PoseEstimationV4(PoseEstimation):
                     if instance_embed_id.shape[1] > 0
                     else 0
                 )
+                min_instance_id = (
+                    np.min(np.ma.array(instance_embed_id[...], mask=id_mask[...]))
+                    if instance_embed_id.shape[1] > 0
+                    else 1
+                )
 
                 if "instance_id_center" in pose_grp:
                     self._num_identities = pose_grp["instance_id_center"].shape[0]
@@ -105,6 +110,14 @@ class PoseEstimationV4(PoseEstimation):
             if max_instance_id > self._num_identities:
                 raise PoseIdEmbeddingException(
                     f"Invalid instance_embed_id, values out of range: {file_path.name}"
+                )
+
+            # instance_embed_id values are 1-based; a value of 0 on unmasked
+            # (id_mask == 0) data would wrap around to a large positive index
+            # when we subtract 1 to build a 0-based identity index below.
+            if min_instance_id < 1:
+                raise PoseIdEmbeddingException(
+                    f"Invalid instance_embed_id, unmasked values must be >= 1: {file_path.name}"
                 )
 
             # generate list of identities based on the max number of instances

--- a/src/jabs/pose_estimation/pose_est_v4.py
+++ b/src/jabs/pose_estimation/pose_est_v4.py
@@ -87,15 +87,16 @@ class PoseEstimationV4(PoseEstimation):
 
                 self._num_frames = len(all_points)
 
-                max_instance_id = (
-                    np.max(np.ma.array(instance_embed_id[...], mask=id_mask[...]))
+                valid_instance_embed_id = (
+                    instance_embed_id[id_mask == 0]
                     if instance_embed_id.shape[1] > 0
-                    else 0
+                    else np.array([], dtype=instance_embed_id.dtype)
+                )
+                max_instance_id = (
+                    valid_instance_embed_id.max() if valid_instance_embed_id.size > 0 else 0
                 )
                 min_instance_id = (
-                    np.min(np.ma.array(instance_embed_id[...], mask=id_mask[...]))
-                    if instance_embed_id.shape[1] > 0
-                    else 1
+                    valid_instance_embed_id.min() if valid_instance_embed_id.size > 0 else 1
                 )
 
                 if "instance_id_center" in pose_grp:
@@ -106,15 +107,16 @@ class PoseEstimationV4(PoseEstimation):
                     print(f"Warning: No identities found in pose file: {file_path}")
                     self._num_identities = 0
 
-            # Validate instance_embed_id range: must be in [0, self._num_identities]
+            # Validate instance_embed_id range for unmasked (id_mask == 0) data:
+            # must be in [1, self._num_identities].
             if max_instance_id > self._num_identities:
                 raise PoseIdEmbeddingException(
                     f"Invalid instance_embed_id, values out of range: {file_path.name}"
                 )
 
             # instance_embed_id values are 1-based; a value of 0 on unmasked
-            # (id_mask == 0) data would wrap around to a large positive index
-            # when we subtract 1 to build a 0-based identity index below.
+            # data would wrap around to a large positive index when we
+            # subtract 1 to build a 0-based identity index below.
             if min_instance_id < 1:
                 raise PoseIdEmbeddingException(
                     f"Invalid instance_embed_id, unmasked values must be >= 1: {file_path.name}"

--- a/tests/pose_estimation/test_pose_file.py
+++ b/tests/pose_estimation/test_pose_file.py
@@ -123,7 +123,7 @@ def test_v4_zero_instance_embed_id_raises(tmpdir_with_pose_files):
         id_mask = f["poseest/id_mask"][:]
         instance_embed_id = f["poseest/instance_embed_id"][:]
         # find an unmasked entry and corrupt it to 0
-        frame, instance = np.argwhere(~id_mask)[0]
+        frame, instance = np.argwhere(id_mask == 0)[0]
         instance_embed_id[frame, instance] = 0
         f["poseest/instance_embed_id"][:] = instance_embed_id
 

--- a/tests/pose_estimation/test_pose_file.py
+++ b/tests/pose_estimation/test_pose_file.py
@@ -2,10 +2,12 @@ import shutil
 import tempfile
 from pathlib import Path
 
+import h5py
 import numpy as np
 import pytest
 
 import jabs.pose_estimation
+from jabs.core.exceptions import PoseIdEmbeddingException
 
 _TEST_FILES = [
     "sample_pose_est_v3.h5",
@@ -105,6 +107,28 @@ def test_scaling_points(pose_est_v4):
     points, _ = pose_est_v4.get_points(10, 0)
     scaled_points, _ = pose_est_v4.get_points(10, 0, 0.03)
     np.testing.assert_equal(points * 0.03, scaled_points)
+
+
+def test_v4_zero_instance_embed_id_raises(tmpdir_with_pose_files):
+    """test that an unmasked instance_embed_id value of 0 raises PoseIdEmbeddingException
+
+    instance_embed_id values are 1-based. A value of 0 on unmasked (id_mask ==
+    False) data would wrap around when 1 is subtracted to build a 0-based
+    identity index.
+    """
+    corrupt_path = tmpdir_with_pose_files / "corrupt_pose_est_v4.h5"
+    shutil.copy(tmpdir_with_pose_files / "sample_pose_est_v4.h5", corrupt_path)
+
+    with h5py.File(corrupt_path, "r+") as f:
+        id_mask = f["poseest/id_mask"][:]
+        instance_embed_id = f["poseest/instance_embed_id"][:]
+        # find an unmasked entry and corrupt it to 0
+        frame, instance = np.argwhere(~id_mask)[0]
+        instance_embed_id[frame, instance] = 0
+        f["poseest/instance_embed_id"][:] = instance_embed_id
+
+    with pytest.raises(PoseIdEmbeddingException):
+        jabs.pose_estimation.open_pose_file(corrupt_path)
 
 
 def test_v4_read_from_cache(tmpdir_with_pose_files):


### PR DESCRIPTION
Closes #231

`poseest/instance_embed_id` values are 1-based; JABS subtracts 1 to build a 0-based identity index when reordering pose data by identity (`PoseEstimationV4.__init__`). If a writer stores a 0 value on unmasked (`poseest/id_mask == 0`) data, that subtraction produces a negative index, silently aliasing data into the wrong identity slot instead of raising an error.

This adds a check alongside the existing out-of-range check (#230) that raises `PoseIdEmbeddingException` when any unmasked `instance_embed_id` value is less than 1. Since every pose version >= v4 inherits from `PoseEstimationV4` and calls `super().__init__()` first, this protects the whole v4-v8 chain.

## Test plan
- [x] Added `test_v4_zero_instance_embed_id_raises`, which corrupts a copy of the sample v4 pose file (sets an unmasked `instance_embed_id` entry to 0) and asserts `PoseIdEmbeddingException` is raised on load.
- [x] `uv run pytest tests/pose_estimation packages/jabs-core/tests/test_exceptions.py tests/project/test_parallel_workers.py` passes.
- [x] `uv run ruff check` / `uv run ruff format --check` pass.