### PR TITLE
docs: correct the kurtosis convention documented for np_kurtosis (Pearson, not scipy's default)

### DIFF
--- a/src/jabs/feature_extraction/window_operations/signal_stats.py
+++ b/src/jabs/feature_extraction/window_operations/signal_stats.py
@@ -113,12 +113,16 @@ def psd_std_dev(freqs: np.ndarray, psd: np.ndarray) -> np.ndarray:
 def psd_kurtosis(freqs: np.ndarray, psd: np.ndarray) -> np.ndarray:
     """Calculates the kurtosis power spectral density
 
+    This uses scipy's default, which is Fisher (excess) kurtosis. The ``kurtosis``
+    window operation in ``window_operations.window_stats`` reports Pearson
+    (non-excess) kurtosis instead, so the two are offset by 3.0.
+
     Args:
         freqs: frequencies in the psd, ignored
         psd: power spectral density matrix
 
     Returns:
-        kurtosis of power
+        excess kurtosis of power
     """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=RuntimeWarning)

--- a/src/jabs/feature_extraction/window_operations/window_stats.py
+++ b/src/jabs/feature_extraction/window_operations/window_stats.py
@@ -101,14 +101,26 @@ def window_std_dev(values: np.ndarray, window: int) -> np.ndarray:
 def np_kurtosis(values: np.ndarray) -> np.ndarray:
     """Calculates kurtosis in a rolling window faster than scipy
 
+    This computes Pearson (non-excess) kurtosis, equivalent to
+    ``scipy.stats.kurtosis(values, axis=1, nan_policy="omit", fisher=False)``. It is
+    *not* equivalent to scipy's default, which subtracts 3.0 to give Fisher (excess)
+    kurtosis: values returned here are 3.0 larger than
+    ``scipy.stats.kurtosis(values, axis=1, nan_policy="omit")``.
+
+    Note that ``signal_stats.psd_kurtosis`` calls scipy with its default arguments, so
+    the ``kurtosis`` window feature and the ``psd_kurtosis`` signal feature do not use
+    the same convention.
+
     Args:
-        values: 2d array of with time and a window
+        values: 2d array with time on the first axis and the window on the second
 
     Returns:
-        kurtosis values that match scipy.stats.kurtosis(values, axis, nan_policy='omit')
+        Pearson kurtosis of the non-nan values in each window. A window that is
+        entirely nan yields nan.
 
-    Raises:
-        RuntimeWarning when an entire window is nans
+    Note:
+        numpy emits (does not raise) a RuntimeWarning when an entire window is nan.
+        Callers such as `window_kurtosis` suppress that warning.
     """
     mean = np.nanmean(values, axis=1)
     std = np.nanstd(values, axis=1)
@@ -139,14 +151,19 @@ def window_kurtosis(values: np.ndarray, window: int) -> np.ndarray:
 def np_skew(values: np.ndarray) -> np.ndarray:
     """Calculates skew in a rolling window faster than scipy
 
+    This computes the biased (population) skew, equivalent to
+    ``scipy.stats.skew(values, axis=1, nan_policy="omit")``, which is scipy's default.
+
     Args:
-        values: 2d array of with time and a window
+        values: 2d array with time on the first axis and the window on the second
 
     Returns:
-        skew values that match scipy.stats.skew(values, axis, nan_policy='omit')
+        skew of the non-nan values in each window. A window that is entirely nan
+        yields nan.
 
-    Raises:
-        RuntimeWarning when an entire window is nans
+    Note:
+        numpy emits (does not raise) a RuntimeWarning when an entire window is nan.
+        Callers such as `window_skew` suppress that warning.
     """
     mean = np.nanmean(values, axis=1)
     std = np.nanstd(values, axis=1)

--- a/tests/feature_extraction/window_operations/test_window_stats.py
+++ b/tests/feature_extraction/window_operations/test_window_stats.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pytest
+from scipy import stats
 
 from jabs.feature_extraction.window_operations import window_stats
 
@@ -102,3 +103,26 @@ def test_np_kurtosis_matches_window_kurtosis() -> None:
     np.testing.assert_allclose(
         window_stats.window_kurtosis(values, window=2), window_stats.np_kurtosis(view)
     )
+
+
+def test_np_skew_matches_scipy_default() -> None:
+    """np_skew reproduces scipy's biased skew over the non-nan values of each window."""
+    view = np.array([[np.nan, 1.0, 2.0, 8.0], [1.0, 2.0, 8.0, 3.0], [2.0, 8.0, 3.0, np.nan]])
+    np.testing.assert_allclose(
+        window_stats.np_skew(view), stats.skew(view, axis=1, nan_policy="omit")
+    )
+
+
+def test_np_kurtosis_is_pearson_not_fisher() -> None:
+    """np_kurtosis reports Pearson kurtosis, i.e. scipy's ``fisher=False``.
+
+    Guards the documented convention: scipy's default subtracts 3.0, so swapping in
+    ``scipy.stats.kurtosis`` with default arguments would silently shift every
+    ``kurtosis`` window feature.
+    """
+    view = np.array([[np.nan, 1.0, 2.0, 8.0], [1.0, 2.0, 8.0, 3.0], [2.0, 8.0, 3.0, np.nan]])
+    result = window_stats.np_kurtosis(view)
+    np.testing.assert_allclose(
+        result, stats.kurtosis(view, axis=1, nan_policy="omit", fisher=False)
+    )
+    np.testing.assert_allclose(result - 3.0, stats.kurtosis(view, axis=1, nan_policy="omit"))


### PR DESCRIPTION
## Reasoning

`np_kurtosis()` in [`src/jabs/feature_extraction/window_operations/window_stats.py`](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/main/src/jabs/feature_extraction/window_operations/window_stats.py#L101-L118) documented its return value as:

> kurtosis values that match `scipy.stats.kurtosis(values, axis, nan_policy='omit')`

That equivalence is wrong. The implementation computes `sum((x - mean)**4) / (n * std**4)`, which is **Pearson (non-excess)** kurtosis, i.e. scipy's `fisher=False` variant. scipy's *default* is `fisher=True`, which subtracts 3.0. Verified against the installed scipy:

```
np_kurtosis          [2.2395, 2.5824, 2.3033, 1.6487, 2.3905]
scipy default        [-0.7605, -0.4176, -0.6967, -1.3513, -0.6095]
scipy fisher=False   [2.2395, 2.5824, 2.3033, 1.6487, 2.3905]
```

I picked this over the other candidates I looked at (a garbled `__init__` docstring and a wrong `external_identities` type in `jabs-core`'s `PoseEstimation`; a `self._config = {...}` assignment in `GapInterpolationStage` that replaces the base class dict instead of adding a key; `packages/jabs-behavior` missing from the package list in `docs/development/development.md`) because this one is actively dangerous rather than merely untidy. The docstring is an invitation: it tells a future developer that `np_kurtosis` is a faster stand-in for a specific scipy call, so replacing the hand-rolled loop with that call looks like a safe simplification. It would shift every `kurtosis` window feature by exactly 3.0, invalidating cached features and trained classifiers with no test failing to catch it.

The confusion is compounded by a real inconsistency in the codebase that nothing documented: `signal_stats.psd_kurtosis` *does* call scipy with default arguments, so the `kurtosis` window feature and the `psd_kurtosis` signal feature genuinely use different conventions (offset by 3.0). Both are registered side by side in `Feature._window_operations` / `Feature._signal_operations`. This PR documents that rather than changing it.

Safety: net-zero behavior change. Every edit to `src/` is inside a docstring — no executable line is touched — so no computed feature value changes and `FEATURE_VERSION` is deliberately left alone. The new tests only assert what the current code already does.

## Change

### Logic changes

None. (Docstring text plus new tests only.)

**`src/jabs/feature_extraction/window_operations/window_stats.py`** — docstring only:
- `np_kurtosis`: state that it returns Pearson (non-excess) kurtosis, equivalent to `scipy.stats.kurtosis(..., fisher=False)`, and that it is 3.0 larger than scipy's default; note the differing convention in `psd_kurtosis`.
- `np_skew`: state that it matches `scipy.stats.skew(..., nan_policy="omit")` (scipy's default, the biased/population estimator). This claim was already correct — confirmed numerically — and is now explicit about which estimator.
- Both: fix the `Args` typo ("2d array of with time and a window"), and move the `Raises: RuntimeWarning when an entire window is nans` line into a `Note:`, since numpy *emits* that warning rather than raising it (`window_kurtosis`/`window_skew` suppress it) — a `Raises:` section for a warning misleads a reader into writing `except RuntimeWarning`.

**`src/jabs/feature_extraction/window_operations/signal_stats.py`** — docstring only:
- `psd_kurtosis`: note that it uses scipy's default (Fisher/excess) kurtosis and is offset by 3.0 from the `kurtosis` window operation; `Returns` now says "excess kurtosis of power".

**`tests/feature_extraction/window_operations/test_window_stats.py`** — two new tests:
- `test_np_skew_matches_scipy_default` — pins `np_skew` to `scipy.stats.skew(..., nan_policy="omit")`.
- `test_np_kurtosis_is_pearson_not_fisher` — pins `np_kurtosis` to `scipy.stats.kurtosis(..., fisher=False)` and asserts the 3.0 offset from scipy's default, so the "just call scipy" refactor now fails loudly instead of silently.

Both cases include a window with a NaN so the `nan_policy="omit"` path is exercised.

### Mechanical updates

**`tests/feature_extraction/window_operations/test_window_stats.py`** — added `from scipy import stats` (mechanical, no logic change). `scipy` is already imported by `tests/feature_extraction/test_feature_base_class.py` and by three modules under `src/jabs/feature_extraction/`.

## Verification

- `ruff check .` — clean; `ruff format .` — 444 files unchanged
- `pytest` — 850 passed, 200 skipped
- No files under `packages/` were touched

---

One thing this PR does **not** fix, flagged for a maintainer decision because it is outside a docstring-only change: `scipy` is imported directly by `src/jabs/feature_extraction/{feature_base_class.py, base_features/angles.py, window_operations/signal_stats.py}` but is not declared as a dependency in any `pyproject.toml`. It currently resolves only transitively (via `xgboost`), so a future dependency change could break the import.

This PR was produced by an automated analysis from Claude Code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUzJL5MwqS4FTYb9gEdrHt)_