### PR TITLE
Scale pose overlay markers sub-linearly with frame size

### DIFF
--- a/src/jabs/pose_drawing/skeleton.py
+++ b/src/jabs/pose_drawing/skeleton.py
@@ -20,11 +20,32 @@ KEYPOINT_SIZE = 3
 _INACTIVE_KEYPOINT_ALPHA = 96
 
 
+# Frame size the base marker sizes below are calibrated against, taken from 800x800
+# open-field footage where a 3px radius reads well.
+_REFERENCE_FRAME = 800
+_BASE_KEYPOINT_SIZE = 3
+_BASE_LINE_WIDTH = 2
+
+
 def native_pose_sizes(width: int, height: int) -> tuple[int, int]:
     """Return ``(keypoint_size, line_width)`` for drawing pose at native video resolution.
 
-    The marker and line sizes scale with the frame's larger dimension so the overlay
-    stays legible across videos of different resolutions.
+    Markers grow with the frame so the overlay stays legible across resolutions, but
+    they grow *sub-linearly* - as the square root of the frame's larger dimension.
+
+    Scaling linearly (the previous behavior) keeps a marker at a constant fraction of
+    the frame, which sounds right but is not what the eye judges. Measured on real
+    footage: a mouse in 1080p home-cage video is about four times longer in pixels
+    than one in 800x800 open-field video, so linear scaling produced 16px dots that
+    covered the animal, while the same formula gave a well-judged 6px dot on the
+    smaller frame. What reads badly is a marker's absolute size, not its share of the
+    frame.
+
+    Sizing markers from the animal's own extent was considered and rejected: matching
+    the 800x800 proportions (dot diameter around 6% of body length) would make the
+    1080p dots *larger* still, at roughly 24px.
+
+    ``keypoint_size`` is a radius, so a dot's diameter is twice this value.
 
     Args:
         width: Frame width in pixels.
@@ -33,9 +54,9 @@ def native_pose_sizes(width: int, height: int) -> tuple[int, int]:
     Returns:
         Tuple of ``(keypoint_size, line_width)`` in pixels.
     """
-    reference = max(width, height, 1)
-    keypoint_size = max(3, round(reference / 250))
-    line_width = max(2, round(reference / 400))
+    scale = (max(width, height, 1) / _REFERENCE_FRAME) ** 0.5
+    keypoint_size = max(_BASE_KEYPOINT_SIZE, round(_BASE_KEYPOINT_SIZE * scale))
+    line_width = max(_BASE_LINE_WIDTH, round(_BASE_LINE_WIDTH * scale))
     return keypoint_size, line_width
 
 

--- a/tests/pose_drawing/test_skeleton.py
+++ b/tests/pose_drawing/test_skeleton.py
@@ -47,15 +47,32 @@ def _identity_transform(x, y):
 @pytest.mark.parametrize(
     ("width", "height", "expected"),
     [
-        (100, 100, (3, 2)),  # min bounds
-        (800, 600, (3, 2)),
-        (1920, 1080, (8, 5)),
+        (100, 100, (3, 2)),  # below the reference size, so the floors apply
+        (800, 600, (3, 2)),  # larger dimension is 800, so the scale is exactly 1
+        (800, 800, (3, 2)),  # the footage the base sizes are calibrated on
+        (1920, 1080, (5, 3)),
+        (3840, 2160, (7, 4)),
     ],
-    ids=["min", "sd", "hd"],
+    ids=["min", "sd", "reference", "hd", "4k"],
 )
 def test_native_pose_sizes(width, height, expected) -> None:
     """Keypoint/line sizes honor their minimums and scale with resolution."""
     assert native_pose_sizes(width, height) == expected
+
+
+def test_native_pose_sizes_grow_sub_linearly() -> None:
+    """Markers must grow more slowly than the frame.
+
+    Linear growth keeps a marker at a fixed share of the frame, which produced dots
+    heavy enough to cover the animal on high-resolution footage. Quadrupling the
+    frame should grow the marker by less than four times.
+    """
+    base_kp, base_lw = native_pose_sizes(800, 800)
+    quad_kp, quad_lw = native_pose_sizes(3200, 3200)
+
+    assert quad_kp > base_kp, "markers should still grow with resolution"
+    assert quad_kp < base_kp * 4, "growth must be sub-linear"
+    assert quad_lw < base_lw * 4
 
 
 def test_native_pose_sizes_monotonic() -> None:


### PR DESCRIPTION
Keypoint dots and skeleton lines in exported frames are too heavy on high-resolution video. This changes their growth from linear in the frame's larger dimension to the square root of it.

```diff
-    keypoint_size = max(3, round(reference / 250))
-    line_width = max(2, round(reference / 400))
+    scale = (max(width, height, 1) / _REFERENCE_FRAME) ** 0.5
+    keypoint_size = max(_BASE_KEYPOINT_SIZE, round(_BASE_KEYPOINT_SIZE * scale))
+    line_width = max(_BASE_LINE_WIDTH, round(_BASE_LINE_WIDTH * scale))
```

| video | radius (was) | dot diameter (was) | line (was) |
|---|---|---|---|
| 800x800 | **3** (3) | **6px** (6) | **2** (2) |
| 720p | 4 (5) | 8px (10) | 3 (3) |
| 1080p | **5** (8) | **10px** (16) | **3** (5) |
| 4K | 7 (15) | 14px (30) | 4 (10) |

800x800 is unchanged, which makes it a useful control: an export at that size should be identical before and after.

## Why sub-linear

Linear scaling keeps a marker at a fixed share of the frame. That sounds correct and is not what the eye judges. Two real exported frames, measured rather than eyeballed:

| | 800x800 open field | 1080p home cage |
|---|---|---|
| dot diameter | 6px | 16px |
| body length (nose to tail base) | 97px | 389px |
| dot / body | 6.2% | **4.1%** |
| body / frame | 12.1% | 20.3% |

The 1080p mouse is four times longer in pixels, so relative to the animal its dots were already the *more* conservative of the two - yet they were the ones covering the animal. What reads badly is a marker's absolute size, not its share of the frame, and square-root growth is what keeps absolute size in a sensible band across resolutions.

**Sizing markers from the animal's own extent was considered and rejected.** It is the intuitive "principled" fix, but the numbers kill it: matching the 800x800 look proportionally (~6.2% of body length) would put the 1080p dots at ~24px diameter - larger than the 16px that prompted this. The docstring records that, so it does not get re-proposed.

## Scope

`native_pose_sizes()` has a single caller, `PlayerWidget.get_overlay_frame()`, so this affects **exported frames only**. Live playback is untouched: `overlays/pose_overlay.py` sizes markers from the on-screen zoom (`KEYPOINT_SIZE * zoom ** 0.8`) and never calls this function.

The reference frame size and base sizes are now named constants rather than inline divisors, so the calibration point is explicit: 800px, where a 3px radius is known to read well.

## Testing

`tests/ui/test_pose_drawing.py` gains 800x800 and 4K cases with the new expected values, plus a test asserting growth is sub-linear - quadrupling the frame must less than quadruple the marker - so a future change back to linear scaling fails rather than silently regressing the look.

Full suite: 1069 passing, ruff clean. Verified by re-exporting the same two frames from this branch.

## Note

Once #449 lands, this file moves to `src/jabs/pose_drawing/skeleton.py`. The function body is identical either way, so whichever merges second needs a trivial rebase.