### PR TITLE
Log behavior search warnings through a module logger

### DIFF
--- a/src/jabs/behavior_search/behavior_search_util.py
+++ b/src/jabs/behavior_search/behavior_search_util.py
@@ -1,3 +1,11 @@
+"""Query types and search routines for locating labels, predictions, and annotations.
+
+Searches run against an open :class:`~jabs.project.Project` and return
+:class:`SearchHit` records identifying the video, identity, and frame range of
+each match.
+"""
+
+import logging
 from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum, auto
@@ -5,6 +13,8 @@ from enum import Enum, auto
 import numpy as np
 
 from jabs.project import Project, TrackLabels
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -130,15 +140,29 @@ def _search_behaviors_gen(
 
                     for aid, animal_probs in probs.items():
                         # do a couple of checks before generating search hits
-                        animal_probs = probs.get(aid)
                         if animal_probs is None or animal_probs.size == 0:
                             continue
 
                         animal_preds = preds.get(aid)
-                        if animal_preds is None or animal_preds.size != animal_probs.size:
-                            print(
-                                f"WARNING: Skipping {video} for {aid} as predictions and probabilities "
-                                f"do not match in size."
+                        if animal_preds is None:
+                            logger.warning(
+                                "Skipping identity %s in %s: no '%s' predictions were loaded "
+                                "alongside the probabilities.",
+                                aid,
+                                video,
+                                behavior,
+                            )
+                            continue
+
+                        if animal_preds.size != animal_probs.size:
+                            logger.warning(
+                                "Skipping identity %s in %s: '%s' has %d predictions but %d "
+                                "probabilities.",
+                                aid,
+                                video,
+                                behavior,
+                                animal_preds.size,
+                                animal_probs.size,
                             )
                             continue
 
@@ -249,11 +273,30 @@ def _gen_contig_true_intervals(
     animal_predictions: np.ndarray,
     animal_probabilities: np.ndarray,
 ) -> Iterable[tuple[int, int]]:
+    """Yield inclusive (start, end) frame ranges where the prediction query is satisfied.
+
+    Args:
+        pred_query: The prediction query describing which frames qualify.
+        animal_predictions: Per-frame predicted class values for one identity.
+        animal_probabilities: Per-frame prediction probabilities for the same identity.
+
+    Yields:
+        Tuples of (start_frame, end_frame), both inclusive, for each contiguous run of
+        frames matching the query. Nothing is yielded if either input is empty or if the
+        two inputs disagree in size.
+
+    Raises:
+        ValueError: If the query's search kind is not supported.
+    """
     if animal_predictions.size == 0 or animal_probabilities.size == 0:
         return
 
     if animal_predictions.size != animal_probabilities.size:
-        print("WARNING: Predictions and probabilities do not match in size. Skipping this animal.")
+        logger.warning(
+            "Skipping identity: %d predictions but %d probabilities.",
+            animal_predictions.size,
+            animal_probabilities.size,
+        )
         return
 
     match pred_query.search_kind:


### PR DESCRIPTION
## Reasoning

`src/jabs/behavior_search/behavior_search_util.py` was the one remaining non-CLI library module writing operational warnings with bare `print()` to **stdout**. CLAUDE.md is explicit — *"Never use `print()` for operational output"* — and this module is driven by the GUI search bar, so the two warnings it emits went to a stream the user never sees, could not be filtered by level, and were absent from the application's log. Everything else in `src/jabs/` that still uses `print()` is either CLI progress output (`project_merge.py`, driven by `jabs-cli merge`) or already writes to `stderr`; this module was neither. The same fix was applied to the `PoseEstimation` base class in 3e63480, so this follows established precedent.

While converting the first warning I found the message was also **misleading**: one branch tested `animal_preds is None or animal_preds.size != animal_probs.size` but reported only *"predictions and probabilities do not match in size"* — which is wrong when no predictions were loaded at all. Splitting the branch lets each message name the condition that actually occurred, and the sizes are now included so the message is actionable.

**Why this is safe (net-zero behavior change):** both branches `continue` exactly as before, so the set of `SearchHit`s returned by any query is unchanged. The only observable difference is where the warning text goes and what it says. I considered adding a `caplog` regression test but deliberately did not — a logging assertion added in a recent PR was dropped on review (35df3a6), so this matches maintainer preference.

Other candidates I looked at and passed over: `TrackLabels.downsample`'s `PAD` docstring is slightly imprecise for bins that mix `NONE` and padding (too marginal to be worth a reviewer's time), and `get_frame_count`/`get_fps` in `video_reader/utilities.py` are now dead after `get_fps_and_nframes` landed (removing them is public-surface removal, not a pure quality fix, so it deserves its own decision).

## Change

### Logic changes

**`src/jabs/behavior_search/behavior_search_util.py`** (only file changed)

- Added `logger = logging.getLogger(__name__)` and the missing module docstring.
- [Prediction search loop](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/claude/quality-2026-09-04/src/jabs/behavior_search/behavior_search_util.py#L140-L165): replaced the `print()` with two `logger.warning()` calls using lazy `%s` formatting — one for "no predictions loaded", one for a genuine size mismatch (which now reports both sizes). Both still `continue`.
- Same loop: dropped `animal_probs = probs.get(aid)`, a redundant re-lookup of the value the `for aid, animal_probs in probs.items()` loop had already bound.
- [`_gen_contig_true_intervals`](https://github.com/KumarLabJax/JABS-behavior-classifier/blob/claude/quality-2026-09-04/src/jabs/behavior_search/behavior_search_util.py#L273-L299): replaced its `print()` with `logger.warning()`, and added the docstring the private helper was missing.

### Mechanical updates

None — no imports, exports, or call sites elsewhere were touched.

## Verification

- `uv run ruff check .` — clean; `uv run ruff format .` — no changes.
- `uv run pytest` — 875 passed, 254 skipped. No `packages/` files touched, so package suites are unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEDXKWdUtWqZM244GSRXif)_