### PR TITLE
release 0.46.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@
 
 [![Python 3.10-3.14](https://img.shields.io/badge/python-3.10--3.14-blue.svg)](https://www.python.org/downloads/)
 [![PyPI version](https://img.shields.io/pypi/v/jabs-behavior-classifier.svg)](https://pypi.org/project/jabs-behavior-classifier/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/v0.46.2/LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/v0.46.3/LICENSE)
 [![DOI](https://img.shields.io/badge/DOI-10.7554%2FeLife.107259.2-green.svg)](https://doi.org/10.7554/eLife.107259.2)
 
-[Documentation](https://jabs-tutorial.readthedocs.io/) · [User Guide](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/v0.46.2/docs/user-guide/overview.md) · [Sample Data](https://doi.org/10.5281/zenodo.16697331) · [Contact Us](mailto:jabs@jax.org)
+[Documentation](https://jabs-tutorial.readthedocs.io/) · [User Guide](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/v0.46.3/docs/user-guide/overview.md) · [Sample Data](https://doi.org/10.5281/zenodo.16697331) · [Contact Us](mailto:jabs@jax.org)
 
 ---
 
-![JABS Screenshot](https://raw.githubusercontent.com/KumarLabJax/JABS-behavior-classifier/v0.46.2/docs/assets/images/jabs_screenshot.png)
+![JABS Screenshot](https://raw.githubusercontent.com/KumarLabJax/JABS-behavior-classifier/v0.46.3/docs/assets/images/jabs_screenshot.png)
 
 </div>
 
@@ -145,7 +145,7 @@ JABS requires pose files generated from the Kumar Lab's mouse pose estimation ne
 
 We provide Singularity/Apptainer definition files and SLURM batch scripts for running
 JABS on Linux compute clusters. See
-[vm/README.md](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/v0.46.2/vm/README.md)
+[vm/README.md](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/v0.46.3/vm/README.md)
 for build instructions and usage details.
 
 ## Project Portability
@@ -181,14 +181,14 @@ JABS uses four version numbers to track compatibility:
 ## Documentation
 
 - **[ReadTheDocs Tutorial](https://jabs-tutorial.readthedocs.io/)** — Complete user guide and tutorials
-- **[User Guide](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/v0.46.2/docs/user-guide/overview.md)** — Markdown documentation
+- **[User Guide](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/v0.46.3/docs/user-guide/overview.md)** — Markdown documentation
 - **[Sample Data](https://doi.org/10.5281/zenodo.16697331)** — Test datasets for demonstration
 
 ## Contributing
 
 Interested in contributing? Check out our:
-- [Contributing Guide](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/v0.46.2/CONTRIBUTING.md)
-- [Development Guide](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/v0.46.2/docs/development/development.md)
+- [Contributing Guide](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/v0.46.3/CONTRIBUTING.md)
+- [Development Guide](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/v0.46.3/docs/development/development.md)
 
 ## Citation
 

--- a/packages/jabs-behavior/pyproject.toml
+++ b/packages/jabs-behavior/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jabs-behavior"
-version = "0.46.2"
+version = "0.46.3"
 description = "JABS behavior event processing and postprocessing filters"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/packages/jabs-core/pyproject.toml
+++ b/packages/jabs-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jabs-core"
-version = "0.46.2"
+version = "0.46.3"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/packages/jabs-io/pyproject.toml
+++ b/packages/jabs-io/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jabs-io"
-version = "0.46.2"
+version = "0.46.3"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/packages/jabs-vision/pyproject.toml
+++ b/packages/jabs-vision/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jabs-vision"
-version = "0.46.2"
+version = "0.46.3"
 description = ""
 readme = "README.md"
 requires-python = ">=3.10,<3.15"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jabs-behavior-classifier"
-version = "0.46.2"
+version = "0.46.3"
 description = ""
 readme = "README.md"
 requires-python = ">=3.10,<3.15"
@@ -15,9 +15,9 @@ authors = [
 ]
 
 dependencies = [
-  "jabs-behavior==0.46.2",
-  "jabs-core==0.46.2",
-  "jabs-io==0.46.2",
+  "jabs-behavior==0.46.3",
+  "jabs-core==0.46.3",
+  "jabs-io==0.46.3",
   "h5py>=3.10.0,<4.0.0",
   "markdown2>=2.5.1,<3.0.0",
   "numpy>=2.0.0,<3.0.0",

--- a/tests/ui/test_video_list_widget.py
+++ b/tests/ui/test_video_list_widget.py
@@ -214,7 +214,7 @@ def test_feature_cache_status_without_project():
     assert VideoListDockWidget()._feature_cache_status("a.avi") is None
 
 
-def _visible_videos(widget: VideoListDockWidget):
+def _visible_videos(widget: "VideoListDockWidget"):
     """Return the video names of the rows currently visible in the list."""
     file_list = widget._file_list
     return [

--- a/tests/ui/test_video_list_widget.py
+++ b/tests/ui/test_video_list_widget.py
@@ -214,7 +214,7 @@ def test_feature_cache_status_without_project():
     assert VideoListDockWidget()._feature_cache_status("a.avi") is None
 
 
-def _visible_videos(widget):
+def _visible_videos(widget: VideoListDockWidget):
     """Return the video names of the rows currently visible in the list."""
     file_list = widget._file_list
     return [

--- a/uv.lock
+++ b/uv.lock
@@ -1734,7 +1734,7 @@ wheels = [
 
 [[package]]
 name = "jabs-behavior"
-version = "0.46.2"
+version = "0.46.3"
 source = { editable = "packages/jabs-behavior" }
 dependencies = [
     { name = "jsonschema" },
@@ -1778,7 +1778,7 @@ test = [
 
 [[package]]
 name = "jabs-behavior-classifier"
-version = "0.46.2"
+version = "0.46.3"
 source = { editable = "." }
 dependencies = [
     { name = "argparse-formatter" },
@@ -1892,7 +1892,7 @@ test = [
 
 [[package]]
 name = "jabs-core"
-version = "0.46.2"
+version = "0.46.3"
 source = { editable = "packages/jabs-core" }
 dependencies = [
     { name = "h5py" },
@@ -1952,7 +1952,7 @@ test = [
 
 [[package]]
 name = "jabs-io"
-version = "0.46.2"
+version = "0.46.3"
 source = { editable = "packages/jabs-io" }
 dependencies = [
     { name = "h5py" },
@@ -2021,7 +2021,7 @@ test = [
 
 [[package]]
 name = "jabs-vision"
-version = "0.46.2"
+version = "0.46.3"
 source = { editable = "packages/jabs-vision" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
This pull request updates the project and all sub-packages from version 0.46.2 to 0.46.3. It also updates all documentation and dependency references to point to the new version. No functional code changes are included—this is a version bump and documentation maintenance release.

Version and dependency updates:

* Bumped the version from 0.46.2 to 0.46.3 in the main project (`pyproject.toml`) and all sub-packages: `jabs-behavior`, `jabs-core`, `jabs-io`, and `jabs-vision` (`pyproject.toml`, `packages/jabs-behavior/pyproject.toml`, `packages/jabs-core/pyproject.toml`, `packages/jabs-io/pyproject.toml`, `packages/jabs-vision/pyproject.toml`) [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-1842584c973b5028a1cb526513120774c8dedf2b5be99d4bd6b094e413349ca9L3-R3) [[3]](diffhunk://#diff-374341e820ab0069bb4e820f9e99e9a969bcf4fdf1b09a00274a8360a9ab25b4L3-R3) [[4]](diffhunk://#diff-73a260afd977c4dd7bb63fa5281581ff8aabd1d09f295294d036c4f5cc339f36L3-R3) [[5]](diffhunk://#diff-1542793564cc7c3b9be1bc39fca1bda7ccb2200b42abd77d41e34259f48ad309L3-R3).
* Updated dependencies in the main `pyproject.toml` to require the new 0.46.3 versions of internal packages (`jabs-behavior`, `jabs-core`, `jabs-io`).

Documentation and reference updates:

* Updated all version-specific links and badges in `README.md` to reference version 0.46.3, including license, user guide, images, and VM instructions [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L148-R148) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L184-R191).

Minor code quality improvement:

* Added a type annotation to the `_visible_videos` helper in `test_video_list_widget.py` for clarity.