### PR TITLE
Fix broken lazy initialization of CornerDistanceInfo average wall length

### DIFF
--- a/src/jabs/feature_extraction/landmark_features/corner.py
+++ b/src/jabs/feature_extraction/landmark_features/corner.py
@@ -28,6 +28,11 @@ class CornerDistanceInfo:
         self._cached_bearings = {}
         self._all_wall_distances = {}
 
+        # None until cache_features() runs; it is then set to the arena's average
+        # wall length, or NaN when the pose file has no "corners" static object.
+        # get_avg_wall_length() relies on this None to know it must still compute.
+        self._avg_wall_length: float | None = None
+
     def cache_features(self, identity: int):
         """cache corner distances and bearings for a given identity
 
@@ -199,11 +204,15 @@ class CornerDistanceInfo:
     def get_avg_wall_length(self, identity: int = 0) -> float:
         """gets the average wall length
 
+        The average wall length is a property of the arena rather than of an
+        individual mouse, so it is computed once for whichever identity happens
+        to populate the cache first and shared by all of them.
+
         Args:
             identity: identity to cache if not yet calculated
 
         Returns:
-            average wall length
+            average wall length, or NaN if the pose file has no corners
         """
         if self._avg_wall_length is None:
             self.cache_features(identity)

--- a/src/jabs/feature_extraction/landmark_features/corner.py
+++ b/src/jabs/feature_extraction/landmark_features/corner.py
@@ -205,8 +205,10 @@ class CornerDistanceInfo:
         """gets the average wall length
 
         The average wall length is a property of the arena rather than of an
-        individual mouse, so it is computed once for whichever identity happens
-        to populate the cache first and shared by all of them.
+        individual mouse, so a single instance-wide value is shared by every
+        identity. ``cache_features()`` derives it from the same static corners
+        every time it runs for a new identity, overwriting the stored value
+        with an identical one.
 
         Args:
             identity: identity to cache if not yet calculated

--- a/tests/feature_extraction/landmark_features/test_corner_features.py
+++ b/tests/feature_extraction/landmark_features/test_corner_features.py
@@ -41,3 +41,27 @@ def test_compute_corner_distances(pose_est_v5_with_static_objects):
         values = dist_to_corner.per_frame(i)["distance to corner"]
         non_nan_indices = ~np.isnan(values)
         assert (values[non_nan_indices] >= 0).all()
+
+
+def test_avg_wall_length_computed_on_first_access(pose_est_v5_with_static_objects) -> None:
+    """get_avg_wall_length() populates the cache itself if nothing else has yet."""
+    pose_est_v5 = pose_est_v5_with_static_objects
+    distance_info = corner_module.CornerDistanceInfo(pose_est_v5, pose_est_v5.cm_per_pixel)
+
+    avg_wall_length = distance_info.get_avg_wall_length(0)
+
+    assert avg_wall_length > 0
+    # a second call returns the same value without recomputing
+    assert distance_info.get_avg_wall_length(0) == avg_wall_length
+
+
+def test_avg_wall_length_matches_cached_value(pose_est_v5_with_static_objects) -> None:
+    """Caching via another accessor first yields the same average wall length."""
+    pose_est_v5 = pose_est_v5_with_static_objects
+    pixel_scale = pose_est_v5.cm_per_pixel
+
+    lazy_info = corner_module.CornerDistanceInfo(pose_est_v5, pixel_scale)
+    eager_info = corner_module.CornerDistanceInfo(pose_est_v5, pixel_scale)
+    eager_info.get_distances(0)
+
+    assert lazy_info.get_avg_wall_length(0) == eager_info.get_avg_wall_length(0)

--- a/tests/feature_extraction/landmark_features/test_corner_features.py
+++ b/tests/feature_extraction/landmark_features/test_corner_features.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import jabs.feature_extraction.landmark_features.corner as corner_module
 
@@ -64,4 +65,4 @@ def test_avg_wall_length_matches_cached_value(pose_est_v5_with_static_objects) -
     eager_info = corner_module.CornerDistanceInfo(pose_est_v5, pixel_scale)
     eager_info.get_distances(0)
 
-    assert lazy_info.get_avg_wall_length(0) == eager_info.get_avg_wall_length(0)
+    assert lazy_info.get_avg_wall_length(0) == pytest.approx(eager_info.get_avg_wall_length(0))


### PR DESCRIPTION
## Reasoning

`CornerDistanceInfo.get_avg_wall_length()` is written as a lazy accessor: it checks `self._avg_wall_length is None` and calls `cache_features()` if the value hasn't been computed yet. But `_avg_wall_length` is never created in `__init__` — it is only assigned at the very end of `cache_features()` ([corner.py:145](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/main/src/jabs/feature_extraction/landmark_features/corner.py#L145)). So the guard itself is what fails: calling `get_avg_wall_length()` on a fresh instance raises `AttributeError: 'CornerDistanceInfo' object has no attribute '_avg_wall_length'` instead of computing the value ([corner.py:199-210](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/main/src/jabs/feature_extraction/landmark_features/corner.py#L199-L210)).

This is latent rather than user-visible today, because the one in-tree caller (`IdentityFeatures.__save_per_frame` in `feature_extraction/features.py`) always calls `get_closest_corner()` first, which populates the cache as a side effect. The accessor is public and its sibling accessors (`get_distances`, `get_bearings`, `get_closest_corner`, `get_wall_distances`) all work standalone, so the ordering dependency is an accident, not a contract — any new caller or test that reaches for the wall length first hits the crash.

I picked this over the other candidates I looked at (a docstring in `_sorted_search_results` that lists sort keys in the wrong order, `print()` calls that should be `logger` calls in `behavior_search_util.py` / `project_merge.py`, and de-duplicating the `"unfragmented_labels" if present else "labels"` ternary that appears in three modules) because it is the only one that is an actual defect rather than a cosmetic issue, and it is priority 1 in the quality ordering.

The fix is safe: on every path that works today, `_avg_wall_length` is assigned by `cache_features()` before it is read, so initializing it to `None` in `__init__` cannot change any value that is currently returned. It only converts a crash into the computation the code already intended. No feature values change, so no `FEATURE_VERSION` bump.

Note that `cache_features()` sets the value to `NaN` (not `None`) when the pose file has no `corners` static object, so the `is None` guard still correctly avoids recomputing for corner-less pose files.

## Change

### Logic changes

- **`src/jabs/feature_extraction/landmark_features/corner.py`** — initialize `self._avg_wall_length: float | None = None` in `CornerDistanceInfo.__init__` so the lazy-init guard in `get_avg_wall_length()` works. Added a comment explaining the `None`/`NaN` distinction, and expanded the `get_avg_wall_length()` docstring to note that the value is arena-wide (not per-identity, despite the `identity` argument, which only selects which identity populates the cache) and that it is `NaN` when the pose file has no corners.

- **`tests/feature_extraction/landmark_features/test_corner_features.py`** — two regression tests: `test_avg_wall_length_computed_on_first_access` fails with `AttributeError` on `main` and passes here; `test_avg_wall_length_matches_cached_value` pins that the lazily computed value matches the one produced when another accessor populates the cache first.

### Mechanical updates

None.

## Verification

- `ruff check .` and `ruff format .` clean
- `pytest`: 861 passed, 200 skipped

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXiL4QHn14Py2q3ucgmwjn)_