### PR TITLE
Skip NWB adapter tests when the optional nwb extra is missing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ assignment, PR process).
 ```bash
 # Setup
 uv sync                                    # Install all deps from lockfile (creates .venv)
+uv sync --all-packages --all-extras --all-groups  # Full env, matching CI (see below)
 uv run pre-commit install                  # Install git hooks (ruff check + ruff format)
 
 # Testing
@@ -66,6 +67,33 @@ uv run jabs-cli merge                      # Merge one JABS project into another
 uv run jabs-cli rename-behavior            # Rename a behavior across a project
 uv run jabs-cli prune                      # Remove videos from a project
 ```
+
+### Optional dependencies and the test environment
+
+A plain `uv sync` installs neither the optional extras (`nwb`, `parquet`, `mlflow`,
+`yaml`) nor `jabs-vision` (not a root dependency). To run the suite the way CI does,
+use the same command CI uses (`.github/workflows/_run-tests-action.yml`):
+
+```bash
+uv sync --all-packages --all-extras --all-groups
+```
+
+Without it, some suites are partially or wholly unrunnable locally even though they
+pass in CI:
+
+| suite | plain `uv sync` | needs |
+|---|---|---|
+| `packages/jabs-io/tests` | 238 pass, 1 skipped | `--extra nwb` for the remaining 61 |
+| `packages/jabs-vision/tests` | 0 collected, 17 errors | `--all-packages` (installs `jabs.vision` + torch) |
+
+**Guard optional imports in tests.** A module-scope import of an optional dependency
+raises during collection, and a collection error aborts the *entire* directory run -
+one missing extra takes every other test in that package with it. Use
+`pytest.importorskip("<module>")` before the guarded imports (see
+`packages/jabs-io/tests/internal/pose/test_nwb.py`), and add an `E402` per-file ignore
+in `ruff.toml` for the imports that must follow it. Qt imports in UI tests use the
+existing `try/except ImportError` + `pytest.mark.skipif` pattern instead; keep non-Qt
+imports out of those blocks.
 
 ## Architecture
 

--- a/packages/jabs-io/tests/internal/pose/test_nwb.py
+++ b/packages/jabs-io/tests/internal/pose/test_nwb.py
@@ -7,6 +7,17 @@ import logging
 import h5py
 import numpy as np
 import pytest
+
+# PoseNWBAdapter's dependencies live in the optional `nwb` extra, and the adapter
+# itself already degrades gracefully without them (see _NWB_AVAILABLE in
+# jabs.io.internal.pose.nwb). Skip this module when they are missing - a plain
+# `uv sync` does not install the extra, and an unguarded import here fails
+# collection, which aborts every other test in this package rather than just
+# these.
+pytest.importorskip("pynwb")
+pytest.importorskip("ndx_pose")
+pytest.importorskip("ndx_multisubjects")
+
 from ndx_multisubjects import NdxMultiSubjectsNWBFile
 from ndx_pose import PoseEstimation
 from pynwb import NWBHDF5IO

--- a/ruff.toml
+++ b/ruff.toml
@@ -32,6 +32,11 @@ convention = "google"
 
 [lint.per-file-ignores]
 "__init__.py" = ["F401"]  # Unused imports in __init__ files
+"packages/jabs-io/tests/internal/pose/test_nwb.py" = [
+    # pytest.importorskip() for the optional `nwb` extra has to run before the
+    # imports it guards, so those imports cannot sit at the top of the module
+    "E402",
+]
 "src/jabs/scripts/cli/cli.py" = [
     "D301",  # Click uses \b in docstrings to control help formatting
     "D412",  # Click Examples sections look better with a blank line before \b blocks


### PR DESCRIPTION
## Problem

`packages/jabs-io/tests/internal/pose/test_nwb.py` imported `pynwb`, `ndx_pose` and `ndx_multisubjects` at module scope. Those live in the optional `nwb` extra, which a plain `uv sync` does not install, so the import raised during collection — and a collection error aborts the *whole* directory:

```
ERROR packages/jabs-io/tests/internal/pose/test_nwb.py
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
1 error in 0.07s
```

**Zero** of the package's 299 tests ran. One optional dependency took the other 238 with it.

Worth being clear about what this is *not*: CI was never broken. It syncs with `--all-packages --all-extras --all-groups` (`.github/workflows/_run-tests-action.yml:35`), so the extra is present and all 299 pass there. This is purely a local-development papercut.

## Fix

`pytest.importorskip` for the three modules, before the imports they guard. The adapter under test already degrades gracefully without them (`_NWB_AVAILABLE` / `_MULTISUBJECTS_AVAILABLE` in `jabs.io.internal.pose.nwb`), so the test module is now consistent with its subject.

`ruff.toml` gets an `E402` per-file ignore, since the guarded imports cannot sit at the top of the module. Documented inline, matching how the existing Click `D301` ignores are handled.

| | before | after |
|---|---|---|
| plain `uv sync` | 0 ran, collection aborted | 238 passed, 1 skipped |
| `--extra nwb` (CI) | 299 passed | 299 passed |

## CLAUDE.md

Added a short subsection on optional dependencies and the test environment: the CI-equivalent sync command, a table of which suites are unrunnable without it, and the convention for guarding optional imports in tests. This is what led me astray in the first place — the documented setup step is a plain `uv sync`, which silently yields an environment that cannot run two of the five suites.

It also records the distinction between the two guard styles in this repo, so the next person picks the right one: `pytest.importorskip` for non-Qt optional imports, and the existing `try/except ImportError` + `pytest.mark.skipif` pattern for Qt in UI tests.

## Testing

Verified in both environments.

- Plain `uv sync`: jabs-io 238 passed / 1 skipped (was 0), root suite 1066 passed.
- `uv sync --all-packages --all-extras --all-groups`: root 1066, jabs-core 88, jabs-io 299, jabs-behavior 113, jabs-vision 177 — all passing, so the numbers quoted in CLAUDE.md are measured rather than assumed.
- `ruff check` clean.

## Deliberately left alone

`packages/jabs-vision/tests` has the same shape of problem but a different cause: 17 collection errors on a plain sync, because `jabs.vision` itself is not installed (`jabs-vision` is not a root dependency), not merely because `torch` is missing. Guards there would convert 17 errors into 17 skips without making any test actually runnable, and it is that package's owner's call. Documented in the CLAUDE.md table instead.