### PR TITLE
docs: correct misleading `window` and `freqs` parameter docs in window_operations

### DIFF
--- a/src/jabs/feature_extraction/window_operations/signal_stats.py
+++ b/src/jabs/feature_extraction/window_operations/signal_stats.py
@@ -64,14 +64,18 @@ def psd_mean_band(
 ) -> np.ndarray:
     """Calculates the mean power spectral density in a band
 
+    Unlike the other functions in this module, this one uses ``freqs`` -- it is
+    what selects the rows of ``psd`` that fall inside the band.
+
     Args:
-        freqs: frequencies in the psd, ignored
+        freqs: frequencies in the psd, used to select the band
         psd: power spectral density matrix
-        band_low: lower bound of the frequency band
-        band_high: upper bound of the frequency band
+        band_low: inclusive lower bound of the frequency band
+        band_high: exclusive upper bound of the frequency band
 
     Returns:
-        mean of power
+        mean of power over the frequencies in the band, or an array of nan if no
+        frequency falls inside the band
     """
     idx = np.logical_and(freqs >= band_low, freqs < band_high)
 

--- a/src/jabs/feature_extraction/window_operations/window_stats.py
+++ b/src/jabs/feature_extraction/window_operations/window_stats.py
@@ -8,7 +8,8 @@ def pad_sliding_window(arr: np.ndarray, window: int, pad_const: float | None = N
 
     Args:
         arr: 1d array to generate a sliding window
-        window: half size of sliding window
+        window: number of frames to include on each side of the center frame. The
+            resulting window spans ``2 * window + 1`` frames.
         pad_const: Constant to pad the array with. None will pad with value at the edge.
 
     Returns:
@@ -50,7 +51,8 @@ def window_mean(values: np.ndarray, window: int) -> np.ndarray:
 
     Args:
         values: 1d np.ndarray of values
-        window: window size
+        window: number of frames to include on each side of the center frame. The
+            window used for each output value spans ``2 * window + 1`` frames.
 
     Returns:
         sliding window mean values
@@ -67,7 +69,8 @@ def window_median(values: np.ndarray, window: int) -> np.ndarray:
 
     Args:
         values: 1d np.ndarray of values
-        window: window size
+        window: number of frames to include on each side of the center frame. The
+            window used for each output value spans ``2 * window + 1`` frames.
 
     Returns:
         sliding window median values
@@ -82,7 +85,8 @@ def window_std_dev(values: np.ndarray, window: int) -> np.ndarray:
 
     Args:
         values: 1d np.ndarray of values
-        window: window size
+        window: number of frames to include on each side of the center frame. The
+            window used for each output value spans ``2 * window + 1`` frames.
 
     Returns:
         sliding window standard deviation values
@@ -119,7 +123,8 @@ def window_kurtosis(values: np.ndarray, window: int) -> np.ndarray:
 
     Args:
         values: 1d np.ndarray of values
-        window: window size
+        window: number of frames to include on each side of the center frame. The
+            window used for each output value spans ``2 * window + 1`` frames.
 
     Returns:
         sliding window kurtosis values
@@ -156,7 +161,8 @@ def window_skew(values: np.ndarray, window: int) -> np.ndarray:
 
     Args:
         values: 1d np.ndarray of values
-        window: window size
+        window: number of frames to include on each side of the center frame. The
+            window used for each output value spans ``2 * window + 1`` frames.
 
     Returns:
         sliding window skew values
@@ -173,7 +179,8 @@ def window_min(values: np.ndarray, window: int) -> np.ndarray:
 
     Args:
         values: 1d np.ndarray of values
-        window: window size
+        window: number of frames to include on each side of the center frame. The
+            window used for each output value spans ``2 * window + 1`` frames.
 
     Returns:
         sliding window minimum values
@@ -190,7 +197,8 @@ def window_max(values: np.ndarray, window: int) -> np.ndarray:
 
     Args:
         values: 1d np.ndarray of values
-        window: window size
+        window: number of frames to include on each side of the center frame. The
+            window used for each output value spans ``2 * window + 1`` frames.
 
     Returns:
         sliding window maximum values


### PR DESCRIPTION
## Reasoning

I looked for a defect where the documentation actively contradicts the code, rather than merely being thin — the kind that makes a reader confidently wrong. Two in `feature_extraction/window_operations/` qualified:

**1. `window` is a half-width, not a window size.**

Seven public functions in [`window_stats.py`](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/main/src/jabs/feature_extraction/window_operations/window_stats.py) (`window_mean`, `window_median`, `window_std_dev`, `window_kurtosis`, `window_skew`, `window_min`, `window_max`) documented their second parameter as simply `window: window size`. It is not the window size — it is the number of frames on *each side* of the center frame. [`pad_sliding_window`](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/main/src/jabs/feature_extraction/window_operations/window_stats.py#L21) builds the view with `window_shape=window * 2 + 1`, so a caller passing `window=5` expecting a 5-frame mean gets an 11-frame one — an error of roughly 2x, silently, in the feature values that get fed to the classifier.

Every other place in the codebase already gets this right and is what makes the `window_stats.py` wording the outlier:

- `Feature.window_width(window_size) -> 2 * window_size + 1` (`feature_base_class.py:119`)
- `Feature.window()`: *"window size NOTE: (actual window size is 2 * window_size + 1)"*
- `_compute_window_feature()`: *"number of frames (in each direction) to include in the window..."*
- `pad_sliding_window` itself: *"half size of sliding window"* — accurate, but leaves the resulting width implicit, so I made it explicit for consistency with the other seven.

Confirmed against the running code rather than by reading alone:

```
>>> window_stats.pad_sliding_window(np.arange(11.), 2, np.nan).shape
(11, 5)                                    # window=2 -> 5 frames wide
>>> window_stats.window_mean(np.arange(11.), 2)[5]
5.0                                        # == mean([3., 4., 5., 6., 7.])
```

The existing tests encode the same semantics (`test_window_mean_ignores_padding` passes `window=1` over 3 values and expects a 3-wide window), so the docstrings were the only thing out of step.

**2. `psd_mean_band` does not ignore `freqs`.**

In [`signal_stats.py`](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/main/src/jabs/feature_extraction/window_operations/signal_stats.py), every `psd_*` function documents `freqs: frequencies in the psd, ignored`, which is true for all of them except `psd_mean_band` — where `freqs` is the *only* thing that does any work (`idx = np.logical_and(freqs >= band_low, freqs < band_high)`). The "ignored" note was evidently copied from its siblings. While correcting it I also recorded two behaviors that were previously undocumented but visible in the code: the band bounds are half-open (`>= band_low`, `< band_high`), and an empty band returns nan rather than raising.

**Why this is safe:** the change is docstrings only — zero executable statements modified. `git diff` touches nothing outside triple-quoted strings, so there is no possible behavior change and no `FEATURE_VERSION` implication. I considered several alternatives and rejected them: renaming the `window` parameter to `window_size` would be a real API change (`feature_base_class.py:330` calls `op(val, window=window_size)` by keyword), and the other candidates I found (a missing `stream.release()` in two unused helpers in `video_reader/utilities.py`; a stale `"animal_id"` key in a `video_labels.py` docstring where `serialize()` actually writes `"identity"`) were either dead code or genuinely trivial. This one sits on the hot path for feature extraction and is the one most likely to mislead someone adding a window operation.

## Change

All edits are **logic-free**; there are no mechanical/import updates in this PR.

### Logic changes

*(none — no executable code was modified)*

### Documentation changes

**`src/jabs/feature_extraction/window_operations/window_stats.py`**
- `pad_sliding_window`: replaced *"half size of sliding window"* with an explicit statement that the window spans `2 * window + 1` frames.
- `window_mean`, `window_median`, `window_std_dev`, `window_kurtosis`, `window_skew`, `window_min`, `window_max`: replaced `window: window size` with *"number of frames to include on each side of the center frame. The window used for each output value spans `2 * window + 1` frames."*

**`src/jabs/feature_extraction/window_operations/signal_stats.py`**
- `psd_mean_band`: `freqs` is no longer described as "ignored"; added a short note that this is the one function in the module that uses it, documented the band bounds as half-open, and documented the all-nan return when no frequency falls in the band.

## Verification

- `ruff check .` — all checks passed
- `ruff format .` — 444 files left unchanged (no formatting noise bundled in)
- `pytest` — 848 passed, 200 skipped

---

This PR was produced by an automated analysis from Claude Code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6V73P3bn1jscqJhU1e6D6)_