### PR TITLE
Keep video list selection when the current video still matches the filter

### DIFF
--- a/src/jabs/ui/main_window/video_list_widget.py
+++ b/src/jabs/ui/main_window/video_list_widget.py
@@ -206,8 +206,10 @@ class VideoListDockWidget(QtWidgets.QDockWidget):
             is_hidden = text not in item.text().lower()
 
             # if the current item is being filtered out, deselect it to
-            # avoid Qt accessibility error messages in the console
-            if current_item and item == current_item:
+            # avoid Qt accessibility error messages in the console. A current
+            # item that still matches the filter keeps its selection, so typing
+            # in the filter box does not cost the user their place in the list.
+            if is_hidden and item == current_item:
                 # suppress selection event to avoid updating the UI -- the current
                 # video will still be displayed in the player widget until the user selects a new one
                 self._suppress_selection_event = True

--- a/tests/ui/test_video_list_widget.py
+++ b/tests/ui/test_video_list_widget.py
@@ -212,3 +212,81 @@ def test_feature_cache_status_falls_back_to_stored_status_on_error():
 def test_feature_cache_status_without_project():
     """With no project loaded there is no status to report."""
     assert VideoListDockWidget()._feature_cache_status("a.avi") is None
+
+
+def _visible_videos(widget):
+    """Return the video names of the rows currently visible in the list."""
+    file_list = widget._file_list
+    return [
+        file_list.item(i).data(Qt.ItemDataRole.UserRole)
+        for i in range(file_list.count())
+        if not file_list.item(i).isHidden()
+    ]
+
+
+def test_filter_keeps_selection_when_current_video_still_matches():
+    """Filtering must not cost the user their place when the selection still matches.
+
+    Regression: the deselect guard checked only whether the item *was* the
+    current one, so every keystroke in the filter box cleared the selection even
+    when the selected video was still visible.
+    """
+    widget = VideoListDockWidget()
+    widget.set_project(_mock_project(["walk_01.avi", "walk_02.avi", "rear_01.avi"], set()))
+    widget.select_video("walk_01.avi", suppress_event=True)
+
+    widget._filter_list("walk")
+
+    assert _visible_videos(widget) == ["walk_01.avi", "walk_02.avi"]
+    current = widget._file_list.currentItem()
+    assert current is not None
+    assert current.data(Qt.ItemDataRole.UserRole) == "walk_01.avi"
+
+
+def test_filter_deselects_current_video_when_it_is_filtered_out():
+    """A current item that no longer matches is deselected, so no hidden row stays current."""
+    widget = VideoListDockWidget()
+    widget.set_project(_mock_project(["walk_01.avi", "rear_01.avi"], set()))
+    widget.select_video("rear_01.avi", suppress_event=True)
+
+    widget._filter_list("walk")
+
+    assert _visible_videos(widget) == ["walk_01.avi"]
+    assert widget._file_list.currentItem() is None
+
+
+def test_filter_does_not_emit_selection_change():
+    """Deselecting a filtered-out item must not be reported as a user selection."""
+    widget = VideoListDockWidget()
+    widget.set_project(_mock_project(["walk_01.avi", "rear_01.avi"], set()))
+    widget.select_video("rear_01.avi", suppress_event=True)
+
+    emitted = []
+    widget.selectionChanged.connect(emitted.append)
+    widget._filter_list("walk")
+
+    assert emitted == []
+
+
+def test_clearing_filter_restores_all_rows():
+    """Clearing the filter text un-hides every row."""
+    widget = VideoListDockWidget()
+    videos = ["walk_01.avi", "walk_02.avi", "rear_01.avi"]
+    widget.set_project(_mock_project(videos, set()))
+
+    widget._filter_list("walk")
+    widget._filter_list("")
+
+    assert _visible_videos(widget) == sorted(videos)
+
+
+def test_filter_with_no_current_item_is_safe():
+    """Filtering with nothing selected must not raise."""
+    widget = VideoListDockWidget()
+    widget.set_project(_mock_project(["walk_01.avi", "rear_01.avi"], set()))
+    widget._file_list.setCurrentItem(None)
+
+    widget._filter_list("walk")
+
+    assert _visible_videos(widget) == ["walk_01.avi"]
+    assert widget._file_list.currentItem() is None


### PR DESCRIPTION
## Problem

Typing anything into the video list filter box cleared the playlist selection, even when the selected video still matched the filter — so you lost your place in the list on every keystroke.

The deselect guard in `_filter_list` never checked whether the current item was actually being filtered out:

```python
is_hidden = text not in item.text().lower()

# if the current item is being filtered out, deselect it to
# avoid Qt accessibility error messages in the console
if current_item and item == current_item:
    ...
    self._file_list.setCurrentItem(None)
```

The comment describes the intent correctly; the condition doesn't implement it. Any time the loop reached the current item it deselected it, regardless of `is_hidden`.

Reproduced with 26 videos, `video_00.avi` selected, filtering on `video_0` (which still matches it): 10 rows visible, current item `None`, current row `-1`.

## Fix

Gate the deselect on `is_hidden`, so only a current item that no longer matches loses its selection. Dropping the now-redundant `current_item` truthiness check is safe — `QListWidgetItem.__eq__(None)` returns `False`, which the new test covers.

## Tests

Five tests around `_filter_list`, which had none:

- current video still matches → selection kept (fails on the old code, passes on the new)
- current video filtered out → deselected, so no hidden row stays current
- deselecting a filtered-out item does not emit `selectionChanged`
- clearing the filter restores all rows
- filtering with nothing selected does not raise

## Context

Found while tracking down this warning on macOS:

```
qt.accessibility.table: Cell requested for row 24 is out of bounds for table with 24 rows! Resizing table model.
```

That message comes from `libqcocoa.dylib` — the macOS accessibility bridge — and this change is **not** a guaranteed fix for it. It does remove a burst of focus/selection accessibility events on every keystroke, which is what drew attention to this method. The warning itself is benign (macOS-only, only with an accessibility client attached, and Qt rebuilds its cache and continues); it can be silenced with `QT_LOGGING_RULES="qt.accessibility.table.warning=false"`.

Worth merging on its own merits either way: losing the playlist selection while filtering is a user-visible bug.