### PR TITLE
Fix pose file version parsing: multi-digit versions and directory-name matches

### DIFF
--- a/src/jabs/pose_estimation/__init__.py
+++ b/src/jabs/pose_estimation/__init__.py
@@ -63,20 +63,32 @@ def get_pose_path(video_path: Path, pose_dir: Path | None = None):
     raise ValueError("Video does not have pose file")
 
 
-def get_pose_file_major_version(path: Path):
+# matches the version suffix of a pose file name, e.g. "_v6.h5" in
+# "video_pose_est_v6.h5". Anchored at the end so only the filename's suffix can
+# supply the version.
+_POSE_VERSION_RE = re.compile(r"_v(\d+)\.h5$")
+
+
+def get_pose_file_major_version(path: Path) -> int:
     """get the major version of a pose file from the _filename_
 
-    Note: does not inspect contents of file, assumes file name matches
-    video_name_v[version number].h5
+    Note: does not inspect contents of file, assumes the file name follows the
+    JABS convention ``<video name>_pose_est_v<major version>.h5``.
 
     Args:
         path: path of pose file
 
     Returns:
         integer major version number
+
+    Raises:
+        ValueError: if the file name does not end with a ``_v<major version>.h5``
+            suffix
     """
-    v = re.search(r"_v([0-9])+\.h5", str(path)).group(1)
-    return int(v)
+    match = _POSE_VERSION_RE.search(path.name)
+    if match is None:
+        raise ValueError(f"'{path.name}' is not a valid pose file name")
+    return int(match.group(1))
 
 
 def get_frames_from_file(path: Path):

--- a/src/jabs/scripts/cli/compute_features.py
+++ b/src/jabs/scripts/cli/compute_features.py
@@ -92,7 +92,7 @@ def compute_features_command(
     """
     try:
         pose_version = get_pose_file_major_version(pose_file)
-    except (AttributeError, ValueError) as e:
+    except ValueError as e:
         raise click.ClickException(
             f"Unable to determine pose version from filename '{pose_file.name}'; "
             "expected a name like '*_pose_est_v<N>.h5'."

--- a/tests/pose_estimation/test_pose_file.py
+++ b/tests/pose_estimation/test_pose_file.py
@@ -72,6 +72,38 @@ def test_open_pose_est_v5(pose_est_v5):
     assert static_objs["corners"].shape == (4, 2)
 
 
+@pytest.mark.parametrize(
+    ("filename", "expected"),
+    [
+        ("sample_pose_est_v2.h5", 2),
+        ("sample_pose_est_v6.h5", 6),
+        ("sample_pose_est_v10.h5", 10),
+        ("sample_pose_est_v123.h5", 123),
+    ],
+    ids=["v2", "v6", "two-digit", "three-digit"],
+)
+def test_get_pose_file_major_version(filename: str, expected: int) -> None:
+    """multi-digit major versions are parsed in full, not just the last digit"""
+    assert jabs.pose_estimation.get_pose_file_major_version(Path(filename)) == expected
+
+
+def test_get_pose_file_major_version_ignores_directories() -> None:
+    """only the file name supplies the version, never a parent directory name"""
+    path = Path("/projects/archive_v3.h5_backup/sample_pose_est_v6.h5")
+    assert jabs.pose_estimation.get_pose_file_major_version(path) == 6
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["sample.h5", "sample_pose_est.h5", "sample_pose_est_v6.h5.bak", "sample_pose_est_vN.h5"],
+    ids=["no-suffix", "no-version", "trailing-extension", "non-numeric"],
+)
+def test_get_pose_file_major_version_invalid(filename: str) -> None:
+    """a name without a version suffix raises ValueError, not AttributeError"""
+    with pytest.raises(ValueError, match="not a valid pose file name"):
+        jabs.pose_estimation.get_pose_file_major_version(Path(filename))
+
+
 def test_get_points(pose_est_v4):
     """test getting pose points from PoseEstimation instance"""
     points, point_mask = pose_est_v4.get_identity_poses(0)


### PR DESCRIPTION
## Reasoning

I looked for a genuine correctness bug rather than another documentation pass, and found one in [`get_pose_file_major_version()`](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/be7b6f4/src/jabs/pose_estimation/__init__.py#L66-L79). It had two defects in a single regex:

```python
v = re.search(r"_v([0-9])+\.h5", str(path)).group(1)
```

1. **The `+` is outside the capture group.** `([0-9])+` repeats the *group*, not the digit class, so `group(1)` only ever holds the last repetition — a single digit. `video_pose_est_v10.h5` parses as version **0**, not 10. Verified:

   ```
   >>> re.search(r"_v([0-9])+\.h5", "/data/video_pose_est_v10.h5").group(1)
   '0'
   ```

   Every supported pose version today is a single digit (v2–v8), so this is latent — but it fails silently rather than loudly. A version-0 result makes `get_static_objects_in_file()` and `get_points_per_lixit()` (both gated on `>= 5`) quietly return empty, so landmark features would just disappear for a v10 pose file with no error anywhere.

2. **The search ran against the whole path string.** `re.search` returns the *first* match, so a parent directory whose name ends in a version suffix supplies the version instead of the file:

   ```
   >>> re.search(r"_v([0-9])+\.h5", "/archive_v3.h5_old/video_pose_est_v6.h5").group(1)
   '3'
   ```

   Contrived, but the function's own docstring says it reads the version "from the _filename_", so matching the directory is plainly not intended.

I picked this over the other candidates I considered (a dead `legacy_names` class attribute in `PostprocessingStage`, a stray annotated-subscript assignment in `VideoLabels.as_dict`, an unreachable `NameError` when `_window_signal` is handed an empty feature dict) because it is the only one of them that is an actual correctness defect on a code path the whole project depends on.

**Why this is safe:** for every pose version JABS supports today (v2–v8, single digit, no pathological directory names) the new regex returns exactly what the old one did — the change is net-zero for all existing data. The only differences are in cases the old code got wrong.

The one deliberate behavior change is in the error path: a name with no version suffix used to raise `AttributeError: 'NoneType' object has no attribute 'group'` from calling `.group()` on a failed match. It now raises a `ValueError` naming the file. `compute-features` was already catching **both** `AttributeError` and `ValueError` here, which is a fair sign the `AttributeError` was understood as a wart; the other two callers (`Project`, `FeatureManager`) caught neither, so they now get a comprehensible message instead of a confusing one.

## Change

### Logic changes

- **`src/jabs/pose_estimation/__init__.py`** — hoisted the pattern to a module-level `_POSE_VERSION_RE = re.compile(r"_v(\d+)\.h5$")`: quantifier moved inside the capture group, anchored at the end. Matched against `path.name` rather than `str(path)`. A non-matching name now raises `ValueError` instead of `AttributeError`. Added the `-> int` return annotation, a `Raises:` section, and corrected the docstring's filename convention (it said `video_name_v[version number].h5`; the actual convention is `[video name]_pose_est_v[major version].h5`).

- **`tests/pose_estimation/test_pose_file.py`** — added three tests covering the fix: a parametrized version-parsing test including two- and three-digit versions, a test that a parent directory name cannot supply the version, and a parametrized test that malformed names raise `ValueError`.

### Mechanical updates

- **`src/jabs/scripts/cli/compute_features.py`** — one line: `except (AttributeError, ValueError)` → `except ValueError`, since `AttributeError` is no longer reachable from this call. Mechanical, no logic change; the `ClickException` it raises is unchanged.

`ruff check .`, `ruff format .`, and `pytest` (859 passed, 200 skipped) all pass. No `packages/` files touched, and no `FEATURE_VERSION` bump — no computed feature value changes.