### PR TITLE
docs: correct the OKS formula documented on compute_oks (off by a factor of 2)

### DIFF
--- a/packages/jabs-vision/src/jabs/vision/timm/metrics/similarity.py
+++ b/packages/jabs-vision/src/jabs/vision/timm/metrics/similarity.py
@@ -27,19 +27,29 @@ def compute_oks(
     """Compute Object Keypoint Similarity between a detection and ground truth.
 
     Follows the COCO OKS formula:
-        OKS = sum(exp(-d_i^2 / (2 * s_i^2 * area * 2)) * delta(v_i > 0)) /
+        OKS = sum(exp(-d_i^2 / (2 * k_i^2 * area)) * delta(v_i > 0)) /
               sum(delta(v_i > 0))
 
-    where d_i is the Euclidean distance for keypoint i, s_i is the per-keypoint
-    sigma, area is the GT annotation area, and v_i is the GT visibility flag.
+    where d_i is the Euclidean distance for keypoint i, k_i is twice that
+    keypoint's sigma (``k_i = 2 * sigmas[i]``, the COCO convention), area is the
+    GT annotation area, and v_i is the GT visibility flag. Written in terms of
+    the sigmas passed in, the exponent denominator is ``8 * sigmas[i]**2 * area``.
 
     Args:
         detection: Predicted keypoint detection.
         ground_truth: Ground-truth keypoint annotation.
-        sigmas: Per-keypoint standard deviations, shape (K,).
+        sigmas: Per-keypoint standard deviations, shape (K,). These are the COCO
+            sigmas, not the doubled k_i of the formula above.
 
     Returns:
-        OKS score in [0, 1]. Returns 0.0 if no visible keypoints in GT.
+        OKS score in [0, 1]. Returns 0.0 when the ground truth has no visible
+        keypoints, or when its ``area`` is missing or non-positive (the formula
+        is undefined in that case).
+
+    Raises:
+        ValueError: If ``sigmas`` is not 1-D with one entry per ground-truth
+            keypoint, or if the detection and ground truth have different
+            keypoint counts.
     """
     gt_kps = ground_truth.keypoints
     det_kps = detection.keypoints
@@ -71,10 +81,11 @@ def compute_oks(
     dy = det_kps[:, 1] - gt_kps[:, 1]
     d_squared = dx**2 + dy**2
 
-    # OKS per keypoint: exp(-d^2 / (2 * s^2 * k^2))
-    # where s^2 = area and k = 2*sigma, matching the canonical COCO formula
-    variance = (2 * sigmas) ** 2 * 2 * area
-    oks_per_kp = np.exp(-d_squared / (variance + np.finfo(np.float64).eps))
+    # OKS per keypoint: exp(-d^2 / (2 * k^2 * area)) with k = 2 * sigma, matching
+    # COCO's vars = (2 * sigmas)**2 and its subsequent division by (2 * area).
+    # eps keeps the division finite when a sigma is 0.
+    denominator = (2 * sigmas) ** 2 * 2 * area
+    oks_per_kp = np.exp(-d_squared / (denominator + np.finfo(np.float64).eps))
 
     return float(np.sum(oks_per_kp[visible]) / num_visible)
 

--- a/packages/jabs-vision/tests/timm/metrics/test_similarity.py
+++ b/packages/jabs-vision/tests/timm/metrics/test_similarity.py
@@ -95,6 +95,39 @@ class TestComputeOKS:
         oks_large_area = compute_oks(det, gt_large, sigma)
         assert oks_large_area > oks_small_area
 
+    def test_matches_documented_coco_formula(self) -> None:
+        """OKS equals exp(-d^2 / (2 * k^2 * area)) with k = 2 * sigma.
+
+        Pins the exact value so the exponent denominator cannot silently drift
+        from the COCO convention documented on ``compute_oks``.
+        """
+        bbox = np.array([0.0, 0.0, 10.0, 20.0], dtype=np.float64)  # area = 200
+        gt_kps = np.array([[10.0, 20.0]], dtype=np.float64)
+        det_kps = np.array([[13.0, 24.0]], dtype=np.float64)  # offset (3, 4) -> d = 5
+        sigma = np.array([0.05], dtype=np.float64)
+
+        det = KeypointDetection(keypoints=det_kps, score=0.9, bbox=bbox)
+        gt = KeypointGroundTruth(keypoints=gt_kps, bbox=bbox)
+
+        area = 200.0
+        d_squared = 25.0
+        expected = np.exp(-d_squared / (2 * (2 * sigma[0]) ** 2 * area))
+
+        assert compute_oks(det, gt, sigma) == pytest.approx(expected)
+
+    def test_degenerate_area(self, sigmas: npt.NDArray[np.float64]) -> None:
+        """OKS is 0.0 when the GT bbox has no area."""
+        kps = np.array(
+            [[10.0, 20.0], [30.0, 40.0], [50.0, 60.0], [70.0, 80.0], [90.0, 100.0]],
+            dtype=np.float64,
+        )
+        bbox = np.array([10.0, 20.0, 10.0, 40.0], dtype=np.float64)  # zero width
+
+        det = KeypointDetection(keypoints=kps, score=0.9, bbox=bbox)
+        gt = KeypointGroundTruth(keypoints=kps, bbox=bbox)
+
+        assert compute_oks(det, gt, sigmas) == 0.0
+
     def test_visibility_mask(self, sigmas: npt.NDArray[np.float64]) -> None:
         """Only visible keypoints contribute to OKS."""
         # Detection matches on visible kps but is far on invisible ones


### PR DESCRIPTION
## Reasoning

I looked for candidates across `packages/jabs-behavior` (postprocessing stages / RLE bout editing), `packages/jabs-core` (utilities, pose helpers), `src/jabs/classifier` (LOGO splitting, label merging), `src/jabs/project` (feature-cache status, `TrackLabels`), and `packages/jabs-vision/src/jabs/vision/timm` (metrics + inference). The clearest defect was in the documented OKS formula, so I picked that over the weaker candidates I found (a dead `PostprocessingStage.legacy_names` class attribute that is never read or set; `GapInterpolationStage.__init__` reassigning `self._config` instead of setting a key like its sibling stages; `interpolate_ap` raising `IndexError` on an empty `recall`; `TrackLabels.downsample`'s docstring not accounting for bins that mix real frames with `PAD`).

**What was wrong.** [`compute_oks`](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/main/packages/jabs-vision/src/jabs/vision/timm/metrics/similarity.py#L27-L79) documented the COCO formula as:

```
OKS = sum(exp(-d_i^2 / (2 * s_i^2 * area * 2)) * delta(v_i > 0)) / sum(delta(v_i > 0))
```

with `s_i` defined in the prose as "the per-keypoint sigma". That denominator is `4 * sigma^2 * area`. The implementation uses COCO's `k_i = 2 * sigma_i` convention (`(2 * sigmas) ** 2 * 2 * area`), i.e. `8 * sigma^2 * area` — so **the documented formula was off by a factor of two in the exponent**, which is not a rounding-level discrepancy in the resulting score. For a single keypoint with `d = 5`, `sigma = 0.05`, `area = 200`, the code returns `0.00193` (matching COCO) while the documented formula gives `3.7e-06`.

The inline comment just above the computation (`exp(-d^2 / (2 * s^2 * k^2))` where "`s^2 = area`") was arithmetically correct but reused `s` for a different quantity than the docstring's `s_i`, which is very likely how the docstring drifted in the first place.

**Why this is safe.** The **code is correct and unchanged** — I verified it reproduces COCO `cocoeval.computeOks` (`vars = (sigmas * 2)**2; e = d2 / vars / (area + spacing) / 2`) to floating-point equality. This PR only rewrites the docstring/comment and renames one local variable, so it is net-zero behavior change. The added tests characterize existing behavior; they pass against the unmodified implementation.

I also added a regression test because the existing OKS tests only assert monotonic relationships (larger sigma → higher OKS, larger area → higher OKS, perfect match → 1.0). A factor-of-two change in the exponent denominator preserves all of those properties, so nothing in the suite would have caught the drift in either direction.

## Change

### Logic changes

**`packages/jabs-vision/src/jabs/vision/timm/metrics/similarity.py`** — docstring/comment corrections plus one local rename in `compute_oks`; no computation changed:
- Restated the formula as `exp(-d_i^2 / (2 * k_i^2 * area))` with `k_i = 2 * sigmas[i]` (the COCO convention the code follows), and spelled out the expansion `8 * sigmas[i]**2 * area` so a reader can check it against the code without re-deriving `k_i`.
- Clarified in `Args` that `sigmas` are the COCO sigmas, not the doubled `k_i` of the formula.
- Documented the second early return: `0.0` when `area` is missing or non-positive (reachable via a degenerate bbox, since `KeypointGroundTruth` derives `area` from the bbox when not supplied).
- Added the missing `Raises:` section for the two `ValueError`s the function already raises.
- Rewrote the inline comment to use the same `k = 2 * sigma` naming as the docstring, and noted what the `eps` term guards against.
- Renamed the local `variance` → `denominator`: the value is the full exponent denominator (`(2σ)² · 2 · area`), not a variance, and the old name invited exactly the confusion above.

**`packages/jabs-vision/tests/timm/metrics/test_similarity.py`** — two tests added to `TestComputeOKS`:
- `test_matches_documented_coco_formula`: pins `compute_oks` to the exact value of the documented formula for a hand-computed case (`d = 5`, `sigma = 0.05`, `area = 200`), so the exponent denominator cannot drift again unnoticed.
- `test_degenerate_area`: covers the newly documented zero-area early return.

### Mechanical updates

None — no imports, exports, or re-export shims touched.

## Verification

- `uv run ruff check .` → clean; `uv run ruff format .` → no files changed
- `uv run pytest` → 875 passed, 254 skipped
- `uv run pytest packages/jabs-vision/tests` → 179 passed
- `uv run pytest packages/jabs-core/tests` → 88 passed; `packages/jabs-io/tests` → 299 passed; `packages/jabs-behavior/tests` → 113 passed

`FEATURE_VERSION` is untouched — nothing here alters computed feature values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfSFJncwXCKBb2hftLRHBM

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfSFJncwXCKBb2hftLRHBM)_